### PR TITLE
docs(sink): clarify examples/ as outside-workflow demonstration zone

### DIFF
--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -20,7 +20,7 @@ You **route** work; you do not **do** work. Your job is to look at the current s
 
 ## Procedure
 
-1. Confirm the **feature slug** with the human if not obvious.
+1. Confirm the **feature slug** with the human if not obvious. **Look only in `specs/`** — never in `examples/`. The `examples/` tree holds demonstration artifacts that simulate what an adopting project produces; they are not active workflow state (see `docs/sink.md` §Examples sub-tree).
 2. Read `specs/<feature>/workflow-state.md`. If it doesn't exist:
    - Check whether the human has a brief or a blank page. If they have a brief, propose `/spec:start <slug>`.
    - If they don't have a brief, recommend the **Discovery Track** instead (`/discovery:start <sprint-slug>` or the [`discovery-sprint`](../skills/discovery-sprint/SKILL.md) skill). The track is defined in [`docs/discovery-track.md`](../../docs/discovery-track.md) and produces a `chosen-brief.md` that seeds `/spec:idea`.

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -46,6 +46,8 @@ Always start by reading these (they're the contract you're enforcing):
 ls specs/ 2>/dev/null
 ```
 
+Scan **only `specs/`** — never `examples/`. The `examples/` tree contains demonstration artifacts that simulate what an adopting project would produce; they are not active workflow state and must not be offered as resumable features (see `docs/sink.md` §Examples sub-tree).
+
 For each `specs/<slug>/workflow-state.md` whose `status` is `active`, `paused`, or `blocked` (all three are resumable per the schema), list `slug | status | current_stage | last_updated`. Then **batch one `AskUserQuestion`** asking the user to pick:
 
 - Resume a listed feature (one option per feature, recommended-first by `last_updated`; show the status next to each).

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ LLM coding agents are powerful, but they fail predictably when given vague inten
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | How to contribute to this template (uses its own workflow) |
 | [`AGENTS.md`](AGENTS.md) | Cross-tool root context (Codex, Cursor, Aider, Copilot all read this) |
 | [`CLAUDE.md`](CLAUDE.md) | Claude Code entry point — imports `AGENTS.md` |
-| [`examples/`](examples/) | Worked end-to-end examples (placeholder for v0.2) |
+| [`examples/`](examples/) | Demonstration artifacts — what a project using this template produces. Each `examples/<slug>/` mirrors `specs/<slug>/` shape. Not part of the template's own workflow; agents must not treat these as active features. (`cli-todo`: stages 1–3 complete, stage 4 in-progress) |
 
 ## Quickstart
 

--- a/docs/sink.md
+++ b/docs/sink.md
@@ -65,7 +65,12 @@ Where every markdown artifact in this kit lives, who owns it, and how it evolves
 │       ├── traceability.md                  # stage 9 (reviewer) — RTM
 │       ├── release-notes.md                 # stage 10 (release-manager)
 │       └── retrospective.md                 # stage 11 (retrospective)
-├── examples/                                # placeholder for v0.2 worked examples
+├── examples/                                # demonstration artifacts — NOT the template's own workflow (see §Examples sub-tree)
+│   └── <feature-slug>/
+│       ├── workflow-state.md                # mirrors specs/<slug>/workflow-state.md shape
+│       ├── idea.md, research.md, …          # same artifact set as specs/<slug>/
+│       └── adr/                             # project-local ADRs for the example (NOT docs/adr/)
+│           └── NNNN-<slug>.md               # project-local sequence, e.g. ADR-CLI-0001
 └── .claude/
     ├── agents/                              # subagent definitions (specialists)
     ├── commands/                            # slash commands (entry points per stage)
@@ -117,7 +122,7 @@ Accepted ADRs are immutable. To change a decision, file a new ADR superseding th
 
 - **Folders and files:** lowercase, kebab-case. No spaces, no underscores in paths the kit creates (legacy uppercase filenames like `CONTEXT.md`, `AGENTS.md`, `CLAUDE.md`, `UBIQUITOUS_LANGUAGE.md`, `LICENSE` and template files like `*-template.md` are intentional exceptions for visibility/convention).
 - **Feature slugs:** kebab-case, ≤6 words. Stable for the lifetime of the feature.
-- **ADRs:** four-digit zero-padded sequence (`0001`, `0002`, …) across the whole repo. Find the next number with `ls docs/adr/0*.md | tail -1`.
+- **ADRs:** four-digit zero-padded sequence (`0001`, `0002`, …) in `docs/adr/`, global across the template repo. Find the next number with `ls docs/adr/0*.md | tail -1`. **Exception — examples:** each `examples/<slug>/adr/` uses its own local sequence (e.g. `ADR-CLI-0001`) that is independent of and does not conflict with the template's global numbering. The prefix (`CLI`, `AUTH`, …) mirrors the feature's `<AREA>` code.
 - **IDs:** see `docs/traceability.md` (`REQ-<AREA>-NNN`, `SPEC-<AREA>-NNN`, `T-<AREA>-NNN`, `TEST-<AREA>-NNN`).
 
 ## Read order for any subagent starting a stage
@@ -135,6 +140,21 @@ Accepted ADRs are immutable. To change a decision, file a new ADR superseding th
 When a team enters the kit with a **blank page** (no brief), the Discovery Track produces `chosen-brief.md` first; that brief is then the input the analyst reads in Stage 1. The track lives at `discovery/<sprint-slug>/` parallel to `specs/`. See [`docs/discovery-track.md`](discovery-track.md) for the methodology and [ADR-0005](adr/0005-add-discovery-track-before-stage-1.md) for the rationale.
 
 A sprint may emit **0, 1, or N** chosen briefs. Zero is a valid outcome (no-go); the sprint folder is preserved as historical context regardless. The handoff is the *only* link between the discovery and specs trees — before handoff no `specs/<slug>/` exists; after handoff the brief is referenced from `idea.md`'s frontmatter `inputs:`.
+
+## Examples sub-tree
+
+`examples/` is a **demonstration zone** — it shows what a real project that adopted this template would produce. It is structurally outside the template's own workflow:
+
+- **Not active workflow state.** Agents, skills, and the orchestrate skill must not treat `examples/<slug>/workflow-state.md` as a resumable feature. The orchestrate skill scans `specs/`; examples live outside that tree deliberately.
+- **Simulates an adopting project.** Each `examples/<slug>/` mirrors the shape of `specs/<slug>/` exactly, so a reader can see every artifact a real feature produces without running the workflow themselves.
+- **Project-local ADRs.** Each example has its own `examples/<slug>/adr/` directory. The numbering (`ADR-CLI-0001`, `ADR-AUTH-0001`, …) is independent of `docs/adr/` and uses the example's `<AREA>` prefix. This deliberately models what ADR naming looks like inside an adopting project, where the template's global `ADR-0001…0005` would not be inherited.
+- **Read-only for agents.** Agents may read example artifacts for reference (e.g. "what does a complete design.md look like?") but must never write to `examples/` as part of a workflow run.
+
+| Path | Owned by | Mutability |
+|---|---|---|
+| `examples/README.md` | Human | Updated as examples are added |
+| `examples/<slug>/` | Human (example maintainer) | Mirrors `specs/<slug>/` shape; updated as the example progresses |
+| `examples/<slug>/adr/` | Human (example maintainer) | Same immutability rules as `docs/adr/`; project-local sequence |
 
 ## Don't put in the sink
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,7 +6,7 @@ Worked end-to-end examples of features developed with this kit.
 
 Status:
 
-- [`examples/cli-todo/`](./cli-todo/) — a tiny CLI todo app, walked through every stage. Demonstrates the workflow on something small enough to read in one sitting. **In progress** — currently at stage 1 (idea); see `cli-todo/workflow-state.md`.
+- [`examples/cli-todo/`](./cli-todo/) — a tiny CLI todo app, walked through every stage. Demonstrates the workflow on something small enough to read in one sitting. **In progress** — stages 1–3 complete (idea, research, requirements); stage 4 design in-progress. See `cli-todo/workflow-state.md`.
 
 Planned:
 


### PR DESCRIPTION
## Summary

- `examples/` is a demonstration zone that simulates what an adopting project produces — it is structurally outside the template's own workflow
- Added `examples/<slug>/` subtree to `sink.md` layout tree with correct shape
- Added new `§Examples sub-tree` section to `sink.md` making the boundary explicit: not resumable workflow state, read-only for agents, project-local ADR numbering (`ADR-<AREA>-NNNN`) independent of `docs/adr/`
- Updated ADR naming rule in `sink.md` to document the examples exception
- Fixed stale stage number in `examples/README.md` (said "stage 1", actually at stage 4 design in-progress)
- Fixed `README.md` `examples/` row (said "placeholder for v0.2", now describes actual state)
- Added explicit guard to orchestrate skill Step 1: scan `specs/` only, never `examples/`
- Added explicit guard to orchestrator agent procedure: look only in `specs/`

## Test plan

- [ ] `sink.md` layout tree includes `examples/<slug>/` with correct subtree shape
- [ ] `sink.md` §Examples sub-tree section clearly explains the outside-workflow boundary
- [ ] `sink.md` ADR naming rule documents the `examples/<slug>/adr/` local sequence exception
- [ ] `examples/README.md` status line reflects stage 4 (design in-progress)
- [ ] Root `README.md` `examples/` row no longer says "placeholder"
- [ ] Orchestrate skill Step 1 contains the `examples/` guard comment
- [ ] Orchestrator agent procedure step 1 contains the `examples/` guard

https://claude.ai/code/session_013yRuXAb5uVgYKLAQMzG8yC

---
_Generated by [Claude Code](https://claude.ai/code/session_013yRuXAb5uVgYKLAQMzG8yC)_