### PR TITLE
Spec Kit v0.2 — Skills layer + sink catalog

### DIFF
--- a/.claude/commands/spec/design.md
+++ b/.claude/commands/spec/design.md
@@ -9,14 +9,15 @@ model: sonnet
 
 Run **stage 4 — Design**. This stage has three contributors; sequence them deliberately.
 
-1. Resolve slug; verify `requirements.md` is `complete`.
+1. Resolve slug; verify `requirements.md` is `complete`. The three design agents read REQ IDs and EARS clauses from `requirements.md` as canonical input — a `skipped` requirements artifact is a hard escalation.
 2. Initialise `specs/<slug>/design.md` from `templates/design-template.md` if it doesn't exist.
-3. **Spawn `ux-designer`** to fill **Part A — UX**: flows, IA, empty/loading/error states, accessibility. **Wait for the agent to return** before continuing.
-4. Once Part A is drafted, **spawn `ui-designer`** to fill **Part B — UI**: screen inventory, components, tokens, microcopy. **Wait for the agent to return** before continuing.
-5. Once Parts A and B are drafted, **spawn `architect`** to fill **Part C — Architecture**: components, data flow, decisions, risks, alternatives. The architect drafts any required ADRs directly using `templates/adr-template.md` (it has `Edit`/`Write`); after this command exits, the user may run `/adr:new` to formalise additional ones if needed. (Slash commands are not invoked from inside subagents.)
-6. The architect also fills the cross-cutting **Requirements coverage** table — every PRD requirement maps to at least one design section.
-7. Run the design quality gate.
-8. Update `workflow-state.md`. Recommend `/spec:specify` next.
+3. **Check for prior `design-twice` synthesis.** If `specs/<slug>/design-comparison.md` exists, read it and pass its recommendation + rejected-alternatives sections to each of the three design subagents below as additional context. The synthesis is the starting point; do not discard it.
+4. **Spawn `ux-designer`** to fill **Part A — UX**: flows, IA, empty/loading/error states, accessibility. **Wait for the agent to return** before continuing.
+5. Once Part A is drafted, **spawn `ui-designer`** to fill **Part B — UI**: screen inventory, components, tokens, microcopy. **Wait for the agent to return** before continuing.
+6. Once Parts A and B are drafted, **spawn `architect`** to fill **Part C — Architecture**: components, data flow, decisions, risks, alternatives. The architect drafts any required ADRs directly using `templates/adr-template.md` (it has `Edit`/`Write`); after this command exits, the user may run `/adr:new` to formalise additional ones if needed. (Slash commands are not invoked from inside subagents.)
+7. The architect also fills the cross-cutting **Requirements coverage** table — every PRD requirement maps to at least one design section.
+8. Run the design quality gate.
+9. Update `workflow-state.md`. Recommend `/spec:specify` next.
 
 ## Note
 

--- a/.claude/commands/spec/release.md
+++ b/.claude/commands/spec/release.md
@@ -9,7 +9,7 @@ model: sonnet
 
 Run **stage 10 — Release**. Irreversible actions (tagging, publishing, deploying) come **after** explicit human authorisation, never before.
 
-1. Resolve slug; verify the review is `Approved` (and any conditions are met).
+1. Resolve slug; verify `review.md` verdict is `Approved` or `Approved with conditions` (per `templates/review-template.md` verdict checkboxes); if `Approved with conditions`, confirm every listed condition has been resolved before continuing. A `Blocked` verdict escalates back to the owning stage.
 2. **Spawn the `release-manager` subagent** for the **prepare** phase. It:
    - writes `specs/<slug>/release-notes.md` (audience: users / stakeholders),
    - updates the project CHANGELOG,

--- a/.claude/commands/spec/requirements.md
+++ b/.claude/commands/spec/requirements.md
@@ -9,7 +9,7 @@ model: sonnet
 
 Run **stage 3 — Requirements**.
 
-1. Resolve slug; verify `idea.md` and `research.md` are `complete`.
+1. Resolve slug; verify `idea.md` and `research.md` are each `complete`. Lean depth produces stub artifacts marked `complete` containing the user's brief and a "discovery skipped" note — the PM agent reads those stubs as the source of truth for scope. A `skipped` upstream here means the file genuinely doesn't exist (PM has nothing to read); escalate.
 2. **Spawn the `pm` subagent.**
 3. The PM produces `specs/<slug>/requirements.md` from `templates/prd-template.md`:
    - functional requirements use **EARS notation** (every one, no exceptions),

--- a/.claude/commands/spec/research.md
+++ b/.claude/commands/spec/research.md
@@ -9,7 +9,7 @@ model: sonnet
 
 Run **stage 2 — Research**.
 
-1. Resolve slug; verify `specs/<slug>/idea.md` exists and is `complete`. If not, escalate.
+1. Resolve slug; verify `specs/<slug>/idea.md` exists and is `complete`. (Lean depth produces a stub marked `complete`; Spike depth never invokes this command since stages 3+ are not dispatched.) If `pending`, `in-progress`, `blocked`, or `skipped`, escalate.
 2. **Spawn the `analyst` subagent.** Pass the open questions from `idea.md` as the research agenda.
 3. The analyst produces `specs/<slug>/research.md` from `templates/research-template.md`:
    - answers each open question (or marks it open with reason),

--- a/.claude/commands/spec/review.md
+++ b/.claude/commands/spec/review.md
@@ -9,7 +9,7 @@ model: opus
 
 Run **stage 9 — Review**.
 
-1. Resolve slug; verify the test report is `complete` and there are no S1/S2 open.
+1. Resolve slug; verify `test-report.md` is `complete` and there are no S1/S2 open. The reviewer agent treats `test-plan.md` and `test-report.md` as core review inputs (see `.claude/agents/reviewer.md`); a `skipped` test report would let Stage 9 produce a release-signaling verdict without Stage 8 evidence — escalate instead.
 2. Build / refresh `specs/<slug>/traceability.md` by parsing the artifacts' structured content: document-level YAML frontmatter, plus the marked-up per-item entries in body — `### REQ-<AREA>-NNN` headings in `requirements.md`, `### SPEC-<AREA>-NNN` blocks and `Satisfies:` lines in `spec.md`, `### T-<AREA>-NNN` blocks and `Satisfies:` lines in `tasks.md`, test IDs and REQ references in the test report, and `Files changed:` / `Spec reference:` lines in `implementation-log.md` for the `Code` column (`file:line`). The pass is mechanical but reads body content, not just frontmatter.
 3. **Spawn the `reviewer` subagent.** It reads everything and produces `specs/<slug>/review.md`:
    - requirements compliance (per-REQ verdict + evidence),

--- a/.claude/commands/spec/specify.md
+++ b/.claude/commands/spec/specify.md
@@ -9,7 +9,7 @@ model: opus
 
 Run **stage 5 — Specification**.
 
-1. Resolve slug; verify `requirements.md` and `design.md` are `complete`.
+1. Resolve slug; verify `requirements.md` and `design.md` are each `complete`. The architect agent reads both as mandatory inputs (see `.claude/agents/architect.md`) — a `skipped` upstream is a hard escalation, not a passable state.
 2. **Spawn the `architect` subagent.**
 3. The architect produces `specs/<slug>/spec.md` from `templates/spec-template.md`:
    - precise interface contracts,

--- a/.claude/commands/spec/tasks.md
+++ b/.claude/commands/spec/tasks.md
@@ -9,7 +9,7 @@ model: sonnet
 
 Run **stage 6 — Tasks**.
 
-1. Resolve slug; verify `spec.md` is `complete`.
+1. Resolve slug; verify `spec.md` is `complete`. The planner agent reads `spec.md` as its primary source artifact (see `.claude/agents/planner.md`); a `skipped` upstream removes the canonical input for SPEC→T traceability and must escalate.
 2. **Spawn the `planner` subagent.**
 3. The planner produces `specs/<slug>/tasks.md` from `templates/tasks-template.md`:
    - each task ≤ ~½ day (S or M),

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -10,9 +10,11 @@
 
 Skills are the smallest unit of "we always do it this way". Anything you find yourself explaining to an agent more than twice belongs here.
 
+The catalog spans three families: a **workflow conductor** (the conversational entry to spec-kit), **practice skills** (the recurring techniques agents pull in mid-stage, mattpocock-style), and **operational skills** (the deterministic procedures that gate pre-PR and ADR work).
+
 ## Layout
 
