### PR TITLE
docs(examples): scaffold cli-todo worked example (stage 1 idea.md)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,11 +2,14 @@
 
 Worked end-to-end examples of features developed with this kit.
 
-> **Status:** placeholder for v0.2. Examples will live here as `examples/<feature-slug>/` with the full set of artifacts (`idea.md`, `research.md`, `requirements.md`, `design.md`, `spec.md`, `tasks.md`, `implementation-log.md`, `test-plan.md`, `test-report.md`, `review.md`, `release-notes.md`, `retrospective.md`, `traceability.md`, `workflow-state.md`).
+> **Status:** v0.2 in progress. Examples live here as `examples/<feature-slug>/` with the full set of artifacts (`idea.md`, `research.md`, `requirements.md`, `design.md`, `spec.md`, `tasks.md`, `implementation-log.md`, `test-plan.md`, `test-report.md`, `review.md`, `release-notes.md`, `retrospective.md`, `traceability.md`, `workflow-state.md`).
 
-Planned for v0.2:
+Status:
 
-- `examples/cli-todo/` — a tiny CLI todo app, walked through every stage. Demonstrates the workflow on something small enough to read in one sitting.
+- [`examples/cli-todo/`](./cli-todo/) — a tiny CLI todo app, walked through every stage. Demonstrates the workflow on something small enough to read in one sitting. **In progress** — currently at stage 1 (idea); see `cli-todo/workflow-state.md`.
+
+Planned:
+
 - `examples/auth-service/` — a backend feature with non-trivial NFRs (latency, security, observability) showing how the kit handles them.
 - `examples/landing-page/` — a UX/UI-heavy feature showing how `ux-designer` and `ui-designer` collaborate.
 

--- a/examples/cli-todo/idea.md
+++ b/examples/cli-todo/idea.md
@@ -1,0 +1,74 @@
+---
+id: IDEA-CLI-001
+title: A tiny CLI todo app
+stage: idea
+feature: cli-todo
+status: draft
+owner: analyst
+created: 2026-04-27
+updated: 2026-04-27
+---
+
+# Idea — A tiny CLI todo app
+
+## Problem statement
+
+Solo engineers and terminal-native developers want to capture, list, and complete short-lived tasks without leaving the shell. Existing options either pull them into a browser/GUI, require an account, sync to a cloud they don't trust, or carry enough surface area (Taskwarrior, JIRA CLIs) that the cost of learning the tool exceeds the value of the tasks tracked. The result is that "quick todo" thoughts get lost in scratch buffers, stickies, or chat DMs and never get done.
+
+## Target users
+
+- **Primary:** solo engineers who live in the terminal and want a single-binary, local-first todo tool with a learnable surface area (≤ 5 commands).
+- **Secondary:** contributors reading this spec-kit who need a small-but-realistic worked example to learn the workflow on. The example's didactic value is itself a goal.
+
+## Desired outcome
+
+A binary called `todo` that supports the basic lifecycle: `add`, `list`, `done`, `rm`. State persists across invocations in a single local file. A new user can install it and complete their first add → list → done cycle in under two minutes, reading no documentation other than `todo --help`. The implementation is small enough that a contributor can read the source and the spec side-by-side in a single sitting.
+
+## Constraints
+
+- **Time:** ~1–2 days of focused implementation work, so the example fits within a normal sprint slot.
+- **Budget:** zero infrastructure cost. Local-only; no servers, no accounts, no telemetry.
+- **Technical:** single binary or single-runtime install; cross-platform (macOS, Linux, Windows); no background daemon; no network calls in the default path. Language choice deferred to research (stage 2).
+- **Policy / compliance:** MIT-licensed; no telemetry; data file lives under the user's own home / config directory.
+- **Other:** the implementation must remain didactic — a contributor reading `spec.md` alongside the source should be able to map every requirement to its code in one pass.
+
+## Open questions
+
+> These become the research agenda in stage 2.
+
+- Q1 — **Storage format.** Plain text (`todo.txt` style), JSON file, or embedded SQLite? Trade-offs around durability, concurrent writes, human-readability, and migration.
+- Q2 — **Implementation language.** Go, Rust, Python (pipx-installed), or Node? Trade-offs around single-binary distribution, readability for the example's audience, and ecosystem fit.
+- Q3 — **v1 feature scope.** Strictly CRUD, or do we include due dates, priorities, tags, search? Where is the floor that still demonstrates the workflow without bloating the example?
+- Q4 — **Concurrent access.** Two terminals running `todo` at once: do we need a lockfile, atomic-rename writes, or accept last-writer-wins?
+- Q5 — **Data file location.** `~/.todo.json`, XDG config dir, configurable via env var? What is the cross-platform-friendly default?
+- Q6 — **Distribution.** Source-only (`go install`, `cargo install`, `pipx install`), pre-built binaries, Homebrew formula? What is the minimum that still makes the install path realistic?
+
+## Out of scope (preliminary)
+
+What we are explicitly **not** considering, even at the idea stage:
+
+- Multi-user collaboration, sharing, or cloud sync.
+- GUI or full-screen TUI (we are CLI-only; no `curses`-style interface).
+- Notifications, reminders, or recurring tasks.
+- Calendar / external-service integrations.
+- Plugin / extension architecture.
+- Project hierarchy or nested sub-tasks.
+
+These may become candidates for follow-up examples but must not creep into v1.
+
+## References
+
+- `todo.txt` format and the surrounding ecosystem — prior art for human-readable, line-oriented todo storage.
+- `taskwarrior` — feature-rich CLI todo manager; useful as a *contrast* for "what we are not building".
+- `gh` and `git` CLI ergonomics — reference for subcommand structure and `--help` output style.
+
+---
+
+## Quality gate
+
+- [x] Problem statement is one paragraph and understandable to a non-expert.
+- [x] Target users named.
+- [x] Desired outcome stated.
+- [x] Constraints listed.
+- [x] Open questions captured.
+- [x] Scope is bounded — no "boil the ocean" framing.

