### PR TITLE
docs(memory): add Discovery-before-idea rule to MEMORY.md

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -13,6 +13,7 @@ See [`README.md`](./README.md) for what belongs here and how to update it.
 
 > How we work — conventions every contributor (human or agent) follows.
 
+- **Discovery before idea** — when no brief exists, run the Discovery Track first (`/discovery:start` → … → `/discovery:handoff`). The track produces `chosen-brief.md` which seeds `/spec:idea`. Skipping discovery on a blank page violates Article II (Separation of Concerns). See [`docs/discovery-track.md`](../../docs/discovery-track.md) and [ADR-0005](../../docs/adr/0005-add-discovery-track-before-stage-1.md).
 - **Branch per concern** — one PR, one concern. Cut every topic branch fresh from the integration branch; never stack. See [`feedback_pr_hygiene.md`](./feedback_pr_hygiene.md).
 - **Verify before push** — the project's verify gate (formatter + linter + types + tests + build) must be green locally before opening a PR. Never `--no-verify`. See [`feedback_verify_gate.md`](./feedback_verify_gate.md) and [`docs/verify-gate.md`](../../docs/verify-gate.md).
 - **Worktrees for parallel work** — every topic branch lives under `.worktrees/<slug>/` so multiple agents can run in parallel without trashing each other's caches. See [`feedback_worktrees_required.md`](./feedback_worktrees_required.md) and [`docs/worktrees.md`](../../docs/worktrees.md).


### PR DESCRIPTION
## Summary

- Adds the **Discovery-before-idea** workflow rule to `.claude/memory/MEMORY.md`
- Deferred from PR #6 per `feedback_memory_edits.md` — memory edits must ride in their own docs-only PR with no changeset or version bump
- Links to `docs/discovery-track.md` and ADR-0005 (both landed in #6)

## What changed

One bullet added to the **Workflow rules** section of `.claude/memory/MEMORY.md`:

> **Discovery before idea** — when no brief exists, run the Discovery Track first (`/discovery:start` → … → `/discovery:handoff`). The track produces `chosen-brief.md` which seeds `/spec:idea`. Skipping discovery on a blank page violates Article II (Separation of Concerns).

## Test plan

- [ ] `.claude/memory/MEMORY.md` is the only file changed
- [ ] No code, templates, agents, or commands are modified
- [ ] Links to `docs/discovery-track.md` and `docs/adr/0005-…` resolve (both exist on `main` since #6 merged)

https://claude.ai/code/session_01De2Sy4TrerLptaQyfVU6zq

---
_Generated by [Claude Code](https://claude.ai/code/session_01De2Sy4TrerLptaQyfVU6zq)_