-One directory per skill. Each contains a `SKILL.md` with this minimum shape:
+One directory per skill. Each contains a `SKILL.md`. For mattpocock-style skills the body uses YAML frontmatter (`name`, `description`, optional `argument-hint`); for operational skills it follows this minimum shape:
 
 ```markdown
 # <skill-name> — <one-line purpose>
@@ -32,11 +34,67 @@ One directory per skill. Each contains a `SKILL.md` with this minimum shape:
 
 Skills MAY include supporting files (templates, scripts, fixtures) alongside `SKILL.md`. Keep them small — large helpers belong in `scripts/` at the repo root.
 
-## Seeded skills
+## Catalog
 
-- **[`verify/`](./verify/SKILL.md)** — run the project's full pre‑PR gate (format / lint / types / test / build) and report failures actionably.
-- **[`new-adr/`](./new-adr/SKILL.md)** — scaffold a new ADR from `templates/adr-template.md` with the next free number.
-- **[`review-fix/`](./review-fix/SKILL.md)** — turn an automated‑review finding into an isolated worktree + plan, ready for TDD.
+### Workflow conductor
+
+| Skill | Triggers when… | What it does |
+|---|---|---|
+| [`orchestrate/`](orchestrate/SKILL.md) | "start a feature", "kick off", "from scratch", "what's next?", "orchestrate" | Drives the full 11-stage Spec Kit workflow conversationally. Reads `workflow-state.md`, gates with `AskUserQuestion`, dispatches `/spec:*` commands in sequence. |
+
+### Practice skills (used by stage agents)
+
+| Skill | Triggers when… | Used by |
+|---|---|---|
+| [`grill/`](grill/SKILL.md) | "grill me", "interrogate this", any clarification gate | `analyst`, `pm`, `architect`, `/spec:clarify` |
+| [`design-twice/`](design-twice/SKILL.md) | "design it twice", non-trivial design choice | User or orchestrator, *before* `/spec:design` (stage 4); design agents read its synthesis as input |
+| [`tracer-bullet/`](tracer-bullet/SKILL.md) | "vertical slice", "tracer bullet", "smallest possible commits" | `planner` (stage 6) |
+| [`tdd-cycle/`](tdd-cycle/SKILL.md) | "TDD", "red-green-refactor", "test first" | `dev` (stage 7) |
+| [`record-decision/`](record-decision/SKILL.md) | "file an ADR", "record a decision", any irreversible choice | `architect`, all stage agents on flag |
+
+### Cross-cutting sink skills
+
+| Skill | Triggers when… | Output |
+|---|---|---|
+| [`domain-context/`](domain-context/SKILL.md) | new domain concept; context boundary shifts; "context map" | `docs/CONTEXT.md` (lazy) |
+| [`ubiquitous-language/`](ubiquitous-language/SKILL.md) | new term coined; terminology disagreement; "glossary" | `docs/UBIQUITOUS_LANGUAGE.md` (lazy) |
+
+### Operational skills (deterministic procedures)
+
+| Skill | Purpose | Used by |
+|---|---|---|
+| [`verify/`](verify/SKILL.md) | Run the project's full pre‑PR gate (format / lint / types / test / build) and report failures actionably. | `dev`, `qa`, `release-manager`, `sre`, `reviewer` (read‑only Bash usage) |
+| [`new-adr/`](new-adr/SKILL.md) | Scaffold a new ADR from `templates/adr-template.md` with the next free number. | `architect` (no `Bash` — list the next number from a directory listing the user supplies; or hand off to an agent with `Bash`) |
+| [`review-fix/`](review-fix/SKILL.md) | Turn an automated‑review finding into an isolated worktree + plan, ready for TDD. | `dev`, `reviewer` (with caveats — `reviewer` typically lacks worktree authority; hand off to `dev`) |
+
+## How to use
+
+### Natural-language entry (typical)
+
+Just talk. The orchestrate skill triggers on phrases like "let's start a feature", "drive this end-to-end", or "what's the next step?". Practice skills auto-pull when their description matches the session context.
+
+### Explicit invocation
+
+Skills with `user-invocable: true` (default for mattpocock-style skills) can be triggered explicitly via `/<skill-name>`:
+
+- `/orchestrate add user profile editing`
+- `/grill the spec at specs/payments/spec.md`
+- `/design-twice user profile API`
+- `/record-decision adopt event sourcing for billing`
+
+### Inside a slash command or stage agent
+
+Stage agents pull a practice skill into their context by referencing it in their instructions. The agent reads the skill's `SKILL.md` and follows the procedure. Examples: the `planner` agent uses `tracer-bullet` during `/spec:tasks`; the `dev` agent uses `tdd-cycle` during `/spec:implement`; `dev` calls `verify` before opening a PR.
+
+## Markdown sink integration
+
+All skills write to the same sink documented in [`docs/sink.md`](../../docs/sink.md):
+
+- **Workflow-scoped artifacts** — `specs/<slug>/*.md` (managed by `/spec:*` commands).
+- **Cross-cutting artifacts** — `docs/adr/`, `docs/CONTEXT.md`, `docs/UBIQUITOUS_LANGUAGE.md` (lazy, additive).
+- **Steering** — `docs/steering/*.md` (human-curated).
+
+The orchestrate skill never invents new sink locations. Practice and operational skills only write to the locations their `SKILL.md` declares.
 
 ## When to add a new skill
 
@@ -56,14 +114,20 @@ Don't add one when:
 
 A skill never overrides an agent's tool restrictions. If `qa.md` can't `Edit` source files, a skill invoked from `qa` still can't `Edit` source files. Skills are *behavioural* shortcuts, not *permission* shortcuts.
 
-### Tool requirements per seeded skill
+### Tool requirements
 
-Some skills assume tools that not every lifecycle agent has. The table below makes the requirements explicit; agents missing a required tool cannot invoke the skill — they must either request the tool's addition (which needs an ADR) or hand off to an agent that has it.
+Some skills assume tools that not every lifecycle agent has. Operational skills generally require `Bash`; mattpocock-style skills work within whatever tools the invoking agent has. Lifecycle agents `analyst`, `pm`, `ux-designer`, `ui-designer`, `planner`, `orchestrator`, and `retrospective` have **no `Bash`** by default — they can't invoke `verify` or `review-fix` directly and must hand off to an agent that has it (typically `dev`).
 
-| Skill | Requires | Lifecycle agents that can invoke it |
-| --- | --- | --- |
-| [`verify`](./verify/SKILL.md) | `Bash` | `dev`, `qa`, `release-manager`, `sre`, `reviewer` (read‑only Bash usage) |
-| [`new-adr`](./new-adr/SKILL.md) | `Read`, `Write`, `Edit` (and `Bash` to scan for the next number) | `architect` (no `Bash` — list the next number from the directory listing the user supplies; or hand off to an agent with `Bash`) |
-| [`review-fix`](./review-fix/SKILL.md) | `Bash` (worktree creation), `Write` (plan scaffold) | `dev`, `reviewer` (with caveats — `reviewer` typically lacks worktree authority; hand off to `dev`) |
+If you add a new skill that assumes `Bash`, document the requirement in its `SKILL.md` and update the operational-skills table above.
 
-If you add a new skill that assumes `Bash`, document the requirement in its `SKILL.md` and update this table. Lifecycle agents `analyst`, `pm`, `ux-designer`, `ui-designer`, `planner`, `orchestrator`, and `retrospective` have **no `Bash`** by default.
+## Authoring a new skill
+
+For mattpocock-style skills, follow the progressive-disclosure pattern (also see Anthropic's `skill-creator`):
+
+1. Create `.claude/skills/<name>/SKILL.md` with YAML frontmatter (`name`, `description`, optional `argument-hint`).
+2. Keep the body ≤200 lines. Split deeper material into `REFERENCE.md`, `EXAMPLES.md`, `<TOPIC>.md` siblings.
+3. Description format: sentence 1 = capability; sentence 2 = "Use when …" with concrete trigger phrases.
+4. Add a row to this README's catalog.
+5. If the skill writes to disk, document the path in `docs/sink.md`.
+
+For operational skills, keep `SKILL.md` short and procedural — Purpose / How to use / Reporting / Do not — and update the catalog + tool-requirements row above.

--- a/.claude/skills/design-twice/SKILL.md
+++ b/.claude/skills/design-twice/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: design-twice
+description: Generate two or three radically different design alternatives for a module, interface, flow, or architecture in parallel using the Task tool, then synthesize a recommendation. Use during stage 4 (Design) of the workflow on non-trivial features, when the user wants to explore options, compare module shapes, "design it twice", or whenever an irreversible design choice needs deliberation.
+argument-hint: <one-line scope, e.g. "user profile editing API">
+---
+
+# Design twice (or three times)
+
+After Ousterhout's "Design It Twice" and Pocock's `design-an-interface`. The most expensive bug is a wrong design baked in early; the cheapest fix is a second alternative drafted before the first ships.
+
+## Procedure
+
+### Step 1 — Frame the design problem
+
+Read upstream:
+
+- `specs/<slug>/research.md`
+- `specs/<slug>/requirements.md`
+- `docs/CONTEXT.md`, `docs/UBIQUITOUS_LANGUAGE.md` (if present)
+
+Restate the design problem in one sentence. Confirm with the user.
+
+### Step 2 — Pick three divergent constraints
+
+Pick three constraints that will pull the design in genuinely different directions. Defaults that work for most module-shaping problems:
+
+- **A — Minimize surface.** Smallest possible public interface. Bias toward fewer methods, fewer parameters, more depth.
+- **B — Maximize flexibility.** Design for extension. Bias toward composition, plug points, orthogonal primitives.
+- **C — Optimize the common case.** The most frequent caller writes the least code. Bias toward affordances over generality.
+
+For UI/UX problems, swap to: **A — minimize click depth**, **B — maximize discoverability**, **C — minimize cognitive load**. For architecture, swap to: **A — minimize moving parts**, **B — maximize testability**, **C — minimize blast radius on failure**.
+
+If the user has stated a constraint that suggests a fourth axis, add it as D.
+
+### Step 3 — Dispatch three parallel subagents
+
+Issue the `Task` calls in the **same turn** so they run concurrently. Each subagent gets:
+
+- The same upstream context references.
+- Its single divergent constraint.
+- Output destination: `specs/<slug>/design-alt-<A|B|C>.md`.
+- Return contract: 5–10 line summary, not full content.
+
+Each subagent should produce: **Module shape**, **Public interface (signatures only)**, **Data flow**, **Trade-offs explicitly accepted**.
+
+### Step 4 — Synthesize
+
+When all three return, **you** (in the main thread) write `specs/<slug>/design-comparison.md` with sections:
+
+- **Compared alternatives** — one paragraph per option summarizing shape and trade-offs.
+- **Recommendation** — which one and why (cite specific upstream constraints).
+- **Hybrid moves** — borrow X from B, drop Y from A.
+- **Rejected alternatives** — what we lost by not picking each.
+
+Then ask the user via `AskUserQuestion`: `Adopt recommendation` (Recommended) / `Adopt alternative <X>` / `Synthesize a hybrid (you describe)` / `Run another design pass with a new constraint`.
+
+### Step 5 — Hand off to /spec:design
+
+The chosen alternative becomes input to `/spec:design`. The architect inside `/spec:design` reads `design-comparison.md` and writes the canonical `design.md`. Do not let `design-twice` pretend to be the design artifact itself — it is exploration, not commitment.
+
+## Rules
+
+- Constraints must be **genuinely divergent**, not three flavors of the same idea.
+- Subagents must not see each other's drafts during their pass.
+- Synthesis is your job in the main thread. Don't dispatch a fourth subagent to "pick the winner" — that defers your judgment.
+- Keep alternatives at interface/shape level. No implementation, no tests.
+- File ADRs for any irreversible decisions the synthesis bakes in (use the `record-decision` skill).

--- a/.claude/skills/domain-context/SKILL.md
+++ b/.claude/skills/domain-context/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: domain-context
+description: Maintain a living domain context map at docs/CONTEXT.md (or scoped contexts under docs/contexts/) — the project's shared mental model of what the system is, who its users are, what bounded contexts exist, and how they relate. Lazily creates the file on first need. Use when a stage agent discovers a new domain concept, when a context boundary shifts, or whenever the user mentions "domain model", "context map", or "bounded context".
+argument-hint: [optional context name for multi-context repos]
+---
+
+# Domain context
+
+After Pocock's `domain-model` skill and Evans's bounded-context concept. `docs/CONTEXT.md` is a single page that tells any new agent (or human) what the system is *about*. It evolves additively across workflows.
+
+## File layout
+
+### Single-context project
+
+```
+docs/CONTEXT.md
+```
+
+### Multi-context project (microservices, multi-product, etc.)
+
+```
+docs/CONTEXT-MAP.md          # the relationships between contexts
+docs/contexts/<name>.md      # one file per bounded context
+```
+
+The orchestrator decides single vs multi by counting distinct domains in `docs/steering/product.md`. Default is single until evidence suggests otherwise.
+
+## CONTEXT.md format
+
+```markdown
+# Domain context
+
+_Last updated: <YYYY-MM-DD> by <agent>_
+
+## What the system is
+
+One paragraph. Plain language. The shape of the thing, not its features.
+
+## Users and their goals
+
+Bulleted list. Who uses it, what they're trying to do, what success looks like.
+
+## Bounded contexts
+
+| Context | Owns | Talks to | Doesn't talk to |
+|---|---|---|---|
+| <name> | <data + behavior> | <other contexts> | <forbidden> |
+
+(Single-context projects can omit this section.)
+
+## Core concepts
+
+Short glossary of the load-bearing nouns. **Bold** the term, then a one-line definition. Cross-link to `UBIQUITOUS_LANGUAGE.md` for fuller definitions.
+
+## Invariants
+
+Numbered list of things that must always be true. These are non-negotiable; violations are bugs.
+
+## Open questions
+
+Bulleted list. Things the team hasn't resolved yet. Each links to a workflow or ADR if applicable.
+```
+
+## Procedure
+
+### When invoked from a stage agent (typical)
+
+Stage agents run inside subagent contexts and **cannot call `AskUserQuestion`** (per the orchestrator contract in `.claude/skills/orchestrate/SKILL.md`). High-confidence, low-risk updates can be written inline; anything that needs human confirmation must be deferred to the main thread.
+
+1. **Detect mode and target file.** Single-context vs. multi-context is determined by what already exists on disk:
+   - If `docs/CONTEXT-MAP.md` exists, this repo is in **multi-context mode**. Determine which bounded context the agent's update belongs to (cite it explicitly — if the agent didn't, ask via the `[CONTEXT-CONFIRM]` flag pattern below). The target file is `docs/contexts/<name>.md` for context-scoped updates, or `docs/CONTEXT-MAP.md` for cross-context relationships. Never write to `docs/CONTEXT.md` in multi-context mode — it should not exist.
+   - Else if `docs/CONTEXT.md` exists, this repo is in **single-context mode**; that file is the target.
+   - Else (no context file exists yet), default to **single-context mode** and scaffold `docs/CONTEXT.md` from the template above. To switch later to multi-context, the architect files an ADR migrating the file (lazy migration: `docs/CONTEXT.md` → `docs/CONTEXT-MAP.md` plus a per-context split).
+2. Diff what the agent reports against the current map:
+   - **New term coined?** Write inline to `Core concepts`.
+   - **Open question resolved?** Move from `Open questions` to wherever the answer landed (typically `Core concepts` or `Invariants`).
+   - **New invariant discovered?** Write a draft entry to `Invariants` and **flag for the orchestrator** — return a one-line `[CONTEXT-CONFIRM] new invariant: <text>` line in the agent's summary. The orchestrator will run a single `AskUserQuestion` in the main thread and finalize.
+   - **Context boundary changed?** Same flag pattern — write the proposed change inline (or stage it as a code-fenced block in the agent's summary) and return `[CONTEXT-CONFIRM] boundary change: <text>` for the orchestrator to confirm. Do not call `AskUserQuestion` from the subagent.
+3. Update `Last updated` and `by` in the file you actually wrote to (not the wrong layout's file).
+4. Append a dated one-line entry to the active feature's `workflow-state.md` `## Hand-off notes` free-form section noting which context file was updated (no frontmatter additions — the schema is fixed).
+
+### When invoked directly by the user
+
+Run a `grill` session focused on the current state of `CONTEXT.md`:
+
+- Walk each section asking "is this still true? is this still complete?"
+- Update inline as decisions resolve.
+
+## Rules
+
+- **Lazy creation.** Don't pre-scaffold `docs/CONTEXT.md`. Wait until something needs to land in it.
+- **Additive updates.** Don't rewrite history; document changes in workflows or ADRs.
+- **Plain language.** Avoid framework names, design patterns, or implementation details. The map is about the *domain*, not the system that serves it.
+- **One source of truth.** If a concept appears here and in `UBIQUITOUS_LANGUAGE.md`, the glossary is authoritative for definitions; CONTEXT.md cross-links and uses the term.
+- **Don't dump.** A 5-page CONTEXT.md is a sign the domain isn't actually understood. Keep it ≤2 pages.
+
+## Relationship to steering files
+
+`docs/steering/product.md` is **prescriptive** ("we are building X for Y"). `docs/CONTEXT.md` is **descriptive** ("here is what the system actually is and the terms we use about it"). They co-exist; updates to one don't auto-propagate to the other.

--- a/.claude/skills/grill/SKILL.md
+++ b/.claude/skills/grill/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: grill
+description: Interview the user relentlessly about a plan, design, or requirement until every branch of the decision tree is resolved. Asks one question at a time, walks down each branch, gives a recommended answer, and explores the codebase to answer questions that don't need a human. Use when the user wants to stress-test a plan, sharpen ambiguity, get grilled on a design, run a clarification gate, or mentions "grill me", "interrogate this", or "tighten this up".
+argument-hint: [path or topic to grill, e.g. "specs/payments/spec.md"]
+---
+
+# Grill
+
+Interview the user one question at a time. Do not stop until every branch of the decision tree is resolved.
+
+After Pocock's `grill-me`. This is the interview primitive every clarification gate (`/spec:clarify`, the analyst's open-question pass, design alternative selection, requirement disambiguation) reaches for.
+
+## Procedure
+
+1. **Restate the artifact under examination** in one sentence. Confirm with the user this is what they want grilled.
+2. **Identify the first ambiguity** — the highest-leverage decision that is currently under-specified.
+3. **Ask one question** to resolve it. Always:
+   - Phrase it as a binary or small enum (≤4 options) where you can.
+   - Provide your **recommended answer** with one-sentence reasoning.
+   - If the answer is in the codebase or upstream artifacts, **answer it yourself** and confirm with the user instead of asking blind.
+4. **Wait for the answer.** On answer, write the resolution into the artifact (or hold a running list to write at the end).
+5. **Walk down the resulting branch** — each answer creates new sub-questions. Recurse until that branch is fully resolved before moving to the next ambiguity.
+6. **When all branches are resolved**, summarize the resolved decisions in a bulleted list and confirm with the user before persisting.
+
+## Rules
+
+- One question per turn. Never batch.
+- Always state your recommended answer. The user should be able to say "yes do that" and move on.
+- Read upstream artifacts (`docs/CONTEXT.md`, `docs/UBIQUITOUS_LANGUAGE.md`, the relevant `specs/<slug>/*.md`) before each question — many ambiguities are already settled there.
+- Use `AskUserQuestion` only when free-text or multi-option is needed. Otherwise plain conversational questions are fine.
+- Don't ask "what do you want?" — propose a default and ask the user to confirm or redirect.
+- Don't grill past the artifact's purpose. A PRD is grilled on requirements, not on implementation.
+
+## When to invoke this skill
+
+- During `/spec:clarify` (it is the body of that command).
+- Inside the analyst when `idea.md` has open questions.
+- Inside the pm when a requirement candidate is under-specified.
+- Inside the architect when a design decision could go multiple ways.
+- Anywhere the user says "grill me" or "tighten this up".
+
+## When not to invoke
+
+- The artifact is already specified. Don't manufacture ambiguity.
+- The decision is the user's intent (e.g. priorities). Don't grill on values; ask once.
+- You're already inside another skill's flow that owns the conversation (don't double-grill).

--- a/.claude/skills/orchestrate/PHASES.md
+++ b/.claude/skills/orchestrate/PHASES.md
@@ -1,0 +1,80 @@
+# Per-stage dispatch templates
+
+The orchestrate skill dispatches the existing `/spec:*` slash commands rather than calling subagents directly — the slash commands already wire the right agent and pass the right inputs. This file documents the **additional context** the orchestrator should pass when re-running a stage with user feedback or with cross-stage context.
+
+**How feedback is delivered.** Slash commands accept their feature slug as an argument; user feedback is *not* a CLI flag. Instead, the orchestrator delivers feedback as **conversational context in the same turn** as the slash command — the spawned stage subagent reads the surrounding conversation and treats explicit "Re-run with feedback: …" lines as constraint on its draft. State the feedback as a short paragraph immediately before invoking the slash command; do not embed it in the command's `$ARGUMENTS`.
+
+The slash commands are defined in `.claude/commands/spec/` and own the agent invocation. Do **not** duplicate their logic here — only document how to enrich them when re-dispatching.
+
+## Stage dispatch reference
+
+### Stage 1 — Idea (`/spec:idea`)
+- **Initial:** dispatch as-is once `workflow-state.md` exists.
+- **Re-run with feedback:** prepend the user's feedback to the dispatch as `Re-run with feedback: <text>`. The analyst will treat it as constraint on the new draft.
+
+### Stage 2 — Research (`/spec:research`)
+- **Initial:** dispatch as-is. The analyst reads `idea.md` open questions as the agenda.
+- **Re-run with feedback:** specify which research questions need deeper treatment.
+- **Suggested skills the analyst may pull:** `grill` (when interrogating ambiguity), `domain-context` (when discovering domain terms).
+
+### Stage 3 — Requirements (`/spec:requirements`)
+- **Initial:** dispatch as-is. The pm reads `research.md` recommendation as the starting point.
+- **Suggested skills:** `grill` (for non-functional requirement discovery), `ubiquitous-language` (whenever a new domain term lands in EARS clauses).
+- **Mandatory:** every functional requirement uses EARS notation per `docs/ears-notation.md`.
+- **Optional gate:** offer `/spec:clarify` after this stage if the user enabled it in Step 2.
+
+### Stage 4 — Design (`/spec:design`)
+- **Initial path A (default):** dispatch as-is. The slash command sequences ux → ui → architect.
+- **Initial path B (deep features):** if the user opted into `design-twice` in Step 5, dispatch `design-twice` first; pass its synthesis to `/spec:design` as additional context.
+- **Suggested skills:** `design-twice`, `record-decision` (when the architect identifies a hard-to-reverse choice).
+- **Optional gate:** offer `/spec:clarify` after this stage if the user enabled it.
+
+### Stage 5 — Specification (`/spec:specify`)
+- **Initial:** dispatch as-is.
+- **Re-run with feedback:** name the spec sections that need tightening.
+
+### Stage 6 — Tasks (`/spec:tasks`)
+- **Initial:** dispatch as-is.
+- **Suggested skills:** `tracer-bullet` (for vertical slicing).
+- **Optional gate:** offer `/spec:analyze` after this stage if the user enabled it. This is the strongest natural place for `/spec:analyze` — it cross-checks REQ → SPEC → T coverage.
+
+### Stage 7 — Implementation (`/spec:implement`)
+- **One task per dispatch.** `/spec:implement` is scoped to a single task per call (`.claude/commands/spec/implement.md` step 1). The dev agent does **not** walk the backlog inside one invocation; the orchestrator must loop dispatches until no ready implementation tasks remain.
+- **Initial dispatch:** read `tasks.md`, find the first ready task (dependencies satisfied per its `Blocked by:` field, no blockers, status `pending`), dispatch `/spec:implement <T-AREA-NNN>`. Wait for return.
+- **Loop:** after each `/spec:implement` returns, branch on the dev agent's outcome — **only mark the task `done` when the agent explicitly reports successful completion** (all acceptance criteria green, full suite passing, log entry appended). Outcome handling:
+  - **Completed successfully** → mark the task `done` in `tasks.md`, re-scan for the next ready task in dependency order, dispatch again.
+  - **Blocked** (the dev agent escalated mid-task — couldn't pass a test in two attempts, hit a missing decision, etc.) → leave the task as `in-progress`, append the blocker to the `## Blocks` section of `workflow-state.md`, set the workflow `status: blocked`, and surface the blocker to the user via `AskUserQuestion`. Do *not* advance.
+  - **Partial / incomplete** (some criteria green, others not) → leave `in-progress`, escalate to the user; do not mark `done`. The next /spec:test would otherwise run against unfinished work.
+  - **Failed** (e.g. test suite went red and couldn't be recovered) → leave `in-progress`, escalate.
+  Continue looping only on the *Completed successfully* branch. The loop terminates when (a) all implementation tasks are `done` (advance to gate), (b) the next ready task is gated for human oversight (gate now), or (c) any non-success outcome above (escalate, do not advance).
+- **Gating cadence:** gate after each task if the user wants tight oversight; gate after each "slice" (group of tasks satisfying one requirement) for normal cadence; gate once at the end of all implementation tasks for autonomous mode (default for trivial features).
+- **Suggested skills:** `tdd-cycle` (mandatory inside the dev agent — strict red/green/refactor scoped to the dispatched task only).
+- **Definition of done for the stage:** every task in `tasks.md` is `done`; `implementation-log.md` is `complete` (the dev agent appends one entry per task).
+
+### Stage 8 — Testing (`/spec:test`)
+- **Initial:** dispatch as-is. The qa agent generates `test-plan.md` then runs and reports `test-report.md`.
+- **Re-run with feedback:** name failing tests or coverage gaps.
+
+### Stage 9 — Review (`/spec:review`)
+- **Initial:** dispatch as-is. The reviewer agent verifies RTM completeness and quality gates.
+- **Required:** RTM at `specs/<slug>/traceability.md` must be complete before this exits.
+
+### Stage 10 — Release (`/spec:release`)
+- **Initial:** dispatch as-is.
+- **Pre-flight check:** confirm `review.md` verdict is `Approved` or `Approved with conditions` (per the verdict checkboxes in `templates/review-template.md`). If the verdict is `Blocked`, return to Stage 9 (Review) — do not dispatch `/spec:release`.
+
+### Stage 11 — Learning (`/spec:retro`)
+- **Mandatory:** runs even on clean ships (per `docs/spec-kit.md` §3.11).
+- **Initial:** dispatch as-is.
+
+## Cross-stage helpers
+
+- **ADR detected mid-stage:** any subagent may flag a decision that needs an ADR. The orchestrator should run `/adr:new "<title>"` on the user's behalf (after a one-question `AskUserQuestion` confirmation) and append a dated line to the `## Hand-off notes` free-form section of `workflow-state.md` recording the ADR path. Do **not** invent an `adrs:` frontmatter field — the schema in `templates/workflow-state-template.md` is fixed.
+- **Domain term coined:** if a subagent reports a new term, append it to `docs/UBIQUITOUS_LANGUAGE.md` via the `ubiquitous-language` skill (lazy creation if file doesn't exist).
+- **Context shift:** if a subagent reports that the domain context map has changed, dispatch the `domain-context` skill to update `docs/CONTEXT.md`.
+
+## What the orchestrator must NOT pass
+
+- The full content of upstream artifacts. The slash command and stage agent read those themselves from disk.
+- Implementation details. The orchestrator only knows scope, depth, and the user's gating choices.
+- Conversation history beyond the current gating round. Each stage is a fresh subagent context.

--- a/.claude/skills/orchestrate/RESUME.md
+++ b/.claude/skills/orchestrate/RESUME.md
@@ -1,0 +1,68 @@
+# Resume protocol
+
+The orchestrate skill must survive crashes, branch switches, and long pauses. State lives in `specs/<slug>/workflow-state.md` (per `templates/workflow-state-template.md`); resuming is a matter of reading that file and picking the next pending stage.
+
+The canonical workflow `status` enum is **`active | blocked | paused | done`** (set in the YAML frontmatter). Do not invent values outside this enum — other commands and skills parse state using the documented schema.
+
+## Detection
+
+On invocation, list candidate features:
+
+```bash
+for f in specs/*/workflow-state.md; do
+  [ -f "$f" ] || continue
+  slug=$(basename "$(dirname "$f")")
+  status=$(awk '/^status:/ {print $2}' "$f" | head -1)
+  stage=$(awk '/^current_stage:/ {print $2}' "$f" | head -1)
+  updated=$(awk '/^last_updated:/ {print $2}' "$f" | head -1)
+  printf "%-40s %-12s %-15s %s\n" "$slug" "$status" "$stage" "$updated"
+done
+```
+
+How to treat each status:
+
+- **`active`** — resumable. Default candidate for "what's next?".
+- **`paused`** — resumable. The user explicitly paused; the orchestrator's pause gate sets this.
+- **`blocked`** — surface the blocker (from the `## Blocks` section) and ask the user whether to proceed anyway, address the blocker, or pause.
+- **`done`** — do **not** auto-resume; `/spec:retro` set this when the workflow finished. Offer "start new feature" instead. If the user explicitly types the slug, ask whether they want to amend (start a related new workflow) or just inspect.
+
+## Decision flow
+
+The picker considers all **resumable** statuses (`active`, `paused`, `blocked`) — never just `active`. A user who paused a feature and later asks "what's next?" must see it offered.
+
+1. **One resumable feature, no `$ARGUMENTS`:** offer to resume it as the recommended option (annotate with its current status), plus "Start new feature" alternative.
+2. **Multiple resumable features:** list each as an `AskUserQuestion` option (annotated with status), sorted by `last_updated` desc. If there are >4, offer the top 3 plus "Start new feature". Sort `active` ahead of `paused`, and `paused` ahead of `blocked` when `last_updated` ties.
+3. **`$ARGUMENTS` matches a known slug:** resume that one without asking, regardless of resumable status. (For `done` slugs, follow the `done` rule above and confirm intent first.)
+4. **`$ARGUMENTS` is a goal phrase, no match:** propose deriving a slug and starting fresh.
+5. **No resumable features and no `$ARGUMENTS`:** ask for the goal.
+
+## On resume
+
+After picking a feature to resume:
+
+1. Read the full `workflow-state.md` and report a one-line summary to the user (current stage, status, last agent, last update).
+2. Read the most recent stage's artifact to confirm it actually completed (don't trust state alone — the file may have been deleted or edited).
+3. Determine the next pending stage from the **YAML `artifacts:` map in the frontmatter** (the canonical machine-readable source per `templates/workflow-state-template.md` line 8). The human-readable status table below the frontmatter is a *view* and may drift; if the table and the frontmatter disagree, trust the frontmatter and surface the inconsistency to the user. Walk the `artifacts:` map in stage order, treating `complete` and `skipped` as passable; the next stage is the one whose owning artifact(s) are still `pending`, `in-progress`, or `blocked`.
+4. Ask via `AskUserQuestion`: `Continue from <next stage>` (Recommended) / `Re-run <current stage>` / `Run /spec:analyze first` / `Pause`.
+5. On Continue, jump to Step 4 of `SKILL.md`. On Re-run, dispatch the current stage's slash command with feedback. On Pause, set `status: paused` in `workflow-state.md` and stop. (To abandon a feature outright, the user can delete the `specs/<slug>/` folder manually — the schema does not include a `cancelled` status.)
+
+## What not to do on resume
+
+- **Don't** re-run earlier stages "to refresh context" — the stage subagent reads upstream artifacts itself.
+- **Don't** silently skip a stage that the upstream marked `pending` — confirm with the user.
+- **Don't** mutate `workflow-state.md` beyond the orchestrator-owned `status` field and free-form `## Hand-off notes` appends; stage transitions and artifact-status updates are owned by the slash commands.
+- **Don't** invent frontmatter fields outside the schema (`active | blocked | paused | done` for workflow status; `pending | in-progress | complete | skipped | blocked` for artifact status).
+- **Don't** auto-resume a `done` feature even if the user types its slug — confirm whether they want to amend or start a related new one.
+
+## Crash recovery
+
+If an artifact in `workflow-state.md` shows `in-progress` but the file was never written and `last_updated` is older than the typical stage runtime (~1 hour), assume the previous orchestrator run crashed mid-stage. Surface this to the user:
+
+> "The last run appears to have crashed during `<stage>` at `<timestamp>`. Do you want to re-run it from scratch, or has work since been done that I should re-detect?"
+
+Offer two safe options only:
+
+- `Re-run <stage>` (Recommended) — overwrite/re-run the stage cleanly.
+- `Inspect manually first` — exit so the user can examine the working tree and reconstruct any partial work.
+
+Do **not** offer "mark complete and continue" here. The artifact file is missing on disk, and resume logic downstream trusts artifact statuses to pick the next stage; flipping the status to `complete` without an actual file would let the workflow advance with required inputs absent, silently corrupting later stages. If the user genuinely has off-disk work that should count as the artifact, they must paste/reconstruct it into the artifact file first, then re-run the stage to validate.

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: orchestrate
+description: Drive a feature end-to-end through the Spec Kit workflow (idea → retrospective) by gathering scope from the user up front, then dispatching the right stage subagent for each phase, persisting artifacts under specs/<slug>/, and gating between stages with the user. Use when the user wants to start a new feature, run the full workflow, drive something end-to-end, asks "what's next?" on an active feature, or mentions "orchestrate", "kick off", or "from scratch".
+argument-hint: [feature-slug or one-line goal]
+---
+
+# Orchestrate
+
+You are the conductor of the Spec Kit workflow defined in `docs/spec-kit.md`. Your job is to **sequence** stages and **gate** between them — never to do the stage work yourself. Each stage runs in its specialist subagent (`.claude/agents/`); you only persist state, surface choices, and dispatch.
+
+`AskUserQuestion` only works in the main thread. Subagents cannot ask the user anything. So all clarification happens in *your* turn — before and between stages.
+
+## Read first
+
+Always start by reading these (they're the contract you're enforcing):
+
+- `docs/spec-kit.md` — the 11-stage workflow definition.
+- `memory/constitution.md` — principles every stage must obey.
+- `docs/quality-framework.md` — gate criteria.
+- The active `specs/<slug>/workflow-state.md` (if resuming).
+
+## The workflow you're driving
+
+| # | Stage | Subagent | Slash command | Artifact |
+|---|---|---|---|---|
+| 0 | Bootstrap | — | `/spec:start <slug> [AREA]` | `workflow-state.md` |
+| 1 | Idea | `analyst` | `/spec:idea` | `idea.md` |
+| 2 | Research | `analyst` | `/spec:research` | `research.md` |
+| 3 | Requirements | `pm` | `/spec:requirements` | `requirements.md` |
+| 4 | Design | `ux-designer` → `ui-designer` → `architect` | `/spec:design` | `design.md` |
+| 5 | Specification | `architect` | `/spec:specify` | `spec.md` |
+| 6 | Tasks | `planner` | `/spec:tasks` | `tasks.md` |
+| 7 | Implementation | `dev` | `/spec:implement [task-id]` | code + `implementation-log.md` |
+| 8 | Testing | `qa` | `/spec:test` | `test-plan.md`, `test-report.md` |
+| 9 | Review | `reviewer` | `/spec:review` | `review.md` |
+| 10 | Release | `release-manager` | `/spec:release` | `release-notes.md` |
+| 11 | Learning | `retrospective` | `/spec:retro` | `retrospective.md` |
+
+**Optional gates** between any two stages: `/spec:clarify` (interrogate active artifact) and `/spec:analyze` (cross-artifact consistency).
+
+## What you do, step by step
+
+### Step 1 — Detect resume vs. fresh start
+
+```
+ls specs/ 2>/dev/null
+```
+
+For each `specs/<slug>/workflow-state.md` whose `status` is `active`, `paused`, or `blocked` (all three are resumable per the schema), list `slug | status | current_stage | last_updated`. Then **batch one `AskUserQuestion`** asking the user to pick:
+
+- Resume a listed feature (one option per feature, recommended-first by `last_updated`; show the status next to each).
+- Start a new feature.
+
+`done` workflows are not auto-listed; if the user names one explicitly, ask whether to amend with a related new workflow or just inspect. If no resumable features exist, skip straight to Step 2.
+
+### Step 2 — Clarify scope (single `AskUserQuestion` call, ≤4 questions)
+
+If starting fresh, batch into one call:
+
+1. **Feature slug** — kebab-case, ≤6 words. Derive from `$ARGUMENTS` if a goal was given; offer it as the recommended option.
+2. **Area code** — uppercase, used for ID prefixes (`REQ-<AREA>-NNN`). Derive from slug.
+3. **Depth**: `Standard` (all 11 stages, recommended) / `Lean` (skip Idea + Research; jump to Requirements) / `Spike` (Idea + Research only, no implementation).
+4. **Optional gates**: multi-select — `Run /spec:clarify after Requirements`, `Run /spec:clarify after Design`, `Run /spec:analyze after Tasks`.
+
+If resuming, instead ask: `Continue from <next stage>` (Recommended) / `Re-run <current stage>` / `Run /spec:analyze first`.
+
+Do not ask "should I proceed?" — proceed once you have answers.
+
+### Step 3 — Bootstrap (fresh start only)
+
+Invoke `/spec:start <slug> [AREA]`. This creates `specs/<slug>/` and `workflow-state.md` with all artifacts set to `pending`. Do not edit those files yourself; the slash command does it.
+
+### Step 3.5 — Apply depth-driven skips up front
+
+Stage slash commands enforce strict preconditions and the **stage agents read upstream artifact *content***, not just status (e.g. `pm.md` reads `idea.md` and `research.md` as mandatory inputs). Marking an artifact `skipped` satisfies the slash command's status check but leaves the agent with nothing to read. So the orchestrator handles depth-driven skips two different ways:
+
+- **Stub-and-mark-complete** when a downstream stage will actually run against the skipped artifact (Lean path).
+- **Mark-skipped** when no downstream stage will run (Spike path: stages 3–10 are never dispatched, so their statuses are documentation only).
+
+This is the one place the orchestrator owns artifact-content edits in `workflow-state.md` and the artifact files themselves; slash commands and stage agents own the rest.
+
+For each depth:
+
+- **Depth = Lean**: write minimal **stub artifacts** for `specs/<slug>/idea.md` and `specs/<slug>/research.md` containing one paragraph each: the user's brief (as `idea.md`'s content) and a one-line note (as `research.md`: "Lean depth — discovery skipped; scope captured directly in requirements"). Mark both `complete` in the YAML `artifacts:` map and the human-readable table. Add a `## Skips` line: `Lean depth — idea + research stubbed, full discovery skipped`. The PM agent will read the stubs and proceed with the brief as input.
+- **Depth = Spike**: Spike is "Idea + Research only", so stages 3–10 are never dispatched. Mark all 10 of `requirements.md`, `design.md`, `spec.md`, `tasks.md`, `implementation-log.md`, `test-plan.md`, `test-report.md`, `review.md`, `traceability.md`, `release-notes.md` as `skipped` in the `artifacts:` map and table. Add one `## Skips` entry: `spike depth — research-only run, no implementation`. (Stage 11 retrospective is never skipped per `docs/spec-kit.md` §3.11.)
+- **Depth = Standard**: nothing to mark.
+
+Bump `last_updated` to today; set `last_agent: orchestrator`. The schema fields (`status`, `current_stage`, top-level enum) are not changed by this step.
+
+### Step 4 — Run stages sequentially
+
+For each stage in the agreed sequence, in order:
+
+1. **Pre-flight**: read `specs/<slug>/workflow-state.md` and confirm every upstream artifact status is `complete` **or** `skipped` (per the artifact-status enum in `templates/workflow-state-template.md`: `pending | in-progress | complete | skipped | blocked`). Treat `complete` and `skipped` as passable; treat `pending`, `in-progress`, or `blocked` as a return-to-that-stage signal.
+2. **Dispatch** the slash command for the stage (e.g. `/spec:research`). The slash command spawns the stage subagent, which reads upstream artifacts, writes its artifact, and updates `workflow-state.md`. Hand off control fully — do not duplicate the agent's work.
+3. **Wait** for the slash command to complete and the artifact to exist.
+4. **Run any opt-in gate** (`/spec:clarify` or `/spec:analyze`) the user selected for this transition.
+5. **Gate with the user** via a single `AskUserQuestion`:
+   - `Continue to <next stage>` (Recommended)
+   - `Pause here` — set `status: paused` in `workflow-state.md` and exit; resume by re-invoking `/orchestrate`.
+   - `Re-run <this stage> with feedback` (free-text in "Other" — pass as additional context to the slash command).
+   - `Skip <next stage>` *(only offered when the next stage is in the skip-allowed set below)* — open `workflow-state.md`, set every artifact owned by the skipped stage from `pending` to `skipped` in the `artifacts:` YAML map (the canonical source) AND the human-readable table, append one `## Skips` line per artifact (or one summary line naming the stage), bump `last_updated`. Some stages own multiple artifacts and they must all be skipped together: stage 8 (Testing) → `test-plan.md` + `test-report.md`; stage 9 (Review) → `review.md` + `traceability.md`. This is required *before* dispatching the stage after the skipped one. Never mark the workflow's top-level `status` as anything other than `active | blocked | paused | done`.
+
+     **Skip-allowed stages (per-stage gate):** **stage 10 (Release) only.** No downstream stage gates on `release-notes.md` content (retro reviews the workflow, not the release notes), so a `skipped` release is recoverable. For all other stages, do not offer Skip — instead suggest `Pause` (so the user can finish the stage manually later) or, for a research-only flow, suggest converting the workflow to Spike depth at workflow start (which pre-skips stages 3–10 deliberately because none of them are dispatched).
+
+     **Skip-forbidden stages and why:**
+     - Stages 1–2 (Idea, Research) — the PM agent reads `idea.md` and `research.md` as mandatory content. Skip these via Lean depth at workflow start instead, which writes stub artifacts the PM can read.
+     - Stage 3 (Requirements) — `/spec:design`, `/spec:specify`, and `/spec:review` all read `requirements.md` content (REQ IDs, EARS clauses) and the RTM is gated on it.
+     - Stage 4 (Design) — `/spec:specify` reads `design.md` content; the design template note explicitly says "Don't skip *parts*; do collapse the agents."
+     - Stage 5 (Specification) — `/spec:tasks` decomposes `spec.md`; without it, the planner has no canonical input.
+     - Stage 6 (Tasks) — `/spec:implement` resolves the next task from `tasks.md`; without it, dev has nothing to do.
+     - Stage 7 (Implementation) — `/spec:test` needs implementation tasks marked `done`.
+     - Stage 8 (Testing) — `/spec:review` requires `test-report.md` to have no S1/S2 open.
+     - Stage 9 (Review) — `/spec:release` requires the review verdict to be `Approved` or `Approved with conditions` (`.claude/commands/spec/release.md` step 1). A `skipped` review has no verdict.
+     - Stage 11 (Learning) — never skipped per `docs/spec-kit.md` §3.11.
+
+### Step 5 — Stage 4 (Design) special handling
+
+If Depth is `Standard` and the feature is non-trivial (PRD has ≥3 functional requirements), suggest invoking the `design-twice` skill **before** `/spec:design` to explore divergent design alternatives in parallel. Ask via `AskUserQuestion`: `Run design-twice first` (Recommended) / `Skip — go straight to /spec:design`.
+
+If the user accepts, dispatch `design-twice` (it spawns 3 parallel subagents and synthesizes). Then continue to `/spec:design` — the architect will use the synthesis as input.
+
+### Step 6 — Wrap up
+
+After `/spec:retro` completes, the retro command itself sets `status: done` in the frontmatter (per the workflow-state schema: `active | blocked | paused | done`). Confirm this happened. Then append a final dated entry to the `## Hand-off notes` free-form section recording the outcome in one or two sentences (shipped behavior, ADRs filed, follow-ups). Do **not** invent new top-level frontmatter fields — the schema is fixed.
+
+Then report a 3-line summary to the user with the path to the feature folder, the count of artifacts produced, and any ADRs filed during the workflow.
+
+## Constraints
+
+- **Never** do stage work in your own turn. If you find yourself reading source code, writing the PRD, or editing implementation files, you've drifted — stop and dispatch the right subagent.
+- **Never** call `AskUserQuestion` from inside a subagent prompt. It will fail.
+- **Never** ask more than one `AskUserQuestion` per gate. Batch options into a single question.
+- **Always** update `workflow-state.md` between stages (delegated to the slash commands).
+- **Always** use the same slug across all artifacts in one feature.
+- **Never** write to `specs/<slug>/` directly during normal stage execution — the stage subagents own those files. **Exception:** Step 3.5 (depth-driven setup) is the *one* place the orchestrator owns artifact-content edits — writing Lean stub `idea.md`/`research.md` and marking depth-driven `skipped` statuses in `workflow-state.md`. After Step 3.5, return to subagent ownership for the rest of the workflow.
+- **Don't** invent new sink locations. Use what `docs/sink.md` defines.
+
+## When a stage agent escalates
+
+If a subagent returns "blocked — needs human input" (e.g. the analyst can't resolve ambiguity), surface its question to the user via `AskUserQuestion` in a single call, capture the answer, then re-dispatch the same slash command with the answer as additional context. Don't try to answer on the user's behalf.
+
+## References
+
+- `PHASES.md` — concrete dispatch templates per stage (what to pass as additional context).
+- `RESUME.md` — resume protocol against `workflow-state.md`.
+- `docs/spec-kit.md` — workflow contract.
+- `docs/sink.md` — markdown sink layout.

--- a/.claude/skills/record-decision/SKILL.md
+++ b/.claude/skills/record-decision/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: record-decision
+description: File a new Architecture Decision Record (ADR) under docs/adr/ for a hard-to-reverse decision. Wraps the existing /adr:new command with guidance on when an ADR is warranted, what to capture, and how to link it back to the workflow. Use when the user wants to record a decision, file an ADR, document a trade-off, or whenever a stage agent flags an irreversible architectural choice.
+argument-hint: <one-line decision title>
+---
+
+# Record decision (ADR)
+
+ADRs are for **decisions you'd regret silently changing later**. Not every choice deserves one. After Nygard's ADR pattern, Pocock's `domain-model`/`improve-codebase-architecture` ADR discipline, and our own `templates/adr-template.md`.
+
+## When to file an ADR
+
+File an ADR when **all three** are true:
+
+1. The decision is **hard to reverse** — undoing it costs days or weeks of rework, or breaks public contracts.
+2. It is the result of a **real trade-off** — there are at least two reasonable alternatives, and the choice is non-obvious without context.
+3. Future readers will be **surprised** without it — they'd ask "why did they do it this way?"
+
+Examples that qualify:
+- Choosing event sourcing over CRUD.
+- Adopting a particular framework with deep API coupling.
+- Picking a deployment topology (monolith vs. microservices).
+- Mandating a notation (e.g. ADR 0003 — adopting EARS).
+
+Examples that don't qualify:
+- Choice of variable name.
+- Local refactor.
+- Anything fully reversible in <1 day.
+- Anything obvious from the spec.
+
+## When NOT to file an ADR
+
+- The decision is implicit in the constitution or steering files. Cite those instead.
+- It's a stage artifact (PRD, design, spec). Those *are* the decision record for what to build; ADRs are for *how*.
+- The decision is project-specific to one feature. Document it inline in `specs/<slug>/design.md`.
+- You're tempted to ADR every choice. ADR fatigue dilutes the signal — the seed ADRs (0001–0003) set the bar.
+
+## Procedure
+
+1. **Confirm the decision is ADR-worthy** against the three criteria above. If two of three fail, decline and recommend inline documentation.
+2. **Pick the next ADR number** — find the highest number under `docs/adr/` and add 1, zero-padded to 4 digits.
+3. **Invoke `/adr:new "<title>"`**. The slash command scaffolds `docs/adr/NNNN-<slug>.md` from `templates/adr-template.md`.
+4. **Fill the ADR** with:
+   - **Status**: Proposed → Accepted (after gate) → Superseded (later).
+   - **Context**: what forces are at play. Cite upstream artifacts (`specs/<slug>/design.md`, `docs/CONTEXT.md`).
+   - **Decision**: what we're doing. One paragraph.
+   - **Alternatives considered**: at least two real alternatives with one-paragraph trade-off each.
+   - **Consequences**: positive, negative, and neutral. The negative ones are the load-bearing part.
+5. **Link back** — append a dated line to the `## Hand-off notes` free-form section of `specs/<slug>/workflow-state.md` recording the ADR path (e.g. `2026-04-26 (architect): filed ADR-0007 — adopt event sourcing for billing`), and add the ADR path to the active stage artifact's "Decisions" section. Do not introduce an `adrs:` frontmatter key — the workflow-state schema is fixed.
+
+## After filing
+
+- Notify the orchestrator that an ADR was filed; the orchestrator records the ADR path as a dated line in the `## Hand-off notes` section of `workflow-state.md` (no schema fields are added).
+- **ADR bodies are immutable from creation** (per ADR-0001: "ADRs are immutable. Changes are made by superseding, not editing."). Only the YAML `status` field (`proposed` → `accepted` → `deprecated` → `superseded by ADR-NNNN`, all lowercase per `templates/adr-template.md`) and the `superseded-by` / `supersedes` pointers may change after the file is written. Rationale, context, decision text, alternatives, and consequences are frozen.
+- The status flips from `proposed` to `accepted` once the stage's quality gate passes — this is a status-only edit (the prose `## Status` heading in the body may be capitalized for readability, but the YAML enum value is lowercase).
+- To change the **decision** (not just status), file a **new** ADR with status `accepted`, populate its `supersedes:` list with the old ADR's ID, and update the old ADR's `superseded-by:` list and YAML `status` to `superseded by ADR-NNNN`. Do not edit the old ADR's body — its frozen rationale is exactly the audit trail future readers need.
+- If you discover an error in a `proposed` ADR before it's accepted (typo, wrong link, unclear sentence), the correction path is the same: supersede it. The cost of one extra ADR file is much lower than the cost of an editable audit trail.
+
+## Boundaries — who should file an ADR
+
+ADRs are auto-discoverable, but the *right* agent to file one depends on the decision domain:
+
+- **`architect`** — architectural choices (data flow, deployment topology, framework lock-in, event vs. CRUD). The default ADR author.
+- **`pm`** — process or product-shape decisions that bind the kit (e.g., adopting EARS, mandating retros).
+- **`release-manager`** — versioning, release-cadence, rollback-policy decisions.
+- **`sre`** — operational guarantees that constrain design (SLOs, observability contracts).
+
+Other agents (`analyst`, `ux-designer`, `ui-designer`, `dev`, `qa`, `reviewer`, `retrospective`) **flag** decisions that need an ADR rather than filing directly. The flag goes to the orchestrator (or to the appropriate decision-owning agent), which then dispatches `record-decision` with the right author. This preserves the v0.1 agent scoping discipline.
+
+## Rules
+
+- Keep ADRs ≤ one page. If you need more, you're explaining how, not what.
+- Use **plain language**. ADRs are read by future humans (and agents) who don't have context.
+- Cite specific upstream artifacts. Don't restate them.
+- Always include rejected alternatives. Without them, the ADR has no evidence of trade-off.

--- a/.claude/skills/tdd-cycle/SKILL.md
+++ b/.claude/skills/tdd-cycle/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: tdd-cycle
+description: Implement one slice using strict red → green → refactor. Write the failing test first, write the smallest code that makes it pass, then refactor only on green. Use during stage 7 (Implementation), when the user mentions "TDD", "red-green-refactor", "test-first", or whenever the dev agent is executing a task from tasks.md.
+argument-hint: [task-id, e.g. "T-PAY-014"]
+---
+
+# TDD cycle
+
+After Beck's TDD and Pocock's `tdd`. The cycle is the contract; if you skip a step, you've drifted from TDD into "tests after."
+
+## The cycle
+
+This skill executes **the currently dispatched task**, not the whole backlog. `/spec:implement` is scoped to a single task per invocation (`.claude/commands/spec/implement.md` step 1); when this task is complete, return control to the orchestrator, which will dispatch the next ready task in a fresh `/spec:implement` call.
+
+For the dispatched task `<T-AREA-NNN>`:
+
+### 🔴 RED
+
+1. Read the task's acceptance criteria.
+2. Pick **one** observable behavior from the criteria — the smallest meaningful one.
+3. Write a single failing test that asserts that behavior **through the public interface** the spec defines. No private-method tests, no implementation peeking.
+4. Run the test. **It must fail with a meaningful message** — "expected X, got Y", not "ReferenceError: foo is not defined". If the failure is about missing scaffolding, write the minimum stubs to get a real assertion failure, then re-run.
+5. Commit (or mark as ready to commit if the user hasn't authorized commits) using the canonical task-ID format from `.claude/commands/spec/implement.md`: `feat(<area>): <T-AREA-NNN> red — <behavior in plain English>`. Always include the task ID so the commit traces back to its task per `docs/traceability.md`.
+
+### 🟢 GREEN
+
+1. Write the **smallest** code change that makes the failing test pass. Resist generality. "The simplest thing that could possibly work."
+2. Run the **whole test suite** — not just this test. A green local with a red suite is a regression.
+3. If something else turned red, you broke an invariant. Revert and find a smaller change.
+4. Commit with the task-ID format: `feat(<area>): <T-AREA-NNN> green — <same behavior phrasing>`.
+
+### 🔵 REFACTOR
+
+1. Look at the code you just wrote and the surrounding code. Ask:
+   - Is there duplication? (extract)
+   - Is a method too long? (split)
+   - Is a module too shallow? (deepen — push more behavior behind a smaller interface)
+   - Is naming honest? (rename to match `docs/UBIQUITOUS_LANGUAGE.md`)
+   - Is there feature envy / primitive obsession?
+2. Make at most **one** refactor per cycle. Run the suite after each change.
+3. If no refactor needed, say so explicitly and move on. Don't manufacture refactors.
+4. Commit with the task-ID format: `refactor(<area>): <T-AREA-NNN> <what you changed>` (use `refactor` type rather than `feat` since no new behavior is added).
+
+### Loop within the dispatched task only
+
+Pick the next observable behavior **from the same task's** acceptance criteria. RED again. Continue until *this task's* acceptance criteria all pass.
+
+When the dispatched task is fully green and refactored, append an entry to `specs/<slug>/implementation-log.md`: task ID, behaviors covered, tests added (count + names), files touched, commit SHAs (or "uncommitted").
+
+Then **return control to the orchestrator** with a one-line summary. Do not pick up the next task — that's the orchestrator's job (it will dispatch a new `/spec:implement` for the next ready task per `.claude/skills/orchestrate/PHASES.md` Stage 7 loop).
+
+## Anti-patterns to refuse
+
+- **Test after.** If the test was written after the production code, it's not TDD; rewrite the test first or delete the production code.
+- **Horizontal slicing.** Don't write all the tests then all the code. Strict one-cycle-at-a-time.
+- **Mock the unit under test.** Mocks belong at system boundaries (network, filesystem, time, randomness). Mocking the thing you're testing means the test is meaningless.
+- **Refactor on red.** Never. Refactoring without a green safety net is just changing code.
+- **Refactor without a refactor.** Don't ship code that you yourself would have flagged in review.
+
+## When you can't make the test pass within two attempts
+
+Stop. Write a note in `implementation-log.md` describing what you tried, what you observed, and what you suspect is the root cause. Return control to the orchestrator with a `blocked` summary. Don't keep grinding — the spec or design probably has a gap.
+
+## Mocking guidance
+
+- Mock at **system boundaries**: HTTP clients, database drivers, filesystem, clock, random.
+- Prefer **SDK-style fakes** over generic mocks (a fake `UserStore` over a generic mock of a method).
+- Never mock the system under test. Never mock value objects.
+- Inject dependencies; don't reach for globals to swap out.
+
+## Definition of done for a task
+
+- All acceptance criteria have at least one passing test asserting the observable behavior.
+- The whole test suite is green.
+- Lint and type-check pass.
+- An `implementation-log.md` entry was appended.
+- No `TODO` left in the code that wasn't already there.
+
+## Outputs
+
+- Source code changes.
+- Test additions.
+- One `implementation-log.md` append per task.
+- No artifacts in `specs/<slug>/` other than the log append — the design and spec are upstream-owned.

--- a/.claude/skills/tracer-bullet/SKILL.md
+++ b/.claude/skills/tracer-bullet/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: tracer-bullet
+description: Decompose a spec into vertical-slice tasks where each slice goes end-to-end through every layer it needs to and leaves the codebase in a working, committable state. Use during stage 6 (Tasks) of the workflow, when the user wants to break work into independently shippable steps, when a plan reads as horizontal slices ("first all the data layer, then all the API…"), or when the user mentions "tracer bullet", "vertical slice", or "smallest possible commits".
+argument-hint: [feature-slug, e.g. "user-profile"]
+---
+
+# Tracer-bullet planning
+
+After Hunt & Thomas's "tracer bullets" and Pocock's `to-issues` and `request-refactor-plan`. The cure for half-finished features and integration drift is to make every step a thin end-to-end slice.
+
+## Procedure
+
+### Step 1 — Read the spec
+
+Read `specs/<slug>/spec.md` (or whatever artifact is being decomposed). Identify:
+
+- **Behaviors**: what observable user-visible outcomes the spec promises.
+- **Layers touched**: data, API, business logic, UI, observability, etc.
+- **Existing seams**: where the codebase is already factored to accept new behavior.
+
+### Step 2 — Draft slices
+
+For each behavior, draft a slice that:
+
+- Touches every layer it needs to (data → API → UI for a user-visible feature; data → API for a backend-only).
+- Is the **smallest meaningful slice** — the minimum that produces an observable change.
+- Leaves the codebase in a **working, committable state** at slice end (tests pass, type-check passes, no broken paths).
+- Has explicit acceptance criteria phrased as observable behavior, not file changes.
+- Declares dependencies on other slices (`Blocked by: T-<AREA>-NNN`).
+
+### Step 3 — Order slices
+
+Sort slices by:
+
+1. **TDD discipline first** (per `docs/spec-kit.md` §3.6) — test tasks for a requirement come before implementation tasks for the same requirement.
+2. **Dependency-respecting** — no slice unblocked before its dependencies.
+3. **Risk-first when ties** — the slice with the most uncertainty goes first so we learn early.
+4. **Smallest first within a risk tier** — a 2-hour slice before a half-day slice.
+
+Number slices `T-<AREA>-NNN` per the traceability scheme (`docs/traceability.md`).
+
+### Step 4 — Write `tasks.md`
+
+Write `specs/<slug>/tasks.md` from `templates/tasks-template.md`. For each slice:
+
+- Title (verb-first, observable outcome).
+- ID (`T-<AREA>-NNN`).
+- Why this slice (one sentence linking to a REQ or SPEC ID).
+- Acceptance criteria (observable behaviors, ≤4 bullets).
+- Test approach (RED test or characterization test).
+- Risk level (L/M/H — high if anything is unknown).
+- Blocked by (list of slice IDs).
+- Owner (agent role from spec-kit).
+
+Include a **dependency graph** at the top of `tasks.md` (mermaid `flowchart` or simple ASCII).
+
+End with a **Definition of done** section: the user-visible behaviors that prove the whole spec is satisfied.
+
+## Anti-patterns to refuse
+
+- **Horizontal slices.** "All the database changes" then "all the endpoints" then "all the UI" is forbidden. If the slice doesn't go end-to-end, it's the wrong shape.
+- **Mega-slice.** Anything >½ day is too big — split it.
+- **Speculative slice.** "Refactor X first to make later work easier" — only allowed if it's required by an immediate slice, otherwise defer to a later workflow.
+- **Implementation-detail slice.** "Add helper function" is not a slice — it's implementation noise inside someone else's slice.
+
+## Rules
+
+- Refer to behaviors and contracts. Avoid file paths and line numbers in the task description (per the `docs/spec-kit.md` discipline).
+- Use vocabulary from `docs/UBIQUITOUS_LANGUAGE.md` exactly. If you need a new term, coin it via the `ubiquitous-language` skill before writing the task.
+- This skill produces `tasks.md`. The `dev` agent during `/spec:implement` is the one that walks the list with `tdd-cycle`.

--- a/.claude/skills/ubiquitous-language/SKILL.md
+++ b/.claude/skills/ubiquitous-language/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: ubiquitous-language
+description: Maintain a living glossary at docs/UBIQUITOUS_LANGUAGE.md — the canonical vocabulary every agent and human uses when talking about the system. Flags ambiguities, picks opinionated canonical terms, and lazily creates the file on first need. Use when a new domain term is coined or refined, when stage agents disagree on terminology, when the user mentions "glossary", "DDD", "ubiquitous language", or whenever a requirement uses fuzzy language that needs sharpening.
+argument-hint: [optional new term to add or refine]
+---
+
+# Ubiquitous language
+
+After Evans's "ubiquitous language" and Pocock's `ubiquitous-language` skill. The glossary is the contract for vocabulary across the spec → design → spec → tasks → code chain. Drift here causes drift everywhere downstream.
+
+## File layout
+
+```
+docs/UBIQUITOUS_LANGUAGE.md
+```
+
+Single file at repo root. Never sharded — sharding defeats the purpose of a single shared vocabulary.
+
+## Format
+
+```markdown
+# Ubiquitous language
+
+_Last updated: <YYYY-MM-DD> by <agent>_
+
+The canonical vocabulary for talking about this system. Every requirement, design, spec, task, ADR, and code identifier should use these terms exactly. If a term is missing or fuzzy, file a PR or run the `ubiquitous-language` skill to add it.
+
+## Subdomain: <Subdomain name>
+
+| Term | Definition | Synonyms (avoid) | Notes |
+|---|---|---|---|
+| **Subscriber** | A user who has an active paid plan. | Customer, paying user | Distinguished from **Trialist** (active trial) and **Lapsed** (canceled). |
+
+(Repeat per subdomain. Subdomains map to bounded contexts in `docs/CONTEXT.md` or to top-level product areas.)
+
+## Flagged ambiguities
+
+Terms that are currently ambiguous, with the active workflow that will resolve them.
+
+- **Account** vs **User** vs **Profile** — _resolving in workflow `2026-04-26-add-user-profile`_
+
+## Example dialogue
+
+A 3–5 exchange dialogue using the glossary correctly, so an agent reading this file knows what "good" sounds like in this project's voice.
+```
+
+## Procedure
+
+### When a new term is coined
+
+1. Read the current `UBIQUITOUS_LANGUAGE.md`. If absent, scaffold from the template.
+2. Identify the **subdomain** the term belongs to.
+3. Check for collisions:
+   - Same word, different meaning elsewhere? Disambiguate explicitly (`Account (billing)` vs `Account (auth)`).
+   - Different word, same meaning? Pick **one** canonical term and list the others as "avoid" synonyms.
+4. Write the entry: term in **bold**, one-sentence definition in domain language, list of synonyms to avoid, optional notes.
+5. Update `Last updated` and `by`.
+
+### When a term is refined (definition shifts)
+
+1. Update the definition in place.
+2. **Search the codebase and `specs/`** for old usages — ambiguous usages are bugs. Surface a list to the user; don't silently rewrite spec files.
+3. Add a one-line note in the term's row: `Refined <YYYY-MM-DD> in workflow <slug>`.
+
+### When ambiguity is flagged
+
+A stage agent may report that a requirement uses a term in two senses. Add an entry to **Flagged ambiguities** linking to the active workflow. The next iteration of the relevant stage must resolve it.
+
+## Rules
+
+- **One canonical term per concept.** No synonyms in active use. Synonyms are explicitly listed as "avoid."
+- **Domain language, not implementation language.** "Subscriber" not "UserModel"; "Order" not "OrderRecord".
+- **Examples beat definitions.** When a definition is hard to write, add one to the example dialogue.
+- **Lazy creation.** Don't scaffold an empty glossary. Wait for the first real term.
+- **Plain Markdown.** No framework-specific syntax, no front-matter — this file should survive any tooling change.
+
+## Relationship to other artifacts
+
+- **`docs/CONTEXT.md`** — uses these terms exactly; defers to this file for definitions.
+- **`docs/steering/product.md`** — uses these terms exactly; refining a term may require a steering update.
+- **`specs/<slug>/requirements.md`** — every EARS clause uses these terms exactly (per `docs/ears-notation.md` discipline).
+- **Code identifiers** — class, function, and variable names should mirror these terms (within language conventions). The reviewer agent enforces this.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,21 +14,27 @@ A template for **spec-driven, agentic software development**. The workflow itsel
 
 ## How to work here
 
-1. To start a *new* feature, run `/spec:start <feature-slug>` — it scaffolds `specs/<feature-slug>/` and sets `workflow-state.md` to the first stage.
-2. To resume work, read `specs/<feature-slug>/workflow-state.md` to learn what stage is active and what's already produced.
-3. Use the slash command for the active stage: `/spec:idea`, `/spec:research`, `/spec:requirements`, `/spec:design`, `/spec:specify`, `/spec:tasks`, `/spec:implement`, `/spec:test`, `/spec:review`, `/spec:release`, `/spec:retro`. Quality gates: `/spec:clarify` and `/spec:analyze`.
-4. Each command spawns the appropriate subagent from `.claude/agents/`. Don't bypass — agent scoping is intentional.
-5. When you finish a stage, update `specs/<feature-slug>/workflow-state.md` and move on.
+You have two equivalent entry points:
+
+- **Conversational (recommended):** say "let's start a feature" or "drive this end-to-end" and the [`orchestrate`](.claude/skills/orchestrate/SKILL.md) skill will guide you. It gates with `AskUserQuestion` and dispatches the right `/spec:*` command per stage.
+- **Manual:** drive the slash commands yourself in stage order: `/spec:start`, `/spec:idea`, `/spec:research`, `/spec:requirements`, `/spec:design`, `/spec:specify`, `/spec:tasks`, `/spec:implement`, `/spec:test`, `/spec:review`, `/spec:release`, `/spec:retro`. Optional gates: `/spec:clarify`, `/spec:analyze`.
+
+In both modes:
+
+1. State lives in `specs/<feature-slug>/workflow-state.md` — read it to learn where the feature is.
+2. Each `/spec:*` command spawns its specialist subagent from `.claude/agents/`. Don't bypass — agent scoping is intentional.
+3. When you finish a stage, the slash command updates `workflow-state.md`. Don't edit it by hand mid-workflow.
 
 ## Conventions specific to Claude Code
 
 - Subagents are project-scoped (`.claude/agents/`). They have intentionally narrow tool lists — if a tool seems missing, that's a feature, not a bug.
-- Skills (`.claude/skills/`) are reusable how-tos any agent can invoke — `verify`, `new-adr`, `review-fix`. They never override an agent's tool list; they only encode "we always do it this way".
+- Skills live in `.claude/skills/` — see [`.claude/skills/README.md`](.claude/skills/README.md). They auto-trigger from natural language and can be invoked explicitly via `/<skill-name>`. The catalog spans the conversational orchestrator, mattpocock-style practice skills (`grill`, `design-twice`, `tracer-bullet`, `tdd-cycle`), cross-cutting sink skills (`domain-context`, `ubiquitous-language`), and operational skills (`verify`, `new-adr`, `review-fix`).
 - Operational bots live under `agents/operational/`. Each is a `PROMPT.md` + `README.md` pair; the prompt is the source of truth the scheduled run loads.
 - Permission rules live in `.claude/settings.json`. Pushes to `main` / `develop` are denied by default; `--no-verify` is denied. See `docs/branching.md`.
 - Topic branches live in worktrees under `.worktrees/<slug>/`. See `docs/worktrees.md`.
 - Run the verify gate before opening a PR. See `docs/verify-gate.md`.
-- For irreversible architectural decisions, run `/adr:new "<title>"`.
+- For irreversible architectural decisions, use the [`record-decision`](.claude/skills/record-decision/SKILL.md) skill (which wraps `/adr:new`).
+- Where every markdown artifact lands is documented in [`docs/sink.md`](docs/sink.md). Don't invent new sink locations.
 - Don't add `.claudeignore` exclusions silently — note them in `docs/steering/tech.md`.
 
 ## What not to do

--- a/README.md
+++ b/README.md
@@ -17,13 +17,14 @@ LLM coding agents are powerful, but they fail predictably when given vague inten
 | [`docs/quality-framework.md`](docs/quality-framework.md) | Quality dimensions, gates, Definition of Done |
 | [`docs/traceability.md`](docs/traceability.md) | ID scheme: requirement → spec → task → code → test |
 | [`docs/ears-notation.md`](docs/ears-notation.md) | Reference for writing testable requirements |
+| [`docs/sink.md`](docs/sink.md) | Catalog of every markdown artifact: where it lives, who owns it, how it evolves |
 | [`docs/steering/`](docs/steering/) | Persistent, scoped context for agents (product, tech, ux, quality, ops) |
 | [`docs/adr/`](docs/adr/) | Architecture Decision Records — start with [`0001`](docs/adr/0001-record-architecture-decisions.md) |
 | [`memory/constitution.md`](memory/constitution.md) | Project principles loaded ahead of every workflow command |
 | [`templates/`](templates/) | Blank artifacts for each stage (idea, prd, design, spec, tasks, …) |
 | [`.claude/agents/`](.claude/agents/) | One subagent per SDLC role (PM, UX, architect, dev, QA, SRE, …) |
 | [`.claude/commands/`](.claude/commands/) | Slash commands per workflow phase (`/spec:specify`, `/spec:tasks`, …) |
-| [`.claude/skills/`](.claude/skills/) | Reusable how-tos any agent can invoke (verify, new-adr, review-fix) |
+| [`.claude/skills/`](.claude/skills/) | Auto-discoverable skill bundles — `orchestrate` (conversational entry), `grill`, `design-twice`, `tracer-bullet`, `tdd-cycle`, `record-decision`, `domain-context`, `ubiquitous-language`, `verify`, `new-adr`, `review-fix` |
 | [`.claude/memory/`](.claude/memory/) | Operational memory: workflow rules + project state, indexed in [`MEMORY.md`](.claude/memory/MEMORY.md) |
 | [`.claude/settings.json`](.claude/settings.json) | Permission baseline (allow/deny) + SessionStart hook |
 | [`agents/operational/`](agents/operational/) | Always-on, scheduled agents (review-bot, docs-review-bot, plan-recon-bot, dep-triage-bot, actions-bump-bot) |
@@ -42,10 +43,12 @@ LLM coding agents are powerful, but they fail predictably when given vague inten
 1. **Clone or fork** this repo as a starting point for your project.
 2. **Adapt the constitution** at `memory/constitution.md` to your project's principles and constraints.
 3. **Fill the steering files** under `docs/steering/` with project-specific context.
-4. **Start a feature** by creating `specs/<feature-slug>/` and walking the stages (`/spec:idea` → `/spec:research` → … → `/spec:retro`).
-5. **Update `specs/<feature-slug>/workflow-state.md`** as you progress so any agent can pick up where the last one left off.
+4. **Start a feature** in one of two ways:
+   - **Conversational (recommended in Claude Code):** say "let's start a feature" or run `/orchestrate <one-line goal>`. The [`orchestrate`](.claude/skills/orchestrate/SKILL.md) skill gates with you and dispatches the right stage per turn.
+   - **Manual:** create `specs/<feature-slug>/` via `/spec:start <slug>` and walk the stages (`/spec:idea` → `/spec:research` → … → `/spec:retro`).
+5. **State lives in `specs/<feature-slug>/workflow-state.md`** — any agent (or you, in a fresh session) can pick up from there.
 
-If you use Claude Code, the slash commands and subagents work out of the box. If you use Codex / Cursor / Aider, the artifact templates and `AGENTS.md` are tool-agnostic.
+If you use Claude Code, the slash commands, subagents, and skills work out of the box. If you use Codex / Cursor / Aider, the artifact templates and `AGENTS.md` are tool-agnostic; the slash commands and skills are Claude-specific but the conventions they enforce (workflow stages, EARS, ADR pattern) carry over.
 
 ## Workflow at a glance
 
@@ -81,8 +84,9 @@ Adopt operational agents one at a time after the lifecycle workflow is in routin
 ## Versioning
 
 - **v0.1** — Foundation: workflow definition, templates, agents, slash commands.
-- **v0.2** (planned) — Worked examples, automated artifact validation, RTM generator.
-- **v0.3** (planned) — CI quality gates, metrics, maturity model.
+- **v0.2** — Skills layer: `orchestrate` skill (conversational entry), practice skills (`grill`, `design-twice`, `tracer-bullet`, `tdd-cycle`, `record-decision`), cross-cutting sink skills (`domain-context`, `ubiquitous-language`), operational learnings (memory, ops bots, branching/verify/worktrees guides), and `docs/sink.md` cataloging the full markdown sink.
+- **v0.3** (planned) — Worked examples, automated artifact validation, RTM generator.
+- **v0.4** (planned) — CI quality gates, metrics, maturity model.
 
 ## License
 

--- a/docs/sink.md
+++ b/docs/sink.md
@@ -1,0 +1,134 @@
+# Markdown sink
+
+Where every markdown artifact in this kit lives, who owns it, and how it evolves. This is the single reference for any agent, skill, or human that needs to know "where does this go?"
+
+## Layout
+
+```
+.
+├── README.md                                # repo entry point
+├── AGENTS.md                                # cross-tool root context
+├── CLAUDE.md                                # Claude Code entry, imports AGENTS.md
+├── memory/
+│   └── constitution.md                      # principles loaded ahead of every workflow command
+├── docs/
+│   ├── spec-kit.md                          # workflow definition (read first)
+│   ├── workflow-overview.md                 # one-page cheat sheet
+│   ├── quality-framework.md                 # quality dimensions, gates, DoD
+│   ├── traceability.md                      # ID scheme REQ → SPEC → T → code → TEST
+│   ├── ears-notation.md                     # EARS reference
+│   ├── sink.md                              # this file
+│   ├── steering/                            # persistent scoped context
+│   │   ├── product.md
+│   │   ├── tech.md
+│   │   ├── ux.md
+│   │   ├── quality.md
+│   │   └── operations.md
+│   ├── adr/                                 # Architecture Decision Records
+│   │   ├── 0001-record-architecture-decisions.md
+│   │   └── NNNN-<slug>.md                   # one per accepted decision
+│   ├── CONTEXT.md                           # living domain context map (LAZY)
+│   ├── CONTEXT-MAP.md                       # multi-context only (LAZY)
+│   ├── contexts/                            # multi-context only (LAZY)
+│   │   └── <name>.md
+│   └── UBIQUITOUS_LANGUAGE.md               # living glossary (LAZY)
+├── templates/                               # blank artifacts; stages copy + fill
+│   └── *-template.md
+├── specs/                                   # one folder per feature
+│   └── <slug>/
+│       ├── workflow-state.md                # state machine, owned by /spec:* commands
+│       ├── idea.md                          # stage 1 (analyst)
+│       ├── research.md                      # stage 2 (analyst)
+│       ├── requirements.md                  # stage 3 (pm) — EARS-formatted
+│       ├── design.md                        # stage 4 (ux + ui + architect)
+│       ├── design-alt-A.md                  # stage 4, design-twice only (LAZY)
+│       ├── design-alt-B.md                  # stage 4, design-twice only (LAZY)
+│       ├── design-alt-C.md                  # stage 4, design-twice only (LAZY)
+│       ├── design-comparison.md             # stage 4, design-twice synthesis (LAZY)
+│       ├── spec.md                          # stage 5 (architect)
+│       ├── tasks.md                         # stage 6 (planner)
+│       ├── implementation-log.md            # stage 7 (dev)
+│       ├── test-plan.md                     # stage 8 (qa)
+│       ├── test-report.md                   # stage 8 (qa)
+│       ├── review.md                        # stage 9 (reviewer)
+│       ├── traceability.md                  # stage 9 (reviewer) — RTM
+│       ├── release-notes.md                 # stage 10 (release-manager)
+│       └── retrospective.md                 # stage 11 (retrospective)
+├── examples/                                # placeholder for v0.2 worked examples
+└── .claude/
+    ├── agents/                              # subagent definitions (specialists)
+    ├── commands/                            # slash commands (entry points per stage)
+    └── skills/                              # auto-discoverable skill bundles
+```
+
+## Ownership
+
+| Path | Owner | Mutability |
+|---|---|---|
+| `memory/constitution.md` | Human (amended by ADR) | Append-only after amendments |
+| `docs/spec-kit.md`, `docs/quality-framework.md`, `docs/traceability.md`, `docs/ears-notation.md` | Human | Versioned (v0.1, v0.2…) |
+| `docs/sink.md` | Human | Versioned alongside spec-kit |
+| `docs/steering/*` | Human | Updated as project evolves |
+| `docs/adr/NNNN-*.md` | Architect / any agent that flags | **Immutable from creation** per ADR-0001: only YAML `status` (proposed → accepted → deprecated → superseded) and `supersedes` / `superseded-by` pointers may change. Body (Context, Decision, Alternatives, Consequences) is frozen on creation. To revise rationale, supersede via new ADR. |
+| `docs/CONTEXT.md`, `docs/CONTEXT-MAP.md`, `docs/contexts/*.md` | `domain-context` skill | Additive, agent-updated |
+| `docs/UBIQUITOUS_LANGUAGE.md` | `ubiquitous-language` skill | Additive, agent-updated |
+| `templates/*-template.md` | Human | Versioned; updates propagate to new features only |
+| `specs/<slug>/workflow-state.md` | `/spec:start`, then `/spec:*` commands on transition | State machine; orchestrator amends final fields |
+| `specs/<slug>/<artifact>.md` | The stage's owning agent (per `docs/spec-kit.md` §3) | Each stage writes once; later stages **never rewrite** upstream artifacts |
+| `specs/<slug>/design-alt-*.md`, `design-comparison.md` | `design-twice` skill | Created lazily on opt-in |
+| `.claude/skills/<name>/SKILL.md` | Skill author | Versioned in repo |
+| `.claude/agents/<name>.md` | Agent author | Versioned in repo |
+| `.claude/commands/<area>/<name>.md` | Command author | Versioned in repo |
+
+## Lifecycle
+
+### Eager — created by a workflow command
+
+Created by the `/spec:*` command for the stage that owns the artifact. The command also updates `workflow-state.md` to reflect status.
+
+### Lazy — created on first need
+
+Files marked `LAZY` above are not pre-scaffolded. They appear when a skill or agent first needs to write to them. Don't `mkdir -p docs/contexts/` proactively; wait until the multi-context decision is actually made.
+
+### Append-only
+
+`docs/CONTEXT.md`, `docs/UBIQUITOUS_LANGUAGE.md`, `specs/<slug>/implementation-log.md`, and the `## Hand-off notes` free-form section of `workflow-state.md` are append-only in spirit. Agents may reorder or refine, but the historical narrative survives. (The workflow-state YAML frontmatter has no `notes:` field — append-only content lives in markdown sections.)
+
+### Immutable
+
+Accepted ADRs are immutable. To change a decision, file a new ADR superseding the old one. The reviewer agent enforces this.
+
+## Naming rules
+
+- **Folders and files:** lowercase, kebab-case. No spaces, no underscores in paths the kit creates (legacy uppercase filenames like `CONTEXT.md`, `AGENTS.md`, `CLAUDE.md`, `UBIQUITOUS_LANGUAGE.md`, `LICENSE` and template files like `*-template.md` are intentional exceptions for visibility/convention).
+- **Feature slugs:** kebab-case, ≤6 words. Stable for the lifetime of the feature.
+- **ADRs:** four-digit zero-padded sequence (`0001`, `0002`, …) across the whole repo. Find the next number with `ls docs/adr/0*.md | tail -1`.
+- **IDs:** see `docs/traceability.md` (`REQ-<AREA>-NNN`, `SPEC-<AREA>-NNN`, `T-<AREA>-NNN`, `TEST-<AREA>-NNN`).
+
+## Read order for any subagent starting a stage
+
+1. `memory/constitution.md`.
+2. The relevant `docs/steering/*.md` (matched by glob to the stage role).
+3. `docs/spec-kit.md` §3.<stage> — the gate criteria for this stage.
+4. `specs/<slug>/workflow-state.md` — confirm upstream stages are complete.
+5. All numerically-earlier `specs/<slug>/<artifact>.md` files in stage order.
+6. `docs/CONTEXT.md` and `docs/UBIQUITOUS_LANGUAGE.md` if present.
+7. Any topically relevant ADRs (skim titles).
+
+## Don't put in the sink
+
+- **Source code.** Lives in the actual codebase, not in `specs/` or `docs/`.
+- **Long log dumps, raw command output, secrets.** Summaries only.
+- **Files specific to a single subagent's scratch work.** Return a summary instead.
+- **Speculative future work.** That's a follow-up workflow, not a sink artifact.
+- **Implementation file paths or line numbers** in spec/PRD/plan markdown. Per the spec-kit discipline, those describe behaviors and contracts, not locations.
+
+## Cross-cutting writes from skills
+
+These skills append to cross-workflow files:
+
+- `record-decision` → `docs/adr/NNNN-<slug>.md` (via `/adr:new`).
+- `domain-context` → `docs/CONTEXT.md` (or `CONTEXT-MAP.md` + `contexts/<name>.md`).
+- `ubiquitous-language` → `docs/UBIQUITOUS_LANGUAGE.md`.
+
+When any of these write, the active feature's `workflow-state.md` gets a dated one-line entry appended to the `## Hand-off notes` free-form section so the workflow has a paper trail. The frontmatter schema (per `templates/workflow-state-template.md`) is fixed — agents do not add new frontmatter keys.


### PR DESCRIPTION
## Summary

Adds a mattpocock-style **skills layer** on top of the v0.1 Spec Kit foundation (PR #1), plus a single doc cataloging the full markdown sink. All net-new — no edits to the v0.1 surface beyond `README.md` (adds Skills row + bumps version) and `CLAUDE.md` (surfaces `orchestrate` as the recommended entry).

> **PR base = `claude/spec-kit-foundation-h0Faq`** so the diff stays focused (14 files). Re-target to `main` after PR #1 merges.

## What's added

### `.claude/skills/orchestrate/` — the conductor

Natural-language entry to the existing 11-stage workflow. Triggers on phrases like "let's start a feature", "drive this end-to-end", "what's next?", or `/orchestrate <goal>`.

- Reads `specs/<slug>/workflow-state.md` to detect resume vs. fresh start.
- Batches **one** `AskUserQuestion` to capture slug, area code, depth (Standard/Lean/Spike), and opt-in gates.
- Dispatches the existing `/spec:*` slash commands per stage — never duplicates their work.
- Gates between stages with a single `AskUserQuestion`: continue / pause / re-run with feedback / skip next.
- Crash-safe resume protocol against `workflow-state.md`.

References split into `PHASES.md` (per-stage dispatch context) and `RESUME.md` (resume protocol) per Pocock's progressive-disclosure pattern.

### Practice skills (used by stage agents, mattpocock-style)

| Skill | Purpose | Used by |
|---|---|---|
| `grill/` | One-question-at-a-time interview primitive | `/spec:clarify`, analyst, pm, architect |
| `design-twice/` | Parallel divergent design via `Task` tool (Ousterhout) | stage 4 |
| `tracer-bullet/` | Vertical-slice planning, refuses horizontal slices | planner, stage 6 |
| `tdd-cycle/` | Strict red → green → refactor with anti-pattern guards | dev, stage 7 |
| `record-decision/` | When/how to file an ADR; wraps `/adr:new` | architect + any agent on flag |

### Cross-cutting sink skills (lazy)

| Skill | Output |
|---|---|
| `domain-context/` | `docs/CONTEXT.md` (or `CONTEXT-MAP.md` + `contexts/<name>.md` for multi-context projects) |
| `ubiquitous-language/` | `docs/UBIQUITOUS_LANGUAGE.md` — single canonical glossary |

Both follow Pocock's lazy-creation discipline: file appears on first need, never pre-scaffolded.

### `docs/sink.md` — single source of truth for markdown outputs

Catalogs **every** markdown artifact: workflow-scoped (`specs/<slug>/*.md`), cross-cutting (`docs/adr/`, `docs/CONTEXT.md`, `docs/UBIQUITOUS_LANGUAGE.md`), governance (`memory/constitution.md`, `docs/steering/*`), and tooling (`.claude/{agents,commands,skills}/`). Documents ownership, eager vs. lazy, immutability rules, naming conventions, and the read order for any subagent starting a stage.

### `.claude/skills/README.md`

Catalog of all skills with trigger phrases and authoring guide for new skills.

## Design choices

- **Skills complement, don't replace.** Commands stay the explicit entry; subagents stay the scoped specialists; skills add (a) a conversational orchestrator, (b) reusable practice bundles, (c) lazy cross-cutting sinks. Zero duplication of existing spec-kit logic.
- **`AskUserQuestion` only in the main thread.** Subagents cannot ask the user (per Anthropic docs) — the orchestrator does all gating and clarification up front and between stages. This shape is enforced by `SKILL.md`'s constraints section.
- **Sink already existed; the doc didn't.** v0.1 already defined `specs/<slug>/`, `docs/adr/`, `docs/steering/`, `templates/`. v0.2 adds the lazy `CONTEXT.md` / `UBIQUITOUS_LANGUAGE.md` files (Pocock pattern) and one doc that catalogs the whole sink in one place.
- **Progressive disclosure.** Each `SKILL.md` ≤200 lines; deeper material lives in sibling `REFERENCE.md` files. Description format follows Pocock's "capability sentence + Use when… sentence" rule.

## Sources

Built on research into:

- [mattpocock/skills](https://github.com/mattpocock/skills) — `grill-me`, `to-prd`, `to-issues`, `domain-model`, `design-an-interface`, `improve-codebase-architecture`, `tdd`
- [obra/superpowers](https://github.com/obra/superpowers) — orchestrator + worker patterns, dispatching-parallel-agents
- [Anthropic — Building effective agents](https://www.anthropic.com/engineering/building-effective-agents) — prompt chaining + orchestrator-workers
- [Claude Code skills docs](https://code.claude.com/docs/en/skills) and [subagents docs](https://code.claude.com/docs/en/sub-agents)

## Test plan

- [ ] Read `.claude/skills/README.md` — does the catalog match what's in the folder?
- [ ] Read `.claude/skills/orchestrate/SKILL.md` — does the procedure read as a single, complete loop?
- [ ] Read `docs/sink.md` — does every artifact path actually exist (or have a clear lazy-creation owner)?
- [ ] Open one practice skill (e.g. `tdd-cycle/SKILL.md`) — does it stand on its own as guidance for an agent that's never seen it?
- [ ] Confirm `CLAUDE.md` still surfaces both entry modes (orchestrate skill + manual `/spec:*`).
- [ ] In a real session, try saying "let's start a feature" and confirm the orchestrate skill auto-triggers.

https://claude.ai/code/session_01PTc1UHovmBA1Psbd3719KD

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTc1UHovmBA1Psbd3719KD)_