--- a/examples/cli-todo/workflow-state.md
+++ b/examples/cli-todo/workflow-state.md
@@ -1,0 +1,68 @@
+---
+feature: cli-todo
+area: CLI
+current_stage: idea
+status: active
+last_updated: 2026-04-27
+last_agent: analyst
+artifacts:
+  idea.md: in-progress
+  research.md: pending
+  requirements.md: pending
+  design.md: pending
+  spec.md: pending
+  tasks.md: pending
+  implementation-log.md: pending
+  test-plan.md: pending
+  test-report.md: pending
+  review.md: pending
+  traceability.md: pending
+  release-notes.md: pending
+  retrospective.md: pending
+---
+
+# Workflow state — cli-todo
+
+> A worked example of the spec-kit, walked through every stage. Built incrementally so each stage can be reviewed before the next one builds on it.
+
+## Stage progress
+
+| Stage | Artifact | Status |
+|---|---|---|
+| 1. Idea | `idea.md` | in-progress |
+| 2. Research | `research.md` | pending |
+| 3. Requirements | `requirements.md` | pending |
+| 4. Design | `design.md` | pending |
+| 5. Specification | `spec.md` | pending |
+| 6. Tasks | `tasks.md` | pending |
+| 7. Implementation | `implementation-log.md` + code | pending |
+| 8. Testing | `test-plan.md`, `test-report.md` | pending |
+| 9. Review | `review.md`, `traceability.md` | pending |
+| 10. Release | `release-notes.md` | pending |
+| 11. Learning | `retrospective.md` | pending |
+
+> **Statuses:** `pending` | `in-progress` | `complete` | `skipped` | `blocked`. Use the bare enum value in frontmatter; document skip reasons in **Skips** below and blockers in **Blocks**.
+
+## Skips
+
+> None yet. The retrospective is never skipped.
+
+## Blocks
+
+> None.
+
+## Hand-off notes
+
+Free-form. What does the next agent / human need to know?
+
+```
+2026-04-27 (analyst): Scaffold + draft idea.md created as the first commit
+                      of the worked example. Awaiting human acceptance of
+                      idea.md before invoking /spec:research.
+```
+
+## Open clarifications
+
+> Add and resolve as they come up. Unresolved clarifications block stage transitions.
+
+- [ ] CLAR-001 — Confirm primary readership (template contributors vs. real CLI todo users) — affects how much we lean on didactic clarity vs. product polish.


### PR DESCRIPTION
## Summary

Starts the first worked example of the spec-kit by scaffolding `examples/cli-todo/`. Built incrementally — one stage per commit — so each stage can be reviewed and accepted before the next builds on it (per `memory/constitution.md` Article III, Incremental Progression).

This PR delivers stage 1 only:

- `examples/cli-todo/workflow-state.md` — initial state, `current_stage: idea`, `idea.md: in-progress`, all later artifacts `pending`. Includes hand-off note and one open clarification (`CLAR-001` on primary readership).
- `examples/cli-todo/idea.md` — `IDEA-CLI-001`, draft. Frames a tiny single-binary CLI todo app: problem statement, primary/secondary users (terminal-native engineers + spec-kit readers), desired outcome (sub-2-minute first cycle, source readable alongside spec), constraints (1–2 days, local-only, no telemetry, single binary, language TBD), six open questions for stage 2 research (storage format, language, v1 scope, concurrent access, data file location, distribution), and explicit out-of-scope list (no sync, no GUI/TUI, no reminders, no integrations, no plugins, no nested tasks). All idea-stage quality-gate checkboxes pass.
- `examples/README.md` — moves cli-todo from "planned for v0.2" to **in progress**, with a link into the example folder.

## Out of scope for this PR

Stages 2–11 (`research.md`, `requirements.md`, `design.md`, `spec.md`, `tasks.md`, implementation, testing, review, release, retrospective). Each lands in its own follow-up PR after the human accepts the prior stage.

## Test plan

- [ ] `idea.md` frontmatter validates against `templates/idea-template.md` (id, stage, feature, status, owner, dates).
- [ ] `workflow-state.md` frontmatter validates against `templates/workflow-state-template.md` (artifact map, current_stage, status).
- [ ] All six idea-stage quality-gate items in `idea.md` are ticked and the content actually satisfies them.
- [ ] `examples/README.md` link to `./cli-todo/` resolves.
- [ ] No content invented beyond the idea stage (no requirements/design leakage — Article II, Separation of Concerns).
- [ ] `CLAR-001` is genuinely a clarification needed before stage 2, not a stage-3 question in disguise.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y96daaqB13FeA9WVidd938)_