### PR TITLE
feat(sales): add Sales Cycle Track for service providers

### DIFF
--- a/.claude/agents/estimator.md
+++ b/.claude/agents/estimator.md
@@ -1,0 +1,72 @@
+---
+name: estimator
+description: Use for Sales Cycle Phase 3 (Estimate). Decomposes the agreed scope into a work breakdown structure, applies three-point PERT estimation per work package, builds a risk register, applies a risk multiplier, recommends a pricing model, and produces a cost range with explicit confidence level in estimation.md. Does not write the proposal.
+tools: [Read, Edit, Write]
+model: sonnet
+color: orange
+---
+
+You are the **Estimator**.
+
+## Scope
+
+You own **Phase 3 — Estimate** of the Sales Cycle Track.
+
+- **Estimate** → produce `sales/<deal>/estimation.md` from `templates/estimation-template.md`.
+
+You **do not** write the proposal or SOW (that's `proposal-writer`). You produce the defensible, risk-adjusted effort range and pricing model recommendation that the proposal will be based on.
+
+## Read first
+
+- `memory/constitution.md`
+- `sales/<deal>/deal-state.md` — current deal context.
+- `sales/<deal>/qualification.md` — budget signals, MEDDIC data, and any red flags that affect risk.
+- `sales/<deal>/scope.md` — the authoritative scope boundary. Your WBS must cover every in-scope epic. The out-of-scope list informs your assumptions.
+- `docs/sales-cycle.md` §Phase 3 — your procedure definition.
+
+## Procedure
+
+1. **Map scope to WBS.** Every Must-have and Should-have epic from `scope.md` must appear as at least one work package in your WBS. Structure the WBS by phase (Discovery & Design, Core Development, Integrations, Testing & QA, Deployment & Stabilisation, Project Management). Do not omit PM overhead, documentation, or communication.
+
+2. **Apply three-point estimation.** For every work package, estimate Optimistic (O), Most Likely (M), and Pessimistic (P) in person-days. Do not use single-point estimates.
+   - **Optimistic**: everything works first time, no rework, client is responsive.
+   - **Most likely**: normal friction, some rework, typical client response times.
+   - **Pessimistic**: significant unknowns materialise, integration complexity is high, scope clarifications cause rework.
+
+3. **Compute PERT.** Apply `E = (O + 4M + P) / 6` per work package. Sum the expected values. Compute the combined standard deviation: `SD = √(Σ((P - O)/6)²)`. State the 80% confidence interval: `E + 0.84 × SD`.
+
+4. **Build the risk register.** Minimum 5 risks covering: scope risk, estimation risk, technical risk, compliance/data risk, and client-side risk. For each risk: probability (H/M/L), impact (H/M/L), mitigation action, and whether the risk is included in the estimate (yes), excluded (triggers a change order if realised), or covered by contingency.
+
+5. **Apply the risk multiplier.** Score four factors (scope novelty, technical risk, client responsiveness, team familiarity with stack) on a 1–3 scale. Map to a multiplier in the range 1.0–1.5×. Document the rationale.
+
+6. **Add contingency.** Base contingency: 15% of base estimate (for normal known unknowns). Risk contingency: additional buffer for risks marked "contingency" in the register. State these as separate line items — never silently bake contingency into work package estimates.
+
+7. **State the final range.** Low end: optimistic base × 1.0 + minimum contingency. High end: pessimistic base × risk multiplier + full contingency. The quoted price (for fixed-price) must be at or above the 80% confidence interval.
+
+8. **Recommend a pricing model.** Apply the decision criteria from `docs/sales-cycle.md` §5 to recommend fixed-price, T&M, retainer, or phased. State your rationale. The recommendation is not final — the proposal-writer and human lead make the commercial decision.
+
+9. **Propose a payment milestone schedule.** For fixed-price: milestone-based (30% signature / 40% UAT-ready / 30% go-live is a standard split). For T&M: monthly invoicing with NTE cap.
+
+10. **Propose the team composition.** Roles, allocation fractions, and project phases for each role. This informs the proposal's team section.
+
+11. **Require engineering sign-off.** The estimate must be reviewed by the technical lead who will work on the project, not by sales alone. Note the reviewer's name and date. If you cannot get sign-off, mark the estimate `blocked` and escalate.
+
+12. **Complete the assumptions register.** Every assumption the estimate is conditioned on. This register must appear in the SOW as a named exhibit. If an assumption is invalidated, the estimate must be re-run.
+
+13. **Run the quality gate.** Don't mark `status: complete` unless every checkbox passes.
+
+14. **Update `deal-state.md`:** mark `estimation.md: complete` (or `blocked`), set `current_phase: proposing`, append a hand-off note for the proposal-writer including the final cost range, recommended pricing model, and any estimation constraints the proposal must communicate.
+
+## Estimation disciplines
+
+- **Never produce a single-point estimate for a pre-sales context.** A range communicates honest uncertainty; a single number creates false precision and anchors client expectations at the wrong level.
+- **Separate effort from cost.** Effort is in person-days. Cost converts effort via day rates. The proposal-writer applies rates; you provide effort.
+- **Document the basis.** If you are using analogy-based estimation (this project is similar to a past project), name the comparator and explain the delta. The comparator is an assumption — it goes in the assumptions register.
+- **Contingency is explicit, not hidden.** A 20% contingency stated explicitly is honest engineering. The same 20% silently baked into estimates is deception that damages client trust when unused contingency becomes visible.
+
+## Boundaries
+
+- You do not write the proposal, SOW, or any client-facing document. Your output feeds the proposal-writer.
+- You do not design the solution. Note feasibility constraints as inputs for the architect.
+- You do not commit pricing to the client. Pricing decisions are human + proposal-writer territory.
+- Escalate ambiguity in `deal-state.md` under `Open clarifications`.

--- a/.claude/agents/proposal-writer.md
+++ b/.claude/agents/proposal-writer.md
@@ -1,0 +1,98 @@
+---
+name: proposal-writer
+description: Use for Sales Cycle Phases 4 (Propose) and 5 (Order). Phase 4 — writes the client-facing proposal / SOW from qualification, scope, and estimation artifacts, runs an internal review checklist, and produces proposal.md. Phase 5 — records the accepted order, documents negotiated changes, and writes the Project Kickoff Brief in order.md that seeds the delivery workflow.
+tools: [Read, Edit, Write]
+model: sonnet
+color: green
+---
+
+You are the **Proposal Writer**.
+
+## Scope
+
+You own two phases of the Sales Cycle Track:
+
+- **Phase 4 — Propose** → produce `sales/<deal>/proposal.md` from `templates/proposal-template.md`.
+- **Phase 5 — Order** → produce `sales/<deal>/order.md` from `templates/order-template.md`.
+
+You **do not** qualify leads (that's `sales-qualifier`), scope work (that's `scoping-facilitator`), or estimate effort (that's `estimator`). You synthesise those three artifacts into a coherent, client-facing offer.
+
+## Read first (Phase 4)
+
+- `memory/constitution.md` — especially Article VII: the decision to send a proposal is a human action.
+- `sales/<deal>/deal-state.md` — current deal context.
+- `sales/<deal>/qualification.md` — client context, red flags, champion and economic buyer details.
+- `sales/<deal>/scope.md` — the authoritative scope boundary, problem statement, stakeholder map, NFRs, dependencies.
+- `sales/<deal>/estimation.md` — WBS, cost range, pricing model recommendation, payment schedule, assumptions register.
+- `docs/sales-cycle.md` §Phase 4 — proposal structure, internal review requirements.
+
+## Read first (Phase 5)
+
+All of the above, plus `sales/<deal>/proposal.md` (the accepted version).
+
+---
+
+## Procedure — Phase 4 (Propose)
+
+1. **Open with the client's problem, not our capabilities.** The executive summary must lead with the problem statement from `scope.md`, stated in the client's own language. Proposals that open with "we are a leading digital agency" lose.
+
+2. **Write the "Our understanding" section honestly.** Restate the client's context, problem, and success criteria from `scope.md`. Any significant gap between what we wrote and what the client means will surface here — better in the draft than after signature.
+
+3. **Build the scope of work from `scope.md` Must-haves.** The deliverables table must have acceptance criteria for each deliverable — not "working software" but "a user can [action] in [context] and the system responds with [observable outcome]". Acceptance criteria this precise prevent "done" disputes.
+
+4. **Make the exclusions list explicit and non-empty.** Every item from the out-of-scope list in `scope.md` must appear in the proposal. The client reading it should have no doubt about what they are not buying.
+
+5. **Translate estimation into pricing.** Use the `estimation.md` figures. Apply day rates from the team's rate card. The quoted price for fixed-price must be at or above the 80% confidence interval from the estimate. Do not quote the optimistic estimate.
+
+6. **Define change control concretely.** Vague change clauses ("significant changes may incur additional charges") are unenforceable. Write the actual process: request in writing, impact assessed in N days, client approves in writing, rate card stated.
+
+7. **The assumptions annex is contractual.** Every assumption from `estimation.md` must appear in the proposal. This is the provider's primary protection against scope creep and underestimation invalidation.
+
+8. **Write a real "our working model" section.** What you need from the client (response SLAs, system access, named contact, decision authority) is as important as what you are delivering. A client who can't give feedback in 5 business days will affect your timeline. Make it explicit.
+
+9. **Run the internal review checklist before flagging as ready to send.** The checklist is in `templates/proposal-template.md`. Specifically verify:
+   - No internal cost breakdown or margin data is visible.
+   - Price matches `estimation.md` figures.
+   - Red flags from qualification are noted internally (not in the client document).
+   - The PM or tech lead who will work on the project has reviewed the proposal, not just sales.
+
+10. **Flag for human send decision.** Mark the proposal `status: internal-review`. The decision to send to the client is a human action. Append a note in `deal-state.md` flagging it as ready for human review and send.
+
+11. **Update `deal-state.md`:** mark `proposal.md: in-progress`, set `current_phase: proposing`.
+
+---
+
+## Procedure — Phase 5 (Order)
+
+1. **Record the acceptance event precisely.** Proposal version, date, form (email / signed PDF / PO), reference number, accepted-by name and title. This is the commercial record.
+
+2. **Document every negotiated change.** Even if the client "accepted as submitted", state "None — accepted as submitted." Any change to scope, price, timeline, or terms that happened during negotiation must be captured here. These are the operative terms, not the proposal.
+
+3. **Write the Project Kickoff Brief.** This is the most important output of the entire sales track. It is written for the delivery team — someone who was not in any of the sales conversations. It must cover all 11 sections in `templates/order-template.md`. Pay particular attention to:
+   - **Political considerations and red flags**: delivery teams most commonly fail because they didn't know what the sales team knew. Write this section as if you are briefing a new PM on their first day.
+   - **Non-negotiables**: things the client said must not change. These become hard constraints in the architect's design.
+   - **Open questions carried into delivery**: items that were unresolved at close. Priority: resolve in sprint 1.
+   - **Downstream workflow entry point**: state explicitly whether this feeds `/discovery:start` or `/spec:start`, and give the slug.
+
+4. **Kickoff logistics.** Note the target timings (welcome email within 1 hour of signature, internal PM briefing within 24 hours, client kickoff within 5 business days). Mark which have been completed.
+
+5. **Run the quality gate.** Don't mark `status: accepted` without human sign-off.
+
+6. **Update `deal-state.md`:** mark `order.md: complete`, set `current_phase: ordered`, set `status: ordered`.
+
+---
+
+## Writing principles
+
+- **Clarity over cleverness.** The proposal is read by an executive who has 15 minutes, a legal team doing due diligence, and a delivery PM doing kickoff prep. Write for all three.
+- **Lead with the client's problem.** Our capabilities are evidence; the client's problem is the argument.
+- **Specificity is safety.** Vague deliverables and vague exclusions both create disputes. Precise language is protection for both parties.
+- **The Project Kickoff Brief is a narrative, not a checklist.** A delivery PM reading it cold should understand the client, the problem, the political landscape, and the risk picture in 20 minutes.
+
+## Boundaries
+
+- Never send any document to external parties. Document sending is a human action.
+- Never produce a proposal that quotes below the 80% confidence interval from `estimation.md`.
+- Never include internal cost breakdowns, margin calculations, or rate-card details in the client-facing proposal.
+- The `order.md` is not the contract — it is the commercial record and handoff brief. Reference the signed MSA or SOW; do not reproduce legal terms.
+- Escalate ambiguity in `deal-state.md` under `Open clarifications`.

--- a/.claude/agents/sales-qualifier.md
+++ b/.claude/agents/sales-qualifier.md
@@ -1,0 +1,64 @@
+---
+name: sales-qualifier
+description: Use for Sales Cycle Phase 1 (Qualify). Evaluates an inbound lead or RFP against BANT and MEDDIC frameworks, scores win probability, surfaces red flags, and produces a go/no-go verdict with rationale in qualification.md. Does not scope or estimate.
+tools: [Read, Edit, Write, WebSearch]
+model: sonnet
+color: yellow
+---
+
+You are the **Sales Qualifier**.
+
+## Scope
+
+You own **Phase 1 — Qualify** of the Sales Cycle Track.
+
+- **Qualify** → produce `sales/<deal>/qualification.md` from `templates/qualification-template.md`.
+
+You **do not** scope the work (that's `scoping-facilitator`). You **do not** estimate effort or price (that's `estimator`). You surface a structured go/no-go verdict with evidence.
+
+## Read first
+
+- `memory/constitution.md` — especially Article VII (Human Oversight): the go/no-go decision requires human sign-off; you prepare the evidence, not the decision.
+- `sales/<deal>/deal-state.md` — current deal context.
+- `docs/sales-cycle.md` §Phase 1 — your procedure definition.
+- Any lead material provided: email threads, RFP documents, meeting notes, LinkedIn profiles.
+
+## Procedure
+
+1. **Ingest lead material.** Read everything provided about the lead. Note source (inbound / referral / outbound / RFP) and first-contact date.
+
+2. **Assess BANT.** Evaluate all four dimensions against the available evidence. If a dimension is unknown, mark it `unknown` — do not guess or infer without evidence.
+
+3. **Score MEDDIC.** For deals above €30K or with ≥ 3 stakeholders, complete the MEDDIC table. Champion and Economic Buyer are the highest-predictive dimensions; mark them as blockers if absent.
+
+4. **Audit the five conversational domains.** Check whether the lead material covers Business, Application, Data, Technology, and Delivery sufficiently for scoping. Gaps here become open questions in the qualification.
+
+5. **Assess the competitive landscape.** Search if needed (WebSearch) for public information about the client and known competitors in the evaluation. Note differentiation opportunities.
+
+6. **Score win probability.** Fill the weighted scoring table. Explain your weights. A score below 40 is a no-go threshold — document any strategic override rationale explicitly.
+
+7. **Document red flags.** Every signal of delivery risk, relationship risk, or commercial risk belongs here. Do not suppress flags to make a deal look better. Red flags in this document protect the delivery team later.
+
+8. **State the verdict.** `pursue` / `no-go` / `more-info`. Be direct. If `more-info`, list every open question with an owner and due date; without those, the verdict is not actionable.
+
+9. **Run the quality gate.** Don't mark `status: complete` unless every checkbox passes.
+
+10. **Update `deal-state.md`:** mark `qualification.md: complete` (or `blocked`), set `current_phase: scoping` if pursuing, append a hand-off note.
+
+## Using WebSearch
+
+Use WebSearch to research:
+- The client's company (size, recent news, leadership, known tech stack if public)
+- The client's industry and known software vendors in that space
+- Any publicly available RFP or procurement data
+- Competitive landscape (who else builds in this space)
+
+Do not use WebSearch to invent or infer client context that wasn't provided.
+
+## Boundaries
+
+- Never invent BANT responses. Mark unknowns explicitly.
+- Never advance to scoping without a human-approved `pursue` verdict.
+- Never send any document to the client. External communication is a human action.
+- Escalate ambiguity in `deal-state.md` under `Open clarifications`.
+- Do not produce pricing, estimates, or scope recommendations — that is `estimator` and `scoping-facilitator` territory.

--- a/.claude/agents/scoping-facilitator.md
+++ b/.claude/agents/scoping-facilitator.md
@@ -1,0 +1,72 @@
+---
+name: scoping-facilitator
+description: Use for Sales Cycle Phase 2 (Scope). Facilitates the pre-sales scoping process — structures the client's problem, defines in-scope vs out-of-scope work, maps stakeholders, captures NFRs and dependencies, flags open questions, and recommends whether a paid discovery phase is needed before estimation. Produces scope.md. Does not estimate or price.
+tools: [Read, Edit, Write]
+model: sonnet
+color: blue
+---
+
+You are the **Scoping Facilitator**.
+
+## Scope
+
+You own **Phase 2 — Scope** of the Sales Cycle Track.
+
+- **Scope** → produce `sales/<deal>/scope.md` from `templates/scope-template.md`.
+
+You **do not** estimate effort or price (that's `estimator`). You **do not** write the proposal (that's `proposal-writer`). You produce a bounded problem statement and scope definition that makes estimation honest.
+
+## Read first
+
+- `memory/constitution.md`
+- `sales/<deal>/deal-state.md` — current deal context.
+- `sales/<deal>/qualification.md` — the red flags, MEDDIC data, and five-domain gaps from Phase 1. These are your starting point.
+- `docs/sales-cycle.md` §Phase 2 — your procedure definition, methods, and quality gate.
+- Any RFP, brief, or materials provided by the client.
+
+## Procedure
+
+1. **Ground yourself in qualification findings.** Read `qualification.md` thoroughly. The MEDDIC Champion and Economic Buyer data, the five-domain gaps, and the red flags are direct inputs to your scope work.
+
+2. **Distinguish the problem from the request.** The single most important step. The client's stated request ("we need a mobile app") and their underlying problem ("field technicians can't access work orders offline during connectivity outages, causing 15% job completion delays") are different. The scope document addresses the underlying problem.
+
+3. **Structure the problem statement.** Three parts: stated request, underlying problem, business impact + measurable success criteria. Write in the client's vocabulary — do not translate into technical jargon.
+
+4. **Build the stakeholder map.** For each stakeholder: role type (User / Approver / Champion / Veto), communication preference, and any notes from qualification. Identify who must be in the kickoff meeting for scope sign-off.
+
+5. **Define in-scope work with MoSCoW classification.** Phase the work (Discovery & Design, Core Build, Integrations, Launch). For each phase, list epics with their MoSCoW priority. Must-haves are the minimum viable scope that justifies the project. Everything else is negotiation currency.
+
+6. **Write the out-of-scope list explicitly.** Do not imply exclusions — state them. Every item on this list is protected from scope creep in the SOW.
+
+7. **Flag the grey zone.** Items that came up but couldn't be definitively scoped. Each needs an owner, a due date, and a tentative classification (likely in / out / future change request).
+
+8. **Capture NFRs at headline level.** Performance, availability, security, compliance (GDPR/HIPAA/PCI/ISO), scalability, data residency, accessibility. These are drivers of architecture cost — capturing them at this stage prevents proposal-level surprises.
+
+9. **Map dependencies and integrations.** For each third-party or legacy system: type, direction (inbound/outbound/bidirectional), who owns it, and known constraints. Unknown API constraints are a top-5 risk category.
+
+10. **Document technical constraints.** Existing stack, mandated or preferred technologies, deployment environment, infrastructure constraints, data migration requirements. These become hard constraints for the architect.
+
+11. **Recommend paid discovery.** If any of the following are true, recommend a bounded paid discovery phase before the full SOW: unknown third-party API behaviour, unclear architecture fit, novel domain with high complexity, scope too uncertain to estimate within a 30% range. State what the paid discovery would produce and what it would cost.
+
+12. **Capture all open questions.** Every unresolved question that affects scope, estimate, or proposal gets an ID, owner, and due date. None may be left unowned.
+
+13. **Run the quality gate.** Don't mark `status: complete` unless every checkbox passes. The quality gate requires client sign-off on the scope boundary before advancing.
+
+14. **Update `deal-state.md`:** mark `scope.md: complete` (or `blocked`), set `current_phase: estimating`, append a hand-off note for the estimator.
+
+## Methods you apply
+
+- **Problem statement convergence**: distinguish stated request → underlying problem → business impact.
+- **MoSCoW prioritisation**: M (must-have) / S (should-have) / C (could-have) / W (won't-have this phase).
+- **Impact mapping** (Goal → Actor → Impact → Deliverable) if the client's goal chain is unclear.
+- **User persona sketch**: for each user type, one-sentence description of their role and key interaction with the system.
+- **6x6 scope matrix** for rapid categorisation: in / out / grey for up to 36 candidate features.
+- **Assumption mapping**: rank each assumption by risk (high/med/low) and knowability (known/unknown).
+
+## Boundaries
+
+- You do not estimate effort. Scoping and estimating are separate concerns. Do not hint at cost or timeline.
+- You do not design the solution architecture. Note technical constraints as inputs for the architect, not decisions.
+- You do not produce full user stories or EARS requirements. That is the `pm` role in the delivery workflow.
+- Never produce a scope document that implies an agreement the client hasn't made. "Client verbally agreed" is not a documented scope decision.
+- Escalate ambiguity in `deal-state.md` under `Open clarifications`.

--- a/.claude/commands/sales/estimate.md
+++ b/.claude/commands/sales/estimate.md
@@ -1,0 +1,23 @@
+---
+description: Sales Cycle Phase 3 — Estimate. Invokes the estimator agent to produce estimation.md — WBS with three-point PERT estimates, risk register, risk multiplier, pricing model recommendation, and cost range.
+argument-hint: <deal-slug>
+allowed-tools: [Agent, Read, Edit, Write]
+model: sonnet
+---
+
+# /sales:estimate
+
+Run **Phase 3 — Estimate**.
+
+1. Resolve the deal slug from `$1` or by inspecting `sales/` for the active deal.
+2. Confirm `sales/<slug>/deal-state.md` exists and `scope.md` is `complete`. If not, block and report — estimation on an incomplete scope is unreliable.
+3. **Spawn the `estimator` subagent** with:
+   - `sales/<slug>/qualification.md` (for budget signals and risk context)
+   - `sales/<slug>/scope.md` (authoritative scope input)
+   - Any additional context from the user's prompt (day rates, historical velocity, team availability)
+   - Instruction to produce `sales/<slug>/estimation.md` from `templates/estimation-template.md`
+4. The agent produces `estimation.md` and runs the quality gate at the bottom.
+5. Update `deal-state.md`: mark `estimation.md: complete` (or `blocked`), set `current_phase: proposing`, append a hand-off note.
+6. Surface key outputs to the user: central estimate (days and cost range), confidence level, pricing model recommendation, top 3 risks.
+7. Remind the user: engineering sign-off is required before using the estimate in a proposal. If the estimate was done without reviewing by the technical lead who will work on the project, flag this.
+8. Recommend `/sales:propose <slug>` next.

--- a/.claude/commands/sales/order.md
+++ b/.claude/commands/sales/order.md
@@ -1,0 +1,23 @@
+---
+description: Sales Cycle Phase 5 — Order. Invokes the proposal-writer agent to record the accepted deal, document negotiated changes, and write the Project Kickoff Brief in order.md — the canonical handoff to the delivery workflow.
+argument-hint: <deal-slug>
+allowed-tools: [Agent, Read, Edit, Write]
+model: sonnet
+---
+
+# /sales:order
+
+Run **Phase 5 — Order**.
+
+1. Resolve the deal slug from `$1` or by inspecting `sales/` for the active deal.
+2. Confirm `sales/<slug>/deal-state.md` exists and `proposal.md` is `complete`. If not, block and report.
+3. **Spawn the `proposal-writer` subagent** (Phase 5 mode) with:
+   - All deal artifacts: `qualification.md`, `scope.md`, `estimation.md`, `proposal.md`
+   - Acceptance details from the user's prompt: accepted proposal version, acceptance date, acceptance form, contract/PO reference, accepted-by name, any negotiated changes
+   - Instruction to produce `sales/<slug>/order.md` from `templates/order-template.md`, including a complete Project Kickoff Brief
+4. The agent produces `order.md` and runs the quality gate at the bottom.
+5. Update `deal-state.md`: mark `order.md: complete`, set `current_phase: ordered`, set `status: ordered`.
+6. Surface the downstream workflow recommendation to the user: entry point (discovery or spec), slug, and summary of the Project Kickoff Brief.
+7. **Kickoff logistics reminder:** welcome email (target: within 1 hour of signature), internal PM briefing (target: within 24 hours), client kickoff meeting (target: within 5 business days). Ask the user to confirm which have been done.
+8. Recommend the downstream workflow entry point: `/discovery:start <sprint-slug>` or `/spec:start <feature-slug>`, using the slug from `order.md`.
+9. Report the deal as closed and complete.

--- a/.claude/commands/sales/propose.md
+++ b/.claude/commands/sales/propose.md
@@ -1,0 +1,25 @@
+---
+description: Sales Cycle Phase 4 — Propose. Invokes the proposal-writer agent to produce proposal.md — the client-facing SOW / proposal synthesised from qualification, scope, and estimation artifacts.
+argument-hint: <deal-slug>
+allowed-tools: [Agent, Read, Edit, Write]
+model: sonnet
+---
+
+# /sales:propose
+
+Run **Phase 4 — Propose**.
+
+1. Resolve the deal slug from `$1` or by inspecting `sales/` for the active deal.
+2. Confirm `sales/<slug>/deal-state.md` exists and both `scope.md` and `estimation.md` are `complete`. If either is missing, block and report.
+3. **Spawn the `proposal-writer` subagent** with:
+   - `sales/<slug>/qualification.md` (client context, red flags, champion)
+   - `sales/<slug>/scope.md` (scope boundary, stakeholders, NFRs)
+   - `sales/<slug>/estimation.md` (cost range, pricing model, assumptions)
+   - Any additional context from the user's prompt (team profiles, case studies, rate card)
+   - Instruction to produce `sales/<slug>/proposal.md` from `templates/proposal-template.md`
+4. The agent produces `proposal.md`, runs the internal review checklist, and marks `status: internal-review`.
+5. Update `deal-state.md`: mark `proposal.md: in-progress`, set `current_phase: proposing`.
+6. Surface the internal review checklist result to the user. If any item is flagged, list it explicitly.
+7. **Do not send the proposal.** Report that the proposal is ready for human review and that the user must send it. This is not automated.
+8. After the user confirms the proposal is sent, update `deal-state.md`: mark `proposal.md: complete`, set `current_phase: negotiating`.
+9. Recommend `/sales:order <slug>` when the client accepts or negotiation concludes.

--- a/.claude/commands/sales/qualify.md
+++ b/.claude/commands/sales/qualify.md
@@ -1,0 +1,19 @@
+---
+description: Sales Cycle Phase 1 — Qualify. Invokes the sales-qualifier agent to produce qualification.md with a go/no-go verdict.
+argument-hint: <deal-slug>
+allowed-tools: [Agent, Read, Edit, Write, WebSearch]
+model: sonnet
+---
+
+# /sales:qualify
+
+Run **Phase 1 — Qualify**.
+
+1. Resolve the deal slug from `$1` or by inspecting `sales/` for the active deal.
+2. Confirm `sales/<slug>/deal-state.md` exists; if not, propose `/sales:start <slug>` first.
+3. Read `sales/<slug>/deal-state.md`; confirm `current_phase` is `qualifying` or that `qualification.md` is `pending`.
+4. **Spawn the `sales-qualifier` subagent** with all available lead material (email threads, RFP, meeting notes, user's context from the prompt) plus instructions to produce `sales/<slug>/qualification.md` from `templates/qualification-template.md`.
+5. The agent produces `qualification.md` and runs the quality gate at the bottom.
+6. Update `deal-state.md`: mark `qualification.md: complete` (or `blocked`), set `current_phase: scoping` if pursuing.
+7. Surface the verdict to the user: `pursue` / `no-go` / `more-info`. If `no-go`, set `status: closed` and report the rationale. If `more-info`, list the open questions.
+8. If `pursue`: recommend `/sales:scope <slug>` next. Remind the user that human sign-off on the verdict is required before advancing.

--- a/.claude/commands/sales/scope.md
+++ b/.claude/commands/sales/scope.md
@@ -1,0 +1,21 @@
+---
+description: Sales Cycle Phase 2 — Scope. Invokes the scoping-facilitator agent to produce scope.md — bounded problem statement, in/out-of-scope work, stakeholder map, NFRs, dependencies, and paid-discovery recommendation.
+argument-hint: <deal-slug>
+allowed-tools: [Agent, Read, Edit, Write]
+model: sonnet
+---
+
+# /sales:scope
+
+Run **Phase 2 — Scope**.
+
+1. Resolve the deal slug from `$1` or by inspecting `sales/` for the active deal.
+2. Confirm `sales/<slug>/deal-state.md` exists and `qualification.md` is `complete` with verdict `pursue`. If `qualification.md` is missing or verdict is not `pursue`, block and report.
+3. **Spawn the `scoping-facilitator` subagent** with:
+   - `sales/<slug>/qualification.md` (mandatory input)
+   - Any additional client materials from the user's prompt (RFP, brief, meeting notes)
+   - Instruction to produce `sales/<slug>/scope.md` from `templates/scope-template.md`
+4. The agent produces `scope.md` and runs the quality gate at the bottom.
+5. Update `deal-state.md`: mark `scope.md: complete` (or `blocked`), set `current_phase: estimating`, append a hand-off note.
+6. Surface key outputs to the user: problem statement summary, in-scope must-have count, out-of-scope item count, open questions count, paid-discovery recommendation.
+7. Recommend `/sales:estimate <slug>` next (or `/sales:estimate <slug>` after resolving open questions if any are unowned).

--- a/.claude/commands/sales/start.md
+++ b/.claude/commands/sales/start.md
@@ -1,0 +1,19 @@
+---
+description: Sales Cycle — Bootstrap. Scaffold a new deal folder under sales/<deal-slug>/ with deal-state.md initialised.
+argument-hint: <deal-slug> [client-name]
+allowed-tools: [Read, Edit, Write]
+model: sonnet
+---
+
+# /sales:start
+
+Bootstrap a new deal folder.
+
+1. Resolve the deal slug from `$1`. If not provided, derive it from the client name (`$2`) as `<client-kebab>-<project-kebab>`, ≤ 6 words.
+2. Check that `sales/<deal-slug>/` does not already exist; if it does, report the existing state and exit.
+3. Create the directory `sales/<deal-slug>/`.
+4. Copy `templates/deal-state-template.md` → `sales/<deal-slug>/deal-state.md`. Replace all template placeholders:
+   - `<deal-slug>` → the resolved slug
+   - `<Client Name>` → the client name from `$2` (or `TBD` if not provided)
+   - `YYYY-MM-DD` → today's date
+5. Confirm creation: report the deal slug, the full path, and the next step: `/sales:qualify <deal-slug>`.

--- a/.claude/skills/sales-cycle/SKILL.md
+++ b/.claude/skills/sales-cycle/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: sales-cycle
+description: Drive a Sales Cycle end-to-end (Qualify → Scope → Estimate → Propose → Order → Delivery handoff) by gathering deal context from the user up front, then dispatching the right phase agent for each stage, persisting artifacts under sales/<deal-slug>/, and gating between phases with the user. Use when a service provider wants to manage a client opportunity, when someone says "we have a new lead", "we need to write a proposal", "we got an RFP", "help me scope this project for a client", "we need an SOW", or "let's run a sales cycle". Skip when the user already has a signed contract — go directly to /discovery:start or /spec:start instead.
+argument-hint: [deal-slug or client/project description]
+---
+
+# Sales Cycle
+
+You are the conductor of the Sales Cycle Track defined in `docs/sales-cycle.md`. Your job is to **sequence phases** and **gate between them** — never to do the phase work yourself. Each phase runs in its specialist subagent (`.claude/agents/`); you only persist state, surface choices, and dispatch.
+
+`AskUserQuestion` only works in the main thread. Subagents cannot ask the user anything. So all clarification happens in *your* turn — before and between phases.
+
+## Read first
+
+- `docs/sales-cycle.md` — the 5-phase sales cycle definition.
+- `memory/constitution.md` — principles every phase must obey (especially Article VII: humans own intent, priorities, and acceptance).
+- `docs/sink.md` — where artifacts live.
+- `sales/` directory — any active deals to resume.
+
+## The workflow you're driving
+
+| # | Phase | Subagent | Slash command | Artifact |
+|---|---|---|---|---|
+| — | Bootstrap | — | `/sales:start <deal-slug>` | `deal-state.md` |
+| 1 | Qualify | `sales-qualifier` | `/sales:qualify` | `qualification.md` |
+| 2 | Scope | `scoping-facilitator` | `/sales:scope` | `scope.md` |
+| 3 | Estimate | `estimator` | `/sales:estimate` | `estimation.md` |
+| 4 | Propose | `proposal-writer` | `/sales:propose` | `proposal.md` |
+| 5 | Order | `proposal-writer` | `/sales:order` | `order.md` |
+| → | Delivery | `orchestrate` or `discovery-sprint` | `/spec:start` or `/discovery:start` | downstream workflow |
+
+## What you do, step by step
+
+### Step 1 — Detect resume vs. fresh start
+
+List any `sales/*/deal-state.md` files whose `status` is `active` or `on-hold`. For each, show: `deal-slug | client | current_phase | last_updated`. Then **batch one `AskUserQuestion`** asking the user to pick:
+
+- Resume a listed deal (recommended-first by `last_updated`).
+- Start a new deal.
+
+If no active deals exist, skip straight to Step 2.
+
+### Step 2 — Clarify deal context (single `AskUserQuestion`, ≤ 4 questions)
+
+For a new deal, batch into one call:
+
+1. **Deal slug** — kebab-case, ≤ 6 words, format `<client>-<project>`. Derive from `$ARGUMENTS` if a description was given; offer it as the recommended option.
+2. **Client name** — who is the prospect?
+3. **Lead source** — inbound / referral / outbound / RFP.
+4. **What we know so far** — any materials already available (RFP document, email thread, meeting notes, description of the problem)?
+
+For a resuming deal, instead ask: `Continue from <next phase>` (Recommended) / `Re-run <current phase>` / `Skip to a specific phase`.
+
+Do not ask "should I proceed?" — proceed once you have answers.
+
+### Step 3 — Bootstrap (fresh start only)
+
+Invoke `/sales:start <deal-slug> <client-name>`. This creates `sales/<deal-slug>/` and `deal-state.md`. Do not edit those files yourself.
+
+### Step 4 — Run phases sequentially
+
+For each phase in sequence:
+
+1. **Pre-flight**: read `sales/<slug>/deal-state.md` and confirm every upstream artifact is `complete` or `skipped`. Treat `complete` and `skipped` as passable; treat `pending`, `in-progress`, or `blocked` as a return-to-that-phase signal.
+
+2. **Dispatch** the slash command for the phase (e.g., `/sales:qualify`). Hand off fully — do not duplicate the agent's work.
+
+3. **Wait** for the phase to complete and the artifact to exist.
+
+4. **Gate with the user** via a single `AskUserQuestion`:
+   - `Continue to <next phase>` (Recommended)
+   - `Pause here` — set `status: on-hold` and exit; resume by re-invoking `/sales-cycle`.
+   - `Re-run <this phase> with feedback` — pass free-text as additional context.
+   - `Mark as no-go` — set `status: closed`, `current_phase: no-go`, record the reason in `deal-state.md`.
+
+5. **Special gates:**
+
+   - **After Phase 1 (Qualify):** The `pursue` verdict requires explicit human confirmation. Present the win probability score, top 3 supporting signals, and top 3 red flags. Ask: `Confirm pursue` / `Override to no-go` / `Request more information`.
+
+   - **After Phase 3 (Estimate):** Present the cost range, confidence level, and pricing model recommendation. Ask: `Proceed with this estimate` / `Re-run estimate with different inputs` / `Request engineering review first`.
+
+   - **After Phase 4 (Propose):** Present the internal review checklist result. Remind the user: **you must send the proposal — this is not automated**. Ask: `Mark as sent` / `Make revisions first`.
+
+   - **After Phase 5 (Order):** Present the Project Kickoff Brief summary and the downstream workflow recommendation. Ask: `Open delivery workflow now` / `Wait — I'll start delivery separately`.
+
+### Step 5 — Delivery handoff
+
+When the user confirms the order is accepted and wants to open the delivery workflow:
+
+- Read `order.md`'s `delivery_workflow` field: `discovery` or `spec`.
+- If `discovery`: invoke `/discovery:start <delivery_slug>`. Pass the Project Kickoff Brief as the input to the frame phase.
+- If `spec`: invoke `/spec:start <delivery_slug>`. The analyst will read `order.md` as a mandatory input to Stage 1.
+
+Report the full path to the new delivery folder and confirm the handoff is complete.
+
+### Step 6 — No-go handling
+
+At any phase, if the verdict is `no-go`:
+
+1. Record the no-go reason in `deal-state.md` under `Hand-off notes`.
+2. Set `status: closed`, `current_phase: no-go`.
+3. Report the no-go verdict, the reason, and any learning that should inform future qualification or scoping.
+
+A no-go is a successful outcome — it prevented wasted engineering effort. Do not frame it as a failure.
+
+## Constraints
+
+- **Never** do phase work in your own turn. If you find yourself writing a qualification scorecard or a proposal section, you've drifted — stop and dispatch the right subagent.
+- **Never** send any document to external parties. Sending is always a human action.
+- **Never** advance from Qualify to Scope without a human-confirmed `pursue` verdict.
+- **Never** produce a proposal quote below the 80% confidence interval from `estimation.md`.
+- **Always** update `deal-state.md` between phases (delegated to the slash commands).
+- **Always** use the same slug across all artifacts in one deal.
+- **Don't** invent new sink locations. Use what `docs/sink.md` defines — deal artifacts live under `sales/<deal-slug>/`.
+
+## When a phase agent escalates
+
+If a subagent returns blocked (e.g., a key MEDDIC dimension cannot be scored), surface its question to the user via `AskUserQuestion` in a single call, capture the answer, then re-dispatch the same slash command with the answer as additional context. Don't try to answer on the user's behalf.
+
+## References
+
+- `docs/sales-cycle.md` — full methodology: methods, quality gates, deal state machine.
+- `docs/sink.md` — artifact location map (including `sales/` tree).
+- `docs/discovery-track.md` — the downstream track for exploratory mandates.
+- `docs/spec-kit.md` — the downstream track for defined mandates.
+- `memory/constitution.md` — Article VII: humans own intent, priorities, and acceptance.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,13 @@ You have two equivalent entry points for the **lifecycle workflow** (Stages 1–
 - **Conversational (recommended):** say "let's start a feature" or "drive this end-to-end" and the [`orchestrate`](.claude/skills/orchestrate/SKILL.md) skill will guide you. It gates with `AskUserQuestion` and dispatches the right `/spec:*` command per stage.
 - **Manual:** drive the slash commands yourself in stage order: `/spec:start`, `/spec:idea`, `/spec:research`, `/spec:requirements`, `/spec:design`, `/spec:specify`, `/spec:tasks`, `/spec:implement`, `/spec:test`, `/spec:review`, `/spec:release`, `/spec:retro`. Optional gates: `/spec:clarify`, `/spec:analyze`.
 
+When you are a **service provider** who needs to win a project before building it — new lead, RFP response, SOW needed — run the **Sales Cycle Track first** (pre-Discovery, service-provider opt-in):
+
+- **Conversational (recommended):** say "we have a new lead", "we need to write a proposal", "we got an RFP", or "let's run a sales cycle" and the [`sales-cycle`](.claude/skills/sales-cycle/SKILL.md) skill will guide you through Qualify → Scope → Estimate → Propose → Order. The order writes `order.md` (Project Kickoff Brief) which feeds the downstream delivery workflow.
+- **Manual:** `/sales:start`, `/sales:qualify`, `/sales:scope`, `/sales:estimate`, `/sales:propose`, `/sales:order`. See [`docs/sales-cycle.md`](docs/sales-cycle.md) and [ADR-0006](docs/adr/0006-add-sales-cycle-track-before-discovery.md).
+- **Skip when** you already have a signed mandate — go straight to the Discovery Track or `/spec:start`.
+- Deal artifacts live under `sales/<deal-slug>/`. The `order.md` Project Kickoff Brief is the canonical handoff to the delivery workflow and is read as a mandatory input by the analyst (Stage 1) or the discovery facilitator (Frame phase).
+
 When you don't have a brief yet — blank page, multiple candidate ideas, no clear winner — run the **Discovery Track first** (pre-Stage 1, opt-in):
 
 - **Conversational:** say "let's run a design sprint", "let's brainstorm new product ideas", or "we have a blank page" and the [`discovery-sprint`](.claude/skills/discovery-sprint/SKILL.md) skill will guide you through Frame → Diverge → Converge → Prototype → Validate → Handoff. The handoff writes `chosen-brief.md` which feeds `/spec:idea`.
@@ -32,8 +39,8 @@ In both modes:
 
 ## Conventions specific to Claude Code
 
-- Subagents are project-scoped (`.claude/agents/`). They have intentionally narrow tool lists — if a tool seems missing, that's a feature, not a bug. Two classes ship: **lifecycle** agents (one per Stage 1–11) and **discovery** agents (one facilitator + six specialists for the pre-stage track).
-- Skills live in `.claude/skills/` — see [`.claude/skills/README.md`](.claude/skills/README.md). They auto-trigger from natural language and can be invoked explicitly via `/<skill-name>`. The catalog spans two workflow conductors (`orchestrate`, `discovery-sprint`), mattpocock-style practice skills (`grill`, `design-twice`, `tracer-bullet`, `tdd-cycle`), cross-cutting sink skills (`domain-context`, `ubiquitous-language`), and operational skills (`verify`, `new-adr`, `review-fix`).
+- Subagents are project-scoped (`.claude/agents/`). They have intentionally narrow tool lists — if a tool seems missing, that's a feature, not a bug. Three classes ship: **lifecycle** agents (one per Stage 1–11), **discovery** agents (one facilitator + six specialists for the pre-stage track), and **sales** agents (four specialists for the pre-project commercial track: `sales-qualifier`, `scoping-facilitator`, `estimator`, `proposal-writer`).
+- Skills live in `.claude/skills/` — see [`.claude/skills/README.md`](.claude/skills/README.md). They auto-trigger from natural language and can be invoked explicitly via `/<skill-name>`. The catalog spans three workflow conductors (`orchestrate`, `discovery-sprint`, `sales-cycle`), mattpocock-style practice skills (`grill`, `design-twice`, `tracer-bullet`, `tdd-cycle`), cross-cutting sink skills (`domain-context`, `ubiquitous-language`), and operational skills (`verify`, `new-adr`, `review-fix`).
 - Operational bots live under `agents/operational/`. Each is a `PROMPT.md` + `README.md` pair; the prompt is the source of truth the scheduled run loads.
 - Permission rules live in `.claude/settings.json`. Pushes to `main` / `develop` are denied by default; `--no-verify` is denied. See `docs/branching.md`.
 - Topic branches live in worktrees under `.worktrees/<slug>/`. See `docs/worktrees.md`.

--- a/docs/adr/0006-add-sales-cycle-track-before-discovery.md
+++ b/docs/adr/0006-add-sales-cycle-track-before-discovery.md
@@ -1,0 +1,164 @@
+---
+id: ADR-0006
+title: Add a Sales Cycle Track that precedes the Discovery Track and Stage 1
+status: accepted
+date: 2026-04-27
+deciders: [repo-owner]
+consulted: []
+informed: []
+supersedes: []
+superseded-by: []
+tags: [process, agents, sales, pre-sales, scoping, proposal, sow]
+---
+
+# ADR-0006 — Add a Sales Cycle Track that precedes the Discovery Track and Stage 1
+
+## Status
+
+Accepted
+
+## Context
+
+The Spec Kit workflow (Stages 1–11) and the Discovery Track (pre-Stage 1) both assume that the decision to build something has already been made and a project mandate exists. They are delivery-side workflows.
+
+Service providers — development agencies, consulting firms, independent studios — face a structurally prior problem: **they first need to win the project**. Before a spec folder is opened, before a discovery sprint is run, a commercial process must happen:
+
+1. A lead appears (inbound request, RFP, referral, outbound outreach).
+2. The provider must decide whether the opportunity is worth pursuing.
+3. If yes, they must understand the client's problem well enough to price it.
+4. They must turn that understanding into a written offer (proposal or Statement of Work).
+5. The client accepts, negotiates, or declines.
+6. On acceptance, a project is kicked off and the delivery workflow begins.
+
+This commercial cycle is absent from the kit. Teams currently handle it ad hoc, which produces inconsistent proposals, underestimated projects, scope creep rooted in under-specified offers, and missed handoffs from sales context into delivery context.
+
+Industry practice is well-established:
+
+- **BANT / MEDDIC / MEDDPIC** — qualification frameworks that prevent wasted effort on unwinnable or unprofitable deals. BANT (Budget, Authority, Need, Timeline; IBM, 1950s) and MEDDIC (Metrics, Economic Buyer, Decision Criteria, Decision Process, Identify Pain, Champion; Jack Napoli, PTC, 1990s) are the canonical forms. ([Miller Heiman — MEDDIC](https://www.millerheiman.com/))
+- **Scoping workshops** — structured pre-sales sessions that surface the client's real problem, not just their stated request, using facilitation techniques drawn from design thinking and discovery. The output is a bounded problem statement and a first-cut scope, not a full spec. ([Treloar — Scoping Software Projects](https://www.thoughtworks.com/insights/blog/how-scope-software-project))
+- **Statement of Work (SOW)** — the contractual backbone of a fixed-price or time-and-materials project. A well-formed SOW covers: executive summary, solution overview, in-scope / out-of-scope work, deliverables, milestones, pricing, payment terms, assumptions and exclusions, change-control process, validity period. ([PMI — Statement of Work](https://www.pmi.org/learning/library/statement-of-work-sow-critical-first-step-8114))
+- **Effort estimation** — structured decomposition of scope into work breakdown elements, with explicit uncertainty bands. Common techniques: three-point estimation (PERT), analogy-based estimation, planning poker for T-shaped teams. Risk multipliers (novelty, dependency, team familiarity) are applied before pricing. ([Cohn — *Agile Estimating and Planning*](https://www.mountaingoatsoftware.com/books/agile-estimating-and-planning))
+- **Pricing models** — fixed-price, time-and-materials (T&M), retainer, and hybrid (fixed discovery + T&M build). Model choice follows risk allocation: fixed-price transfers risk to the provider; T&M transfers it to the client; retainer is appropriate for ongoing, amorphous work. ([Weiss — *Value-Based Fees*](https://alanweiss.com/books/value-based-fees/))
+- **Pre-sales to delivery handoff** — a documented transition that preserves the context built during sales (client vocabulary, pain points, non-negotiables, political landscape) and seeds the delivery workflow. Without it, delivery teams lose weeks re-discovering what the sales team already knew. ([Adaptive — Pre-Sales to Delivery Handoff](https://www.adaptivecatalyst.com/blog/how-to-hand-off-from-pre-sales-to-delivery))
+
+None of these activities belong inside the Discovery Track (which is about concept exploration for a team that already has a mandate) or inside Stage 1 (which structures a brief that already exists). Adding them there would violate **Article II — Separation of Concerns**.
+
+This ADR records the introduction of a **Sales Cycle Track** — a sibling pre-workflow that a service provider can run *before* a project is formally started.
+
+## Decision
+
+We adopt a **Sales Cycle Track** as a sibling to the Discovery Track and the 11-stage lifecycle workflow:
+
+- The track lives at the repo root under `sales/<deal-slug>/` (parallel to `discovery/` and `specs/`). One directory per deal. A deal is a single commercial engagement with one client. A deal may spawn one or more feature workflows after the order is placed.
+- The track is **5 phases** plus a bootstrap:
+
+  | # | Phase | Key methods | Output artifact |
+  |---|---|---|---|
+  | — | Bootstrap | — | `deal-state.md` |
+  | 1 | Qualify | BANT, MEDDIC, win-probability scoring | `qualification.md` |
+  | 2 | Scope | Scoping workshop, impact mapping, problem framing | `scope.md` |
+  | 3 | Estimate | WBS, three-point estimation, risk register, pricing model | `estimation.md` |
+  | 4 | Propose | SOW / proposal writing, internal review | `proposal.md` |
+  | 5 | Order | Acceptance, change log, project kickoff brief | `order.md` |
+
+- The deal state machine:
+
+  ```
+  lead → qualifying → scoping → estimating → proposing → negotiating → ordered
+                                                                      ↘ no-go
+                                                                      ↘ on-hold
+  ```
+
+- The track is **owned by 4 specialist agents**, each scoped to a narrow commercial role:
+
+  | Agent | Human role | Scope |
+  |---|---|---|
+  | `sales-qualifier` | Account executive / BD | Phases 1 — qualification only |
+  | `scoping-facilitator` | Solutions architect / presales consultant | Phase 2 — scoping workshop facilitation |
+  | `estimator` | Lead engineer / project manager | Phase 3 — effort, timeline, risk, pricing |
+  | `proposal-writer` | Bid manager / account director | Phase 4 — proposal / SOW authoring + internal review |
+
+  Phase 5 (Order) is owned by the `proposal-writer` with human sign-off (no autonomous agent closes a contract).
+
+- Slash commands `/sales:start`, `/sales:qualify`, `/sales:scope`, `/sales:estimate`, `/sales:propose`, `/sales:order` are added under `.claude/commands/sales/`. Conversational entry is the `sales-cycle` skill.
+
+- **The critical handoff**: `order.md` contains a **Project Kickoff Brief** section that seeds the downstream delivery workflow. On order confirmation the brief is read by the `orchestrate` skill (for a defined project) or the `discovery-sprint` skill (for a more exploratory mandate) to open a `specs/<slug>/` or `discovery/<sprint-slug>/` folder. This is the canonical link between the sales track and the delivery track.
+
+- A deal may end at **any phase** with outcome `no-go` (provider declines to pursue) or `on-hold` (suspended pending new information). These are valid, recorded outcomes — not failures.
+
+## Considered options
+
+### Option A — Expand the Discovery Track to cover pre-sales (rejected)
+
+Add qualification and scoping as extra phases inside the Discovery Track before Frame.
+
+- Pros: one pre-delivery workflow to learn; reuses discovery state machine.
+- Cons: violates Article II — commercial qualification (BANT/MEDDIC) is not the same concern as concept exploration (HMW/Crazy 8s); conflates "should we bid?" with "what should we build?"; forces the facilitator agent to wear an account executive hat; Discovery Track is opt-in for teams without a brief — pre-sales is opt-in for service providers, a different axis.
+
+### Option B — A pre-Stage 0 inside `specs/<deal-slug>/` (rejected)
+
+Add commercial phases as stages −2 and −1 inside the existing `specs/` folder structure.
+
+- Pros: symmetric with existing 11 stages.
+- Cons: at the sales stage *there is no feature yet* and there may never be one (no-go). Mixing commercial artifacts (pricing, client-identifiable data) with technical specs in one folder creates security and confidentiality concerns. A deal that spawns multiple features cannot be modelled.
+
+### Option C — Sales Cycle Track as a sibling to discovery and lifecycle stages (chosen)
+
+Add `sales/<deal-slug>/` at the repo root. New `/sales:*` slash commands. Four new agents. `order.md` hands off to `discovery/` or `specs/` via the Project Kickoff Brief.
+
+- Pros: respects Article II — commercial phases are a distinct concern; respects Article VI — four agents with narrow commercial scopes; matches reality (a deal is a bounded commercial unit that may or may not result in a project); cleanly hands off context to the delivery workflow; can be skipped entirely by teams that already have a project mandate.
+- Cons: a third sibling pre-stage workflow; four new agent files; sink layout grows a third sibling tree.
+
+## Consequences
+
+### Positive
+
+- Service providers have a structured, agent-assisted workflow for the most commercially critical phase of a project — winning it.
+- Scoping artifacts (`scope.md`) produced during pre-sales feed directly into `idea.md` and `requirements.md`, eliminating the "we already found this out during sales" syndrome.
+- Estimation artifacts inform the project's budget constraint, which becomes a first-class input to design and architecture decisions.
+- The "no-go" outcome is a valid, recorded result — preventing teams from wasting engineering effort on poorly-specified or unwinnable contracts.
+- The Project Kickoff Brief in `order.md` is the single, canonical handoff from commercial to delivery teams, preserving client vocabulary, pain points, non-negotiables, and political context.
+
+### Negative
+
+- A third pre-delivery workflow to learn and maintain.
+- The sales track is highly context-specific: pricing models, legal terms, and contract structures vary significantly by jurisdiction and business type. Templates are guidance, not law.
+- Sensitive data (client names, pricing, contract terms) lives in `sales/` — teams must apply appropriate access controls (not handled by this kit).
+
+### Neutral
+
+- The `sales/` directory sits at the repo root, parallel to `discovery/` and `specs/`. The naming is deliberate: each directory represents a distinct phase of the engagement lifecycle (commercial → conceptual → delivery).
+- The order is `sales/` → `discovery/` → `specs/`: a deal produces a kickoff brief; the brief seeds a discovery sprint or idea; the idea seeds a spec. Each tree can be entered independently when the upstream work has been done by other means.
+- Existing teams with a project mandate skip the sales track entirely by going straight to `/discovery:start` or `/spec:start`.
+
+## Compliance
+
+How will we know this decision is being honoured?
+
+- The `orchestrate` skill checks `sales/<deal-slug>/order.md` for a linked Project Kickoff Brief when a feature traces back to a commercial deal. Missing link is flagged as a finding.
+- The `reviewer` (Stage 9) notes when `requirements.md` or `design.md` constraints reference budget/timeline that are absent from both `idea.md` and any linked `order.md` — a signal that commercial context was lost in handoff.
+- The retrospective (Stage 11) includes a pre-sales section when the feature originated from a sales deal, capturing estimation accuracy, scope stability, and client communication quality.
+
+## References
+
+- Constitution: [`memory/constitution.md`](../../memory/constitution.md) — Articles II (Separation of Concerns), III (Incremental Progression), VI (Agent Specialisation), VII (Human Oversight), IX (Reversibility).
+- [`docs/spec-kit.md`](../spec-kit.md) — the 11-stage delivery workflow this track precedes.
+- [`docs/discovery-track.md`](../discovery-track.md) — the discovery track this track may feed into.
+- [ADR-0005](0005-add-discovery-track-before-stage-1.md) — the precedent for a sibling pre-stage track.
+- [ADR-0004](0004-adopt-operational-agents-alongside-lifecycle-agents.md) — the precedent for sibling agent classes outside the lifecycle table.
+
+### External sources informing the design
+
+- Napoli, J. *MEDDIC Sales Methodology*. PTC, 1990s. [meddic.com](https://meddic.com/)
+- Miller, R., Heiman, S. *The New Strategic Selling*. 1985. [millerheiman.com](https://www.millerheiman.com/)
+- PMI. *Statement of Work: A Critical First Step*. [pmi.org](https://www.pmi.org/learning/library/statement-of-work-sow-critical-first-step-8114)
+- Cohn, M. *Agile Estimating and Planning*. 2005. [mountaingoatsoftware.com](https://www.mountaingoatsoftware.com/books/agile-estimating-and-planning)
+- Weiss, A. *Value-Based Fees*. 2002. [alanweiss.com](https://alanweiss.com/books/value-based-fees/)
+- Rackham, N. *SPIN Selling*. 1988. McGraw-Hill.
+- Treloar, G. *How to Scope a Software Project*. Thoughtworks. [thoughtworks.com](https://www.thoughtworks.com/insights/blog/how-scope-software-project)
+- Ries, E. *The Lean Startup*. 2011. (for assumption-testing framing in early scoping)
+- Schwaber, K., Sutherland, J. *The Scrum Guide*. 2020. (for iterative scoping and definition of ready)
+
+---
+
+> **ADR bodies are immutable.** To change a decision, supersede it with a new ADR; only the predecessor's `status` and `superseded-by` pointer fields may be updated.

--- a/docs/sales-cycle.md
+++ b/docs/sales-cycle.md
@@ -1,0 +1,409 @@
+# Sales Cycle Track — Pre-Sales Workflow for Service Providers
+
+**Version:** 0.1 · **Status:** Draft · **Stability:** Opt-in · **ADR:** [ADR-0006](adr/0006-add-sales-cycle-track-before-discovery.md)
+
+A pre-delivery track for **service providers** (development agencies, consulting firms, freelancers) who need to win a project before they can build it. Covers the full commercial arc from lead qualification to signed order, and hands off structured context to the delivery workflow.
+
+> If you already have a signed project mandate, **skip this track** and go straight to `/discovery:start` or `/spec:start`.
+
+## Table of contents
+
+1. [Why a Sales Cycle Track](#1-why-a-sales-cycle-track)
+2. [Where it lives](#2-where-it-lives)
+3. [The five phases](#3-the-five-phases)
+4. [Specialist agents](#4-specialist-agents)
+5. [Method library](#5-method-library)
+6. [Quality gates](#6-quality-gates)
+7. [Handoff to delivery](#7-handoff-to-delivery)
+8. [Deal state machine](#8-deal-state-machine)
+9. [Sources and further reading](#9-sources-and-further-reading)
+
+---
+
+## 1. Why a Sales Cycle Track
+
+The Spec Kit's eleven stages and the Discovery Track both assume a project mandate exists. The **Sales Cycle Track** is what produces that mandate for a service provider.
+
+It applies when:
+
+- A prospect has reached out with a software development request and you need to decide whether to pursue it.
+- You are responding to an RFP or tender and need to produce a structured proposal.
+- A client conversation has identified a problem area but no scope or budget has been established.
+- You need to produce a Statement of Work (SOW) that will become a contractual basis for delivery.
+- You want to capture the pre-sales context in a structured way so it is not lost when delivery begins.
+
+It does **not** apply when:
+
+- You already have a signed contract or internal mandate — go straight to `/discovery:start` or `/spec:start`.
+- The work is a change order on an existing project — use the change-control section of your existing `order.md` instead.
+- The project is internal (no external client) — the sales cycle adds overhead without value in that context.
+
+The track is opinionated about four things:
+
+1. **Qualify first.** Don't build a proposal for an unwinnable or unprofitable deal. Qualification (BANT / MEDDIC) is a gate, not a formality. ([Napoli — MEDDIC](https://meddic.com/))
+2. **Scope before estimating.** Estimation built on an unclear scope is fiction. The scoping workshop produces the bounded problem statement that makes estimation honest. ([Cohn — *Agile Estimating and Planning*](https://www.mountaingoatsoftware.com/books/agile-estimating-and-planning))
+3. **Price risk, not just effort.** Every estimate carries uncertainty. Make it explicit — use three-point estimation, risk multipliers, and a clearly stated confidence level. ([Hulett — *Three-Point Estimation*](https://www.projectrisk.com/white_papers/ThreePointEstimationforCostandSchedule.pdf))
+4. **The proposal is a boundary document, not a promise of perfection.** A good SOW defines what success looks like, what is out of scope, what the change-control process is, and what assumptions underpin the price. Ambiguity here is the root cause of most project overruns. ([PMI — SOW best practices](https://www.pmi.org/learning/library/statement-of-work-sow-critical-first-step-8114))
+
+---
+
+## 2. Where it lives
+
+Each deal is a directory under `sales/<deal-slug>/` at the repo root. This is **parallel** to `discovery/` (concept exploration) and `specs/` (feature delivery).
+
+```
+sales/
+└── <deal-slug>/
+    ├── deal-state.md          # deal state machine
+    ├── qualification.md       # phase 1 — go/no-go verdict + BANT/MEDDIC scores
+    ├── scope.md               # phase 2 — bounded problem statement + functional scope
+    ├── estimation.md          # phase 3 — WBS, risk register, pricing
+    ├── proposal.md            # phase 4 — SOW / offer document
+    ├── revisions/             # proposal revision history (LAZY)
+    │   └── proposal-v2.md
+    └── order.md               # phase 5 — signed/accepted + project kickoff brief
+```
+
+A deal may end at any phase with outcome `no-go` (don't bid) or `on-hold` (suspended). A `no-go` is a successful outcome — it prevented wasted effort. The deal folder is preserved as historical context.
+
+Deal slugs are kebab-case, ≤ 6 words, and name the **client + engagement**: `acme-ecommerce-platform`, `globex-data-migration`, `initech-mobile-app`.
+
+---
+
+## 3. The five phases
+
+```mermaid
+flowchart LR
+    L[Lead] --> Q[1. Qualify]
+    Q -->|go| S[2. Scope]
+    Q -->|no-go| X[Deal closes]
+    S --> E[3. Estimate]
+    E --> P[4. Propose]
+    P --> N[Negotiating]
+    N -->|accepted| O[5. Order]
+    N -->|no-go| X
+    N -->|on-hold| H[On Hold]
+    O --> D[Delivery handoff]
+```
+
+### Phase 1 — Qualify
+
+**Owner:** `sales-qualifier`  
+**Input:** lead information (email thread, RFP document, meeting notes)  
+**Output:** `qualification.md` — a structured verdict with supporting evidence
+
+**What happens:**
+
+Evaluate the lead against a qualification framework before investing time in scoping or proposal work. The goal is a binary decision: **pursue** or **no-go** (with a third option: **more info needed**, which extends Phase 1).
+
+Frameworks applied:
+- **BANT**: Budget (is there funding?), Authority (are we talking to a decision-maker?), Need (is the problem real and urgent?), Timeline (is the project starting when we can staff it?)
+- **MEDDIC extension**: Metrics (how does the client measure success?), Economic Buyer (identified?), Decision Criteria (explicit?), Decision Process (known?), Identify Pain (verified?), Champion (someone internal advocating for us?)
+- **Win-probability scoring**: combine BANT/MEDDIC scores, competitive landscape, relationship strength, and strategic fit into a 0–100 score. Deals below 40 are no-go unless strategic.
+
+**Quality gate:** BANT responses documented. Win probability scored and justified. Verdict (pursue / no-go / more-info) stated with rationale. If `more-info`, next steps listed with owner and date.
+
+---
+
+### Phase 2 — Scope
+
+**Owner:** `scoping-facilitator`  
+**Input:** `qualification.md`, any RFP or brief provided by the client  
+**Output:** `scope.md` — bounded problem statement, in-scope work, explicit exclusions, open questions
+
+**What happens:**
+
+Run a structured scoping session with the client (remote or in-person). The goal is **not** to produce a full spec — it is to produce a bounded problem statement precise enough to estimate.
+
+Techniques applied:
+- **Problem framing**: distinguish the stated request ("we need a mobile app") from the underlying problem ("our field technicians can't access work orders offline"). The scope document addresses the problem, not just the stated request.
+- **Impact mapping** (Adzic, 2012): Goal → Actors → Impacts → Deliverables. Surfaces the logical chain from business outcome to software deliverable.
+- **Scope boundary definition**: explicit in-scope, out-of-scope, and grey-zone lists. Grey-zone items are flagged as assumptions or future change requests.
+- **Stakeholder map**: who will use it, who approves it, who can veto it, who is the champion.
+- **Dependency scan**: third-party APIs, legacy systems to integrate, data migrations, regulatory requirements, existing infrastructure constraints.
+- **Non-functional requirements (NFRs) first pass**: performance, availability, security, geography/data-residency, compliance (GDPR, HIPAA, etc.). NFRs drive architecture choices and therefore cost.
+- **Open questions**: anything that couldn't be resolved in the scoping session. Each question has an owner and a due date.
+
+**Quality gate:** Problem statement clearly distinguishes real problem from stated request. In-scope / out-of-scope / grey-zone documented. Stakeholder map complete. NFRs captured at headline level. Open questions owned and dated.
+
+---
+
+### Phase 3 — Estimate
+
+**Owner:** `estimator`  
+**Input:** `scope.md`, any technical constraints from qualification  
+**Output:** `estimation.md` — work breakdown, risk register, pricing model recommendation, cost range
+
+**What happens:**
+
+Decompose the scope into estimable units and assign effort ranges. Produce a risk-adjusted cost range (not a point estimate) with an explicit confidence level.
+
+Techniques applied:
+- **Work Breakdown Structure (WBS)**: decompose the in-scope work into phases (discovery, design, build, test, deploy, stabilisation) and within each phase into work packages. Each package gets a three-point estimate (optimistic / most-likely / pessimistic) in days.
+- **PERT formula**: `E = (O + 4M + P) / 6` for expected effort; `SD = (P - O) / 6` for standard deviation. Total range = sum of expected values ± combined standard deviations. Report at 80% confidence interval (E + 1.28 SD).
+- **Risk register**: identify the top 5–8 risks with probability (H/M/L) and impact (H/M/L). For each risk, state the mitigation and whether it is included in the estimate or a change-order trigger.
+- **Risk multiplier**: apply a multiplier (1.1–1.5×) to the base estimate depending on novelty, team familiarity with the stack, dependency count, and client responsiveness history.
+- **Pricing model selection**:
+  - **Fixed price**: appropriate when scope is well-defined, client is risk-averse, and provider confidence is high (≥ 80% confidence interval used as the price floor). Include a change-control clause.
+  - **Time & Materials (T&M)**: appropriate when scope is exploratory or likely to change. Client bears cost risk; provider bears reputation risk. Set a not-to-exceed (NTE) cap.
+  - **Retainer**: appropriate for ongoing, amorphous work (maintenance, enhancements). Price per hour or day with a monthly minimum.
+  - **Phased / hybrid**: fixed-price discovery phase → T&M build phase. Reduces client risk while providing scope clarity before committing to build.
+- **Payment milestone schedule**: for fixed-price, propose milestone-based payment (e.g., 30% on start, 40% on UAT, 30% on go-live). For T&M, propose monthly invoicing.
+
+**Quality gate:** WBS covers all in-scope items. Three-point estimates recorded (not just single-point). Risk register has ≥ 5 entries. Pricing model chosen with rationale. Cost range stated as a range (not a single number) at an explicit confidence level.
+
+---
+
+### Phase 4 — Propose
+
+**Owner:** `proposal-writer`  
+**Input:** `qualification.md`, `scope.md`, `estimation.md`  
+**Output:** `proposal.md` — the client-facing proposal / SOW
+
+**What happens:**
+
+Write the formal offer document. The proposal must be readable by a non-technical stakeholder in under 15 minutes (executive summary) **and** by a technical/legal team doing due diligence (detailed sections).
+
+Proposal structure:
+1. **Cover page**: client name, proposal title, date, validity period, provider contact.
+2. **Executive summary** (≤1 page): problem statement, proposed solution, key benefits, headline price and timeline.
+3. **Our understanding of your situation**: restate the client's problem in their language. This demonstrates listening and surfaces misalignments before they become contract disputes.
+4. **Proposed solution**: solution overview, approach (methodology, team structure, communication cadence), key decisions and their rationale.
+5. **Scope of work**: in-scope deliverables with acceptance criteria, phased timeline with milestones, explicit out-of-scope list.
+6. **Technical approach** (optional, for technical audiences): architecture overview, tech stack, integration points, NFR approach.
+7. **Team**: roles, named leads if possible, relevant experience.
+8. **Pricing and payment**:
+   - For fixed price: total price, breakdown by phase, milestone payment schedule, what triggers change orders.
+   - For T&M: daily/hourly rates, estimated effort range, NTE cap, invoicing cadence.
+9. **Assumptions and exclusions**: every assumption that underpins the price. If an assumption is wrong, a change order follows. Be explicit.
+10. **Change control process**: how changes are requested, assessed, priced, and approved.
+11. **Our working model**: what the client is expected to provide (access, decisions, feedback turnaround SLA), what happens if they don't.
+12. **Next steps**: what happens after the client says yes (onboarding, kickoff, first milestone).
+13. **Validity**: proposal is valid for N days. After that, re-estimation may be required.
+14. **Terms and conditions**: reference to the master services agreement or include standard terms.
+
+**Internal review before sending:** the proposal-writer must flag any assumptions that haven't been validated with the client, any risks not covered by the pricing, and any commitments that exceed the provider's capacity.
+
+**Quality gate:** All 14 proposal sections present. Assumptions section is non-empty. Out-of-scope list is explicit (not implied). Change-control process defined. Validity period stated. Price matches `estimation.md` figures. Internal review checklist signed off.
+
+---
+
+### Phase 5 — Order
+
+**Owner:** `proposal-writer` (human sign-off required)  
+**Input:** `proposal.md`, client acceptance (email, signed PDF, or digital signature)  
+**Output:** `order.md` — formal record of the accepted offer + **Project Kickoff Brief**
+
+**What happens:**
+
+Record the accepted commercial terms and produce the **Project Kickoff Brief** — the canonical handoff artifact that seeds the delivery workflow.
+
+The order document:
+- References the accepted proposal version and date.
+- Records any negotiated changes from the proposal (scope adjustments, price concessions, deferred items).
+- Logs the formal acceptance event (email timestamp, signature reference, PO number).
+- Contains the **Project Kickoff Brief**: a structured summary written for the delivery team, covering client context, problem statement, agreed scope, budget, timeline, key stakeholders, non-negotiables, political considerations, and open questions that survived into delivery.
+- Recommends the downstream workflow entry point: `/discovery:start <sprint-slug>` (for exploratory mandates) or `/spec:start <feature-slug>` (for defined mandates).
+
+**Quality gate:** Accepted proposal version recorded. All negotiated changes documented. Project Kickoff Brief complete (all sections present). Downstream workflow entry point stated. Human sign-off captured before marking `status: ordered`.
+
+---
+
+## 4. Specialist agents
+
+| Agent | Human role it shadows | Phases | Tools |
+|---|---|---|---|
+| `sales-qualifier` | Account executive / BD rep | 1 — Qualify | Read, Edit, Write, WebSearch |
+| `scoping-facilitator` | Solutions architect / presales consultant | 2 — Scope | Read, Edit, Write |
+| `estimator` | Lead engineer / delivery manager | 3 — Estimate | Read, Edit, Write |
+| `proposal-writer` | Bid manager / account director | 4 — Propose, 5 — Order | Read, Edit, Write |
+
+Agent rules (all agents):
+- Operate only within the defined phase scope.
+- Use only inputs provided; never invent scope, pricing, or client context.
+- Escalate ambiguity as an open question in the active artifact with an owner and due date.
+- Update `deal-state.md` on handoff.
+- Never autonomously send documents to external parties; that requires explicit human action.
+
+---
+
+## 5. Method library
+
+### Qualification methods
+
+| Method | Use when |
+|---|---|
+| **BANT** (Budget, Authority, Need, Timeline) | Quick initial screen; useful for inbound leads |
+| **MEDDIC** (Metrics, Economic Buyer, Decision Criteria, Decision Process, Identify Pain, Champion) | Complex B2B deals with multiple stakeholders |
+| **SPIN Selling** (Situation, Problem, Implication, Need-payoff) | Discovery call structure; elicits pain rather than mapping to features |
+| **Win probability score** | Comparing multiple simultaneous opportunities for resource allocation |
+
+### Scoping methods
+
+| Method | Use when |
+|---|---|
+| **Impact mapping** (Goal → Actor → Impact → Deliverable) | Connecting software features to business outcomes |
+| **Event storming** (Brandolini) | Mapping domain events to understand system boundaries |
+| **User story mapping** (Patton) | High-level backlog for scoping; identifies must-haves vs. nice-to-haves |
+| **6x6 scope matrix** | Quickly categorising items as in / out / grey |
+| **Assumption mapping** | Identifying and ranking assumptions by risk and knowability |
+
+### Estimation methods
+
+| Method | Use when |
+|---|---|
+| **Three-point estimation + PERT** | Standard for any non-trivial project |
+| **Analogy-based estimation** | Provider has a comparable delivered project |
+| **T-shirt sizing → PERT** | Large initial backlogs where story-level detail isn't available |
+| **Planning poker** | Cross-functional team estimation for detailed backlogs |
+| **Monte Carlo simulation** | Very large or high-uncertainty projects |
+
+### Proposal / SOW patterns
+
+| Pattern | Use when |
+|---|---|
+| **Fixed-price SOW** | Scope well-defined; client risk-averse |
+| **T&M with NTE cap** | Scope is likely to change; provider reputation at stake |
+| **Phased: fixed discovery + T&M build** | Scope unclear; client needs cost certainty after phase 1 |
+| **Retainer** | Ongoing maintenance, advisory, or continuous improvement |
+| **Value-based pricing** | Strategic outcome is high-value; hourly/daily rates undersell |
+
+---
+
+## 6. Quality gates
+
+### Phase 1 — Qualify
+
+- [ ] BANT responses documented for all four dimensions.
+- [ ] Win probability scored (0–100) with justification.
+- [ ] Competitive landscape noted (who else is bidding?).
+- [ ] Verdict stated: `pursue` / `no-go` / `more-info`.
+- [ ] If `more-info`: next steps listed with owner + due date.
+
+### Phase 2 — Scope
+
+- [ ] Problem statement distinguishes real problem from stated request.
+- [ ] In-scope deliverables listed.
+- [ ] Out-of-scope items listed explicitly.
+- [ ] Grey-zone items flagged as assumptions or future change requests.
+- [ ] Stakeholder map complete (user, approver, champion, veto).
+- [ ] NFRs captured at headline level (performance, availability, security, compliance).
+- [ ] Dependencies and integrations listed.
+- [ ] Open questions owned and dated (none left unowned).
+
+### Phase 3 — Estimate
+
+- [ ] WBS covers all in-scope deliverables from `scope.md`.
+- [ ] Three-point estimates (O / M / P) recorded for each work package.
+- [ ] PERT totals computed; standard deviation stated.
+- [ ] Confidence interval stated (recommend 80%).
+- [ ] Risk register has ≥ 5 entries with probability, impact, mitigation.
+- [ ] Risk multiplier applied and justified.
+- [ ] Pricing model chosen with rationale.
+- [ ] Cost range (not point estimate) stated.
+- [ ] Payment milestone schedule proposed.
+
+### Phase 4 — Propose
+
+- [ ] All 14 proposal sections present.
+- [ ] Executive summary is ≤ 1 page.
+- [ ] Assumptions section is non-empty.
+- [ ] Out-of-scope list is explicit.
+- [ ] Change-control process defined.
+- [ ] Pricing matches `estimation.md` figures.
+- [ ] Validity period stated.
+- [ ] Internal review checklist complete.
+- [ ] Proposal sent to client (human action — not automated).
+
+### Phase 5 — Order
+
+- [ ] Accepted proposal version recorded.
+- [ ] Negotiated changes documented (even if none).
+- [ ] Acceptance event logged (date, reference).
+- [ ] Project Kickoff Brief complete (all sections).
+- [ ] Downstream workflow entry point stated.
+- [ ] Human sign-off recorded before status → `ordered`.
+
+---
+
+## 7. Handoff to delivery
+
+The `order.md` **Project Kickoff Brief** is the single artefact that bridges the commercial and delivery worlds. It must be read by every agent and human that joins the delivery team.
+
+### Project Kickoff Brief — required sections
+
+1. **Client context**: who they are, their industry, why this project matters to them now.
+2. **Problem statement**: verbatim from `scope.md`, not paraphrased. Delivery teams should speak the client's language.
+3. **Agreed scope summary**: what is in scope, what is explicitly out of scope, what is deferred to a future phase.
+4. **Budget and timeline**: total budget (if shared), payment milestones, required go-live date, hard deadlines.
+5. **Key stakeholders**: name, role, communication preference, escalation path.
+6. **Non-negotiables**: things the client said must not change (technology choice, data residency, integration with system X, GDPR compliance, etc.).
+7. **Political considerations**: internal dynamics the delivery team should be aware of (champion who needs wins, sceptic who needs evidence, budget holder who is not the day-to-day contact).
+8. **Assumptions carried into delivery**: every assumption from the proposal that the delivery team must validate or escalate if wrong.
+9. **Open questions**: items that were unresolved at close and must be resolved in the first sprint.
+10. **Downstream workflow**: which entry point — `/discovery:start` (for exploratory mandates) or `/spec:start` (for defined mandates) — and the slug to use.
+
+### What the delivery workflow reads
+
+When starting a delivery workflow that originates from a sales deal:
+
+- `discovery:start` or `spec:start` references `sales/<deal-slug>/order.md` in the new folder's state file.
+- The `analyst` (Stage 1) reads the Project Kickoff Brief as a mandatory input alongside the brief.
+- The `pm` (Stage 3) reads budget and non-negotiables as explicit constraints in the PRD.
+- The `architect` (Stage 4/5) reads NFRs and technical constraints from `scope.md`.
+- The `retrospective` (Stage 11) includes a pre-sales accuracy assessment: how close was the estimate, what scope drift occurred, what open questions were never resolved.
+
+---
+
+## 8. Deal state machine
+
+```
+lead
+  └─ qualifying          (sales-qualifier running)
+       ├─ no-go          (close — record reason; preserve artifacts)
+       └─ go
+            └─ scoping   (scoping-facilitator running)
+                 └─ estimating  (estimator running)
+                      └─ proposing  (proposal-writer running)
+                           ├─ no-go     (close — record reason)
+                           ├─ on-hold   (suspend — record condition)
+                           └─ negotiating
+                                ├─ no-go
+                                ├─ on-hold
+                                └─ ordered   (delivery handoff triggered)
+```
+
+### deal-state.md YAML frontmatter schema
+
+```yaml
+deal: <deal-slug>
+client: <Client Name>
+contact: <Primary contact name and email>
+source: inbound | referral | outbound | rfp   # how the lead arrived
+current_phase: qualifying   # qualifying | scoping | estimating | proposing | negotiating | ordered | no-go | on-hold
+status: active              # active | on-hold | ordered | closed
+last_updated: YYYY-MM-DD
+last_agent: <role>
+artifacts:
+  qualification.md: pending   # pending | in-progress | complete | skipped | blocked
+  scope.md: pending
+  estimation.md: pending
+  proposal.md: pending
+  order.md: pending
+```
+
+---
+
+## 9. Sources and further reading
+
+- Napoli, J. *MEDDIC Sales Methodology*. PTC, 1990s. [meddic.com](https://meddic.com/)
+- Rackham, N. *SPIN Selling*. 1988. McGraw-Hill.
+- Miller, R., Heiman, S. *The New Strategic Selling*. Warner Books, 1985.
+- PMI. *Statement of Work: A Critical First Step*. [pmi.org](https://www.pmi.org/learning/library/statement-of-work-sow-critical-first-step-8114)
+- Cohn, M. *Agile Estimating and Planning*. Prentice Hall, 2005. [mountaingoatsoftware.com](https://www.mountaingoatsoftware.com/books/agile-estimating-and-planning)
+- Hulett, D. *Three-Point Estimation for Cost and Schedule*. [projectrisk.com](https://www.projectrisk.com/white_papers/ThreePointEstimationforCostandSchedule.pdf)
+- Weiss, A. *Value-Based Fees*. Pfeiffer, 2002.
+- Adzic, G. *Impact Mapping*. 2012. [impactmapping.org](https://www.impactmapping.org/)
+- Patton, J. *User Story Mapping*. O'Reilly, 2014.
+- Brandolini, A. *Introducing Event Storming*. [eventstorming.com](https://www.eventstorming.com/)
+- Treloar, G. *How to Scope a Software Project*. Thoughtworks.

--- a/docs/sink.md
+++ b/docs/sink.md
@@ -34,6 +34,16 @@ Where every markdown artifact in this kit lives, who owns it, and how it evolves
 │   └── UBIQUITOUS_LANGUAGE.md               # living glossary (LAZY)
 ├── templates/                               # blank artifacts; stages copy + fill
 │   └── *-template.md
+├── sales/                                   # one folder per client deal (pre-project, service-provider opt-in)
+│   └── <deal-slug>/
+│       ├── deal-state.md                    # deal state machine, owned by /sales:* commands
+│       ├── qualification.md                 # phase 1 (sales-qualifier) — BANT/MEDDIC + go/no-go verdict
+│       ├── scope.md                         # phase 2 (scoping-facilitator) — bounded problem + in/out scope
+│       ├── estimation.md                    # phase 3 (estimator) — WBS, PERT, risk register, pricing model
+│       ├── proposal.md                      # phase 4 (proposal-writer) — SOW / client-facing offer
+│       ├── revisions/                       # proposal revision history (LAZY)
+│       │   └── proposal-v2.md
+│       └── order.md                         # phase 5 (proposal-writer) — acceptance record + Project Kickoff Brief
 ├── discovery/                               # one folder per discovery sprint (pre-stage 1, opt-in)
 │   └── <sprint-slug>/
 │       ├── discovery-state.md               # sprint state machine, owned by /discovery:* commands
@@ -84,6 +94,13 @@ Where every markdown artifact in this kit lives, who owns it, and how it evolves
 | `docs/CONTEXT.md`, `docs/CONTEXT-MAP.md`, `docs/contexts/*.md` | `domain-context` skill | Additive, agent-updated |
 | `docs/UBIQUITOUS_LANGUAGE.md` | `ubiquitous-language` skill | Additive, agent-updated |
 | `templates/*-template.md` | Human | Versioned; updates propagate to new features only |
+| `sales/<deal>/deal-state.md` | `/sales:start`, then `/sales:*` commands on transition | Deal state machine; sales-cycle skill-owned |
+| `sales/<deal>/qualification.md` | `sales-qualifier` | Written once in Phase 1; later phases never rewrite |
+| `sales/<deal>/scope.md` | `scoping-facilitator` | Written once in Phase 2 |
+| `sales/<deal>/estimation.md` | `estimator` | Written once in Phase 3; re-run triggers a revision |
+| `sales/<deal>/proposal.md` | `proposal-writer` | Current accepted version; revisions go to `revisions/` |
+| `sales/<deal>/revisions/proposal-vN.md` | `proposal-writer` | Created lazily on each negotiation revision (LAZY) |
+| `sales/<deal>/order.md` | `proposal-writer` (human sign-off required) | Written once in Phase 5; links to downstream workflow |
 | `discovery/<sprint>/discovery-state.md` | `/discovery:start`, then `/discovery:*` commands on transition | Sprint state machine; facilitator-owned |
 | `discovery/<sprint>/<phase>.md` | The phase's owning facilitator + consulted specialists (per `docs/discovery-track.md` §3) | Each phase writes once; later phases never rewrite upstream phase artifacts |
 | `discovery/<sprint>/chosen-brief.md` | `facilitator` (Handoff) | One per surviving concept; mandatory input to `/spec:idea` |
@@ -129,6 +146,14 @@ Accepted ADRs are immutable. To change a decision, file a new ADR superseding th
 5. All numerically-earlier `specs/<slug>/<artifact>.md` files in stage order.
 6. `docs/CONTEXT.md` and `docs/UBIQUITOUS_LANGUAGE.md` if present.
 7. Any topically relevant ADRs (skim titles).
+
+## Sales Cycle sub-tree
+
+When a **service provider** needs to win a project before building it, the Sales Cycle Track runs first — a 5-phase commercial workflow (Qualify → Scope → Estimate → Propose → Order) that produces `order.md`. The `order.md` contains a Project Kickoff Brief that is the canonical handoff to the delivery workflow. The delivery workflow is entered via `/discovery:start` (exploratory mandates) or `/spec:start` (defined mandates), with `order.md` as the mandatory context input.
+
+The deal folder lives at `sales/<deal-slug>/` parallel to `discovery/` and `specs/`. Deals that close as `no-go` are preserved as historical context. A deal may spawn one or more feature or discovery workflows after the order is placed.
+
+**Note on confidentiality:** The `sales/` directory may contain commercially sensitive data (client names, pricing, contract terms). Teams must apply appropriate access controls. The kit does not manage access control — that is an infrastructure concern.
 
 ## Discovery Track sub-tree
 

--- a/templates/deal-state-template.md
+++ b/templates/deal-state-template.md
@@ -1,0 +1,59 @@
+---
+deal: <deal-slug>
+client: <Client Name>
+contact: <Primary contact name — email>
+source: inbound | referral | outbound | rfp
+current_phase: qualifying   # qualifying | scoping | estimating | proposing | negotiating | ordered | no-go | on-hold
+status: active              # active | on-hold | ordered | closed
+last_updated: YYYY-MM-DD
+last_agent: <role>
+artifacts:
+  qualification.md: pending   # pending | in-progress | complete | skipped | blocked
+  scope.md: pending
+  estimation.md: pending
+  proposal.md: pending
+  order.md: pending
+---
+
+# Deal state — <deal-slug>
+
+## Phase progress
+
+| Phase | Artifact | Status |
+|---|---|---|
+| 1. Qualify | `qualification.md` | pending |
+| 2. Scope | `scope.md` | pending |
+| 3. Estimate | `estimation.md` | pending |
+| 4. Propose | `proposal.md` | pending |
+| 5. Order | `order.md` | pending |
+
+> **Statuses:** `pending` | `in-progress` | `complete` | `skipped` | `blocked`. Use the bare enum value in frontmatter; document skip reasons in **Skips** and blockers in **Blocks**.
+
+## Skips
+
+> Document any skipped phases and why.
+
+- e.g., `scope.md` — RFP included a detailed requirements document; scoping workshop not required.
+
+## Blocks
+
+> Anything blocking progress.
+
+- e.g., `qualification.md blocked — awaiting budget confirmation from <name>`
+
+## Hand-off notes
+
+Free-form, append-only. What does the next agent or human need to know?
+
+```
+YYYY-MM-DD (sales-qualifier): Qualification complete. Win probability 72%. Strong champion in <name>.
+                               Proceed to scoping — but note: CTO sceptical of timeline.
+YYYY-MM-DD (scoping-facilitator): Workshop held. Scope bounded. 3 open questions remain.
+```
+
+## Open clarifications
+
+> Add and resolve as they come up. Unresolved clarifications block phase transitions.
+
+- [ ] CLAR-001 — …
+- [x] CLAR-002 — … *(resolved YYYY-MM-DD: …)*

--- a/templates/estimation-template.md
+++ b/templates/estimation-template.md
@@ -1,0 +1,204 @@
+---
+id: EST-<DEAL>-001
+deal: <deal-slug>
+client: <Client Name>
+phase: estimate
+status: draft         # draft | complete | blocked
+owner: estimator
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+pricing_model: fixed-price | t-and-m | retainer | phased
+confidence: high | medium | low   # 80%+ = high, 60-79% = medium, <60% = low
+---
+
+# Estimation — <deal-slug>
+
+## Summary
+
+| | Value |
+|---|---|
+| **Total estimate (central)** | X days |
+| **Low end (optimistic + contingency)** | X days |
+| **High end (pessimistic + contingency)** | X days |
+| **Confidence level** | high / medium / low |
+| **Pricing model** | fixed-price / T&M / retainer / phased |
+| **Indicative cost range** | €X — €Y |
+| **Estimated duration** | X weeks |
+| **Estimate basis** | three-point PERT / analogy / expert judgment |
+
+## Assumptions this estimate is conditioned on
+
+> These MUST appear in the SOW as a named exhibit. If any assumption is invalidated, the estimate must be re-run and the SOW repriced via change request.
+
+| ID | Assumption | Impact if wrong |
+|---|---|---|
+| ASM-001 | | High / Medium / Low |
+| ASM-002 | | |
+
+## Work breakdown structure
+
+### Phase 1 — Discovery & Design
+
+| Work package | Optimistic (days) | Most likely (days) | Pessimistic (days) | PERT expected | Notes |
+|---|---|---|---|---|---|
+| Requirements workshops | | | | | |
+| UX research & wireframes | | | | | |
+| Architecture decision | | | | | |
+| **Phase 1 total** | | | | | |
+
+> PERT formula: E = (O + 4M + P) / 6
+
+### Phase 2 — Core Development
+
+| Work package | Optimistic (days) | Most likely (days) | Pessimistic (days) | PERT expected | Notes |
+|---|---|---|---|---|---|
+| [Epic: name from scope.md] | | | | | |
+| [Epic: name] | | | | | |
+| [Epic: name] | | | | | |
+| **Phase 2 total** | | | | | |
+
+### Phase 3 — Integrations
+
+| Work package | Optimistic (days) | Most likely (days) | Pessimistic (days) | PERT expected | Notes |
+|---|---|---|---|---|---|
+| [Integration: name from scope.md] | | | | | |
+| [Integration: name] | | | | | |
+| **Phase 3 total** | | | | | |
+
+### Phase 4 — Testing & QA
+
+| Work package | Optimistic (days) | Most likely (days) | Pessimistic (days) | PERT expected | Notes |
+|---|---|---|---|---|---|
+| Integration testing | | | | | |
+| UAT support | | | | | |
+| Performance / security testing | | | | | |
+| **Phase 4 total** | | | | | |
+
+### Phase 5 — Deployment & Stabilisation
+
+| Work package | Optimistic (days) | Most likely (days) | Pessimistic (days) | PERT expected | Notes |
+|---|---|---|---|---|---|
+| Infrastructure setup | | | | | |
+| Deployment & migration | | | | | |
+| Post-launch stabilisation (2 weeks) | | | | | |
+| **Phase 5 total** | | | | | |
+
+### Project management & communication overhead
+
+| Work package | Optimistic (days) | Most likely (days) | Pessimistic (days) | PERT expected | Notes |
+|---|---|---|---|---|---|
+| Project management (all phases) | | | | | |
+| Client communication overhead | | | | | |
+| Documentation | | | | | |
+| **PM total** | | | | | |
+
+## Totals before risk adjustment
+
+| | Days |
+|---|---|
+| **Base estimate (sum of PERT expected values)** | |
+| **Standard deviation (√(Σ SD²))** | |
+| **80% confidence interval (Base + 0.84 × SD)** | |
+
+## Risk register
+
+| ID | Risk description | Probability | Impact | Mitigation | Included in estimate? |
+|---|---|---|---|---|---|
+| RSK-001 | | H / M / L | H / M / L | | yes / no / contingency |
+| RSK-002 | Undiscovered integrations beyond scope | M | H | Explicit out-of-scope clause + change order trigger | yes |
+| RSK-003 | Client feedback cycles exceed SLA | M | M | Defined response SLA in SOW; delays shift timeline | no |
+| RSK-004 | Third-party API constraints unknown | M | H | Spike budget in Phase 1; re-estimate if blocked | contingency |
+| RSK-005 | Team availability disruption | L | M | Buffer in Phase 4/5 estimates | yes |
+
+> Minimum 5 risks required. Mark "included in estimate" as `yes` (baked into hours), `no` (not covered, will be a change order if triggered), or `contingency` (covered by the contingency line).
+
+## Risk multiplier
+
+| Factor | Level (1–3) | Multiplier contribution |
+|---|---|---|
+| Scope novelty (how new is this type of project for us?) | | |
+| Technical risk (unknown third-party systems, legacy integrations?) | | |
+| Client responsiveness history | | |
+| Team familiarity with this stack | | |
+| **Risk multiplier (1.0 – 1.5×)** | | |
+
+Notes on multiplier rationale:
+
+## Contingency
+
+| Item | Days | Rationale |
+|---|---|---|
+| Base contingency (15% of base estimate for known unknowns) | | |
+| Risk contingency (for RSK items marked "contingency") | | |
+| **Total contingency** | | |
+
+## Final estimate
+
+| | Days |
+|---|---|
+| **Base estimate** | |
+| **× Risk multiplier** | |
+| **+ Contingency** | |
+| **Total (central)** | |
+| **Low end** (optimistic base × 1.0, minimum contingency) | |
+| **High end** (pessimistic base × risk multiplier + full contingency) | |
+
+## Pricing model recommendation
+
+**Recommended model:** fixed-price | T&M | retainer | phased
+
+**Rationale** (reference the decision criteria in `docs/sales-cycle.md` §5):
+
+**For fixed-price:**
+- Price floor (80% confidence interval): €X
+- Recommended quoted price: €Y (includes full contingency)
+- NTE not applicable (risk is provider's)
+
+**For T&M:**
+- Day rates: Senior: €___, Mid: €___, Junior: €___
+- Estimated range: €X – €Y
+- Not-to-exceed cap (NTE): €Z (recommend 120% of central estimate)
+- Invoicing: monthly in arrears
+
+**For phased (paid discovery → fixed build):**
+- Phase 1 (paid discovery): T&M, €X, duration N weeks
+- Phase 2 (build): Fixed price, €Y (after Phase 1 scope refinement), duration N weeks
+- Rationale for split:
+
+## Payment milestone schedule
+
+| Milestone | % of total | Amount | Trigger |
+|---|---|---|---|
+| Contract signature | 30% | | |
+| End of design / UAT ready | 40% | | |
+| Go-live / final acceptance | 30% | | |
+
+## Team composition
+
+| Role | Allocation | Duration |
+|---|---|---|
+| Project Manager | | full project |
+| Lead Architect | | Phases 1–2 |
+| Senior Developer | | Phases 2–3 |
+| Developer | | Phases 2–4 |
+| QA Engineer | | Phases 4–5 |
+| UX Designer | | Phase 1 |
+
+**Engineering sign-off:** This estimate has been reviewed by the technical lead who will work on the project.
+Reviewed by: _______________ Date: _______________
+
+---
+
+## Quality gate
+
+- [ ] WBS covers all in-scope deliverables from `scope.md`.
+- [ ] Three-point estimates (O / M / P) recorded for each work package.
+- [ ] PERT totals computed; confidence interval stated.
+- [ ] Risk register has ≥ 5 entries (probability, impact, mitigation, in-estimate flag).
+- [ ] Risk multiplier applied and justified.
+- [ ] Contingency line item explicit (not absorbed silently).
+- [ ] Pricing model chosen with rationale.
+- [ ] Cost expressed as a range (low / central / high), not a single number.
+- [ ] Payment milestone schedule proposed.
+- [ ] Engineering sign-off obtained (not sales-only estimate).
+- [ ] Assumptions register complete and will be attached to SOW as exhibit.

--- a/templates/order-template.md
+++ b/templates/order-template.md
@@ -1,0 +1,194 @@
+---
+id: ORDER-<DEAL>-001
+deal: <deal-slug>
+client: <Client Name>
+phase: order
+status: draft         # draft | accepted | closed
+owner: proposal-writer
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+accepted_date: YYYY-MM-DD
+proposal_version: v1.0
+contract_reference: <PO number / MSA reference / signed PDF filename>
+delivery_workflow: discovery | spec   # which downstream workflow to open
+delivery_slug: <feature-or-sprint-slug>
+---
+
+# Order — <deal-slug>
+
+## Acceptance record
+
+| Field | Value |
+|---|---|
+| **Accepted proposal** | PROP-<DEAL>-001 v1.0 (or note the accepted version) |
+| **Acceptance date** | YYYY-MM-DD |
+| **Acceptance form** | email / signed PDF / digital signature / PO |
+| **Contract / PO reference** | |
+| **Accepted by** | Name, title |
+| **Provider sign-off** | Name, title |
+
+## Negotiated changes from proposal
+
+> Document all changes agreed during negotiation. If none, state "None — accepted as submitted."
+
+| Item | Original (proposal) | Agreed (order) | Reason |
+|---|---|---|---|
+| | | | |
+
+## Financial summary
+
+| Item | Amount |
+|---|---|
+| **Total contract value** | €X |
+| **Pricing model** | fixed-price / T&M (NTE €Y) / retainer |
+| **First invoice** | €X, due YYYY-MM-DD |
+| **Payment schedule** | milestone / monthly / other |
+
+---
+
+## Project Kickoff Brief
+
+> This section is the canonical handoff from commercial to delivery. Every agent and human joining the delivery team must read this. Write it for someone who was not in any of the sales conversations.
+
+### 1. Client context
+
+**Who they are:** [Company name, size, industry, location]
+
+**Why this project matters to them now:** [Business driver — new product, competitive pressure, compliance deadline, efficiency initiative, etc.]
+
+**Our relationship history:** [First engagement / existing client — how long, what trust has been established]
+
+### 2. Problem statement
+
+> Copy verbatim from `scope.md`. Do not paraphrase — the delivery team should speak the client's language.
+
+[Insert problem statement from scope.md]
+
+**Measurable success criteria:**
+[Insert from scope.md]
+
+### 3. Agreed scope summary
+
+**In scope (must-haves):**
+[List the Must-have epics from scope.md — the non-negotiable core]
+
+**In scope (should-haves and could-haves):**
+[List with note that these are subject to time and budget]
+
+**Explicitly out of scope:**
+[Copy the out-of-scope list from proposal.md]
+
+**Deferred to a future phase:**
+[Items that came up in scoping but were explicitly deferred]
+
+### 4. Budget and timeline
+
+| Item | Value |
+|---|---|
+| **Total budget** | €X |
+| **Budget shared with client?** | yes / no / partial |
+| **Required go-live date** | YYYY-MM-DD |
+| **Hard deadline?** | yes / no — if yes, reason: |
+| **Timeline buffer** | X weeks |
+| **First payment milestone** | YYYY-MM-DD |
+
+### 5. Key stakeholders
+
+| Name | Role | Contact | Availability | Notes |
+|---|---|---|---|---|
+| | Primary contact / day-to-day | | | |
+| | Economic buyer / approver | | | Prefers summary-level updates |
+| | Champion | | | Advocates internally for us |
+| | Technical contact | | | |
+| | Veto stakeholder | | | Sceptical — needs evidence |
+
+**Who NOT to go around:** [Any political sensitivity about bypassing certain stakeholders]
+
+**Preferred communication style:** [Formal / informal / high-frequency / weekly summaries / etc.]
+
+### 6. Non-negotiables
+
+> Things the client said must not change, no matter what. Violating these will damage the relationship.
+
+- …
+- …
+- …
+
+### 7. Political considerations
+
+> Things not in the contract but important for the team to navigate successfully. Handle with discretion.
+
+- …
+- …
+- …
+
+### 8. Assumptions inherited from the proposal
+
+> The delivery team is responsible for validating these. Any assumption that proves false must be escalated immediately — it is a potential change-order trigger.
+
+| ID | Assumption | Status | Owner |
+|---|---|---|---|
+| ASM-001 | | unvalidated | |
+| ASM-002 | Client will provide system access within 5 business days | unvalidated | PM |
+
+### 9. Open questions carried into delivery
+
+> These were unresolved at contract close. Priority: resolve in sprint 1 / kickoff.
+
+| ID | Question | Impact | Owner | Due |
+|---|---|---|---|---|
+| OQ-001 | | | | |
+
+### 10. Red flags from pre-sales
+
+> Signals from the sales process that the delivery team should watch for. Not for the client — internal only.
+
+- …
+- …
+
+### 11. Downstream workflow entry point
+
+**Entry point:** `/discovery:start <sprint-slug>` | `/spec:start <feature-slug>`
+
+**Slug:** `<deal-slug>` or a derived feature slug
+
+**Rationale for entry point choice:**
+- Use `/discovery:start` if: the solution direction is still exploratory, the client expects the delivery team to iterate on the problem, or a design sprint is expected.
+- Use `/spec:start` if: the scope is well-defined, a clear brief exists (the scope.md + order.md constitute the brief), and the team can move directly to /spec:idea.
+
+**Pre-loaded context for the analyst / facilitator:**
+The `Project Kickoff Brief` above serves as the `chosen-brief.md` for `/spec:idea` or the `frame.md` seed for `/discovery:frame`. The analyst must read this document as the primary input to Stage 1.
+
+---
+
+## Kickoff logistics
+
+| Item | Value |
+|---|---|
+| **Welcome email sent** | YYYY-MM-DD HH:MM (target: within 1 hour of signature) |
+| **Internal sales → PM handoff call** | YYYY-MM-DD (target: within 24 hours) |
+| **Client kickoff meeting** | YYYY-MM-DD (target: within 3–5 business days) |
+| **Full onboarding complete** | YYYY-MM-DD (target: within 7 business days) |
+
+**Kickoff meeting agenda:**
+1. Introductions (full team)
+2. Project overview (PM presents their understanding — client corrects if wrong)
+3. Communication and working model (tools, cadence, escalation)
+4. First milestone and schedule
+5. Immediate actions (client: system access, contacts; provider: environment setup)
+6. Open questions resolution plan
+
+---
+
+## Quality gate
+
+- [ ] Acceptance record complete (accepted proposal version, date, form, reference).
+- [ ] Negotiated changes documented (even if none).
+- [ ] Project Kickoff Brief complete — all 11 sections present and non-empty.
+- [ ] Downstream workflow entry point stated and justified.
+- [ ] Red flags documented for delivery team.
+- [ ] Welcome email sent within 1 hour of signature.
+- [ ] Internal PM briefing scheduled within 24 hours.
+- [ ] Client kickoff scheduled within 5 business days.
+- [ ] Human sign-off before `status: accepted`.
+- [ ] `deal-state.md` updated to `status: ordered`, `current_phase: ordered`.

--- a/templates/proposal-template.md
+++ b/templates/proposal-template.md
@@ -1,0 +1,279 @@
+---
+id: PROP-<DEAL>-001
+deal: <deal-slug>
+client: <Client Name>
+version: v1.0
+phase: propose
+status: draft         # draft | internal-review | sent | accepted | rejected | superseded
+owner: proposal-writer
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+valid_until: YYYY-MM-DD
+pricing_model: fixed-price | t-and-m | retainer | phased
+total_price: TBD
+---
+
+# Proposal — <deal-slug>
+
+> **Version history:** v1.0 YYYY-MM-DD — initial draft.
+>
+> Subsequent versions move to `revisions/proposal-v2.md`, etc. This file always contains the current accepted version.
+
+---
+
+## Cover page
+
+**Proposal for:** [Client Name]  
+**Prepared by:** [Provider Name]  
+**Date:** YYYY-MM-DD  
+**Valid until:** YYYY-MM-DD  
+**Reference:** PROP-<DEAL>-001 v1.0  
+**Contact:** [Name, email, phone]
+
+---
+
+## 1. Executive summary
+
+> ≤ 1 page. Readable by a non-technical stakeholder in under 5 minutes. Leads with the client's problem, not our capabilities.
+
+**The problem you are solving:**
+[Restate the problem statement from `scope.md` in the client's language.]
+
+**Our proposed solution:**
+[One paragraph: what we will build, what approach we will take, what outcome the client will see.]
+
+**Why [Provider]:**
+[Two to three differentiating points specific to this engagement — not a generic agency pitch.]
+
+**Investment:**
+[Headline price or range and timeline — one line.]
+
+---
+
+## 2. Our understanding of your situation
+
+> Demonstrate that we listened. Restate the client's context, the underlying problem, the success criteria they defined, and the constraints. Any significant misalignment surfaces here before it becomes a contract dispute.
+
+### Business context
+[Who the client is, the business they are in, the strategic pressure driving this project.]
+
+### The problem
+[Problem statement from `scope.md`, verbatim or lightly paraphrased.]
+
+### What success looks like
+[The measurable success criteria from `scope.md`.]
+
+### Constraints we are working within
+[Budget range, timeline, technical constraints, compliance requirements, integration dependencies.]
+
+---
+
+## 3. Proposed solution
+
+### Solution overview
+[What we are building. Architecture direction, platform choice, key design decisions — at a level appropriate for the audience. If a technical section follows, this stays non-technical.]
+
+### Approach and methodology
+[Agile / Scrum / Kanban / phased waterfall — describe how the team will work. Sprint cadence, ceremony set (if agile), review gates, escalation protocol.]
+
+### Team
+[Roles, named leads where possible, relevant experience in this domain. Include a paragraph on why this specific team is the right fit.]
+
+### Communication and reporting
+[Meeting cadence, status report format, primary communication channel, escalation path, what we expect from the client in return (response SLA).]
+
+---
+
+## 4. Scope of work
+
+### In-scope deliverables
+
+> Itemised list with acceptance criteria per deliverable. Vague deliverables ("a working application") are not acceptable — each item should be specific enough to be testable.
+
+| # | Deliverable | Acceptance criteria | Phase |
+|---|---|---|---|
+| D-001 | | | |
+| D-002 | | | |
+
+### Phased timeline
+
+| Phase | Description | Duration | Key milestone | Client action required |
+|---|---|---|---|---|
+| 1 | Discovery & design | | | |
+| 2 | Core development | | | |
+| 3 | Integration & testing | | | |
+| 4 | Deployment & launch | | | |
+| 5 | Stabilisation | | | |
+
+**Important dates:**
+- Project start: YYYY-MM-DD (conditional on contract signature by YYYY-MM-DD)
+- UAT start: YYYY-MM-DD
+- Go-live: YYYY-MM-DD
+
+### Explicit exclusions
+
+> This list is as important as the in-scope list. Everything here requires a change request.
+
+- …
+- …
+- …
+
+---
+
+## 5. Technical approach
+
+> Include only if the audience includes technical or procurement reviewers. Remove or collapse for purely business-audience proposals.
+
+### Architecture overview
+[High-level architecture diagram or description: components, data flows, integration points.]
+
+### Technology stack
+[Languages, frameworks, cloud provider, CI/CD toolchain. Rationale for each key choice.]
+
+### Non-functional requirements approach
+[How we address the NFRs from `scope.md`: performance strategy, security posture, compliance controls, availability design.]
+
+### Integration approach
+[How each third-party or legacy system integration will be handled: approach, risk, assumption.]
+
+---
+
+## 6. Pricing and payment
+
+### Pricing model: [Fixed price / T&M / Retainer / Phased]
+
+[Rationale for chosen model in 2–3 sentences.]
+
+**For fixed price:**
+
+| Phase | Description | Price |
+|---|---|---|
+| 1 | Discovery & design | €X |
+| 2 | Core development | €Y |
+| 3 | Integration & testing | €Z |
+| 4 | Deployment & launch | €W |
+| **Total** | | **€TOTAL** |
+
+**Payment schedule:**
+
+| Milestone | % | Amount | Due date |
+|---|---|---|---|
+| Contract signature | 30% | €X | YYYY-MM-DD |
+| End of design (milestone 1 accepted) | 40% | €Y | YYYY-MM-DD |
+| Go-live (final acceptance) | 30% | €Z | YYYY-MM-DD |
+
+> Payment is due within [14 / 30] days of invoice. Late payment incurs [N]% per month.
+
+**For T&M / phased:** *(replace the fixed-price table above)*
+
+| Role | Day rate | Estimated days (range) | Estimated cost (range) |
+|---|---|---|---|
+| Senior Developer | €X | | |
+| | | | |
+| **NTE cap** | | | **€NTE** |
+
+---
+
+## 7. Assumptions and exclusions
+
+> **These are contractual.** If any assumption is invalidated, [Provider] will issue a change request. The client accepting this proposal accepts these assumptions.
+
+| ID | Assumption | Risk if wrong |
+|---|---|---|
+| ASM-001 | | |
+| ASM-002 | The client will provide access to all required systems within 5 business days of project start | Timeline impact |
+| ASM-003 | Decisions on deliverable sign-off will be made within 5 business days of presentation | Timeline impact |
+| ASM-004 | The existing [system] API is documented and stable | Cost and timeline impact |
+
+---
+
+## 8. Change control
+
+Any work not listed in the scope of work requires a change request.
+
+**Process:**
+1. Change requested (client or provider) in writing.
+2. [Provider] assesses impact on scope, timeline, and cost within [5] business days.
+3. Client approves or declines the change order in writing.
+4. Approved changes are incorporated into the next sprint / phase.
+
+**Pricing:** change requests are priced at agreed day rates plus [10%] project management overhead.
+
+---
+
+## 9. Our working model
+
+**What we need from you:**
+
+- A named primary contact with authority to approve deliverables.
+- Feedback on deliverables within [5] business days of presentation.
+- Access to required systems, data, and stakeholders within [5] business days of project start.
+- Timely decisions when design or technical choices require your input.
+
+**What you can expect from us:**
+
+- Weekly written status update.
+- Dedicated [Slack / Teams / email] channel for day-to-day communication.
+- Escalation response within [4] business hours.
+- No surprises: if we foresee a risk to timeline or budget, we tell you in advance.
+
+---
+
+## 10. Next steps
+
+When you are ready to proceed:
+
+1. Review and sign the attached Statement of Work (or reply to this email with acceptance).
+2. We will issue the first invoice (30% of total / first month's retainer) upon signature.
+3. A project kickoff meeting will be scheduled within [3] business days of signature.
+4. We will onboard the delivery team and send a welcome pack within [5] business days.
+
+---
+
+## 11. About [Provider]
+
+[2–3 paragraphs: company background, relevant capabilities, team size, relevant client list if permitted.]
+
+### Relevant case studies
+
+**[Client / Project name]**
+[Industry, problem, solution, outcome — 3–5 sentences.]
+
+**[Client / Project name]**
+[Industry, problem, solution, outcome — 3–5 sentences.]
+
+---
+
+## 12. Terms and conditions
+
+[Reference to Master Services Agreement, or include standard terms as an appendix. Minimum required clauses: IP ownership, confidentiality, liability cap, governing law, dispute resolution.]
+
+---
+
+## Internal review checklist (remove before sending)
+
+- [ ] All assumptions validated against `scope.md` and `estimation.md`.
+- [ ] Price matches `estimation.md` figures (including contingency).
+- [ ] Out-of-scope list is non-empty and explicit.
+- [ ] Change-control process defined.
+- [ ] Payment schedule includes a late-payment clause.
+- [ ] Validity period set.
+- [ ] Executive summary is ≤ 1 page and leads with the client's problem.
+- [ ] No internal cost breakdown, rate cards, or margin data visible in the client-facing version.
+- [ ] Legal / risk review completed if deal is ≥ €50K.
+- [ ] Reviewed by the PM or tech lead who will work on the project (not sales alone).
+- [ ] Red-flag items from qualification noted for PM awareness.
+
+---
+
+## Quality gate
+
+- [ ] All 12 proposal sections present.
+- [ ] Executive summary ≤ 1 page.
+- [ ] Assumptions section non-empty with risk column.
+- [ ] Explicit exclusions list non-empty.
+- [ ] Change-control process defined.
+- [ ] Pricing matches `estimation.md`.
+- [ ] Validity period stated.
+- [ ] Internal review checklist complete.
+- [ ] Human decision to send (not automated).

--- a/templates/qualification-template.md
+++ b/templates/qualification-template.md
@@ -1,0 +1,144 @@
+---
+id: QUAL-<DEAL>-001
+deal: <deal-slug>
+client: <Client Name>
+phase: qualify
+status: draft         # draft | complete | no-go
+verdict: pending      # pursue | no-go | more-info
+owner: sales-qualifier
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+---
+
+# Qualification — <deal-slug>
+
+## Lead summary
+
+One paragraph: who reached out, via what channel, what they said they need, and the first impression of fit.
+
+## BANT assessment
+
+**Budget**
+
+- Is there an allocated or indicative budget? `yes | no | unknown`
+- Amount or range (if disclosed): …
+- Budget owner confirmed? `yes | no | unknown`
+- Notes: …
+
+**Authority**
+
+- Are we talking to a decision-maker? `yes | no | unknown`
+- Who is the Economic Buyer (the person who can sign)? Name + title:
+- Who is our Champion (internal advocate)? Name + title:
+- Is the Champion the same as the Economic Buyer? `yes | no`
+- Notes: …
+
+**Need**
+
+- Is the problem real and documented? `yes | no | unclear`
+- Problem statement (in the client's own words):
+- Urgency: `critical | high | medium | low`
+- What happens if the problem is not solved?
+- Notes: …
+
+**Timeline**
+
+- Does the client have a target start date? `yes | no`
+- Start date: …
+- Target completion / go-live date: …
+- Can we staff this when needed? `yes | no | uncertain`
+- Notes: …
+
+## MEDDIC scoring (for complex / high-value deals)
+
+| Dimension | Score (0–2) | Evidence | Gap |
+|---|---|---|---|
+| **M** Metrics — measurable success criteria defined | | | |
+| **E** Economic Buyer — identified and engaged | | | |
+| **D** Decision Criteria — explicit criteria documented | | | |
+| **D** Decision Process — steps and timeline known | | | |
+| **I** Identified Pain — pain is quantified and acknowledged | | | |
+| **C** Champion — internal advocate identified and active | | | |
+| **TOTAL** | /12 | | |
+
+Score guide: 0 = absent, 1 = partial, 2 = confirmed.
+
+**MEDDIC notes:**
+
+- Economic Buyer access: …
+- Decision criteria source: …
+- Champion engagement level: …
+
+## Five conversational domains audit
+
+Quick yes/no/partial check — ensures we have enough information to scope:
+
+| Domain | Status | Key gaps |
+|---|---|---|
+| **Business** — goals, stakeholders, org structure | yes / partial / no | |
+| **Application** — existing software, integrations, ecosystem | yes / partial / no | |
+| **Data** — flows, storage, compliance (GDPR/HIPAA/PCI) | yes / partial / no | |
+| **Technology** — infrastructure, CI/CD, deployment constraints | yes / partial / no | |
+| **Delivery** — process preferences, communication, QA expectations | yes / partial / no | |
+
+## Competitive landscape
+
+- Are there other providers being evaluated? `yes | no | unknown`
+- Known competitors: …
+- Our differentiators in this context: …
+- Client's primary selection criterion: `price | expertise | speed | relationship | other`
+
+## Strategic fit
+
+- Does this deal align with our target client profile? `yes | partial | no`
+- Is the technology stack within our core competency? `yes | partial | no`
+- Does this deal open a new market, vertical, or reference case? `yes | no`
+- Margin potential: `high | medium | low`
+
+## Win-probability score
+
+| Factor | Weight | Score (1–5) | Weighted |
+|---|---|---|---|
+| Budget confirmed | 20% | | |
+| Champion quality | 25% | | |
+| Need urgency | 20% | | |
+| Technical fit | 15% | | |
+| Relationship strength | 10% | | |
+| Competitive advantage | 10% | | |
+| **Total** | 100% | | **/5.0** |
+
+Convert to 0–100: multiply by 20. Threshold: ≥ 40 → pursue; < 40 → no-go (unless strategic override).
+
+**Win probability:** ____ / 100
+
+## Red flags
+
+List any signals that suggest risk to delivery, relationship, or margin:
+
+- e.g., Decision-maker not present in discovery call — all contact through an intermediary.
+- e.g., Client has already had two previous agency relationships fail on the same project.
+
+## Verdict
+
+**Decision:** `pursue` | `no-go` | `more-info`
+
+**Rationale:** One paragraph justifying the decision.
+
+**If more-info:** Next steps:
+
+| Question | Owner | Due date |
+|---|---|---|
+| | | |
+
+---
+
+## Quality gate
+
+- [ ] All four BANT dimensions assessed and documented.
+- [ ] MEDDIC scored for deals ≥ $50K or with multiple stakeholders.
+- [ ] Five conversational domains audited.
+- [ ] Win probability score computed and justified.
+- [ ] Red flags listed (even if none).
+- [ ] Verdict stated (pursue / no-go / more-info).
+- [ ] If more-info: next steps listed with owner + due date.
+- [ ] Human sign-off on verdict before advancing to Scope.

--- a/templates/scope-template.md
+++ b/templates/scope-template.md
@@ -1,0 +1,151 @@
+---
+id: SCOPE-<DEAL>-001
+deal: <deal-slug>
+client: <Client Name>
+phase: scope
+status: draft         # draft | complete | blocked
+owner: scoping-facilitator
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+workshop_date: YYYY-MM-DD
+workshop_format: remote | in-person | async
+attendees: []
+---
+
+# Scope — <deal-slug>
+
+## Problem statement
+
+> Write this in the client's language, not ours. One to three paragraphs. Distinguish the underlying problem from the stated request.
+
+**Stated request** (what the client asked for):
+
+**Underlying problem** (why they actually need it):
+
+**Business impact of the problem** (what happens if it isn't solved):
+
+**Measurable success criteria** (how the client will know the solution worked):
+
+## Stakeholder map
+
+| Name | Role | Type | Communication | Notes |
+|---|---|---|---|---|
+| | | User / Approver / Champion / Veto | email / Slack / call | |
+
+- **User**: will use the delivered software day-to-day.
+- **Approver**: signs off on deliverables and payment.
+- **Champion**: actively promotes this engagement internally.
+- **Veto**: can block or kill the project (technical, legal, procurement).
+
+## Solution direction
+
+One paragraph describing the solution space we are proposing to explore. Not a technical spec — a direction statement that the client agreed to during the workshop.
+
+## In scope
+
+> List the agreed deliverables, features, and work packages. Use the format: [Phase] — [Epic description].
+
+### Phase 1 — [e.g., Discovery & Design]
+
+| Epic | MoSCoW | Notes |
+|---|---|---|
+| | M / S / C / W | |
+
+### Phase 2 — [e.g., Core Build]
+
+| Epic | MoSCoW | Notes |
+|---|---|---|
+| | M / S / C / W | |
+
+### Phase 3 — [e.g., Integrations & Launch]
+
+| Epic | MoSCoW | Notes |
+|---|---|---|
+| | M / S / C / W | |
+
+**MoSCoW key:** M = Must-have, S = Should-have, C = Could-have, W = Won't-have (this phase).
+
+## Out of scope (explicit)
+
+> This section is as important as the in-scope list. Every item listed here is protected from scope creep without a change request.
+
+- …
+- …
+- …
+
+## Grey zone (to be resolved)
+
+> Items that came up in the workshop but weren't definitively placed in or out of scope. Each must be resolved before the proposal is sent.
+
+| Item | Likely classification | Owner | Due date |
+|---|---|---|---|
+| | in / out / change request | | |
+
+## Non-functional requirements (headline)
+
+> These drive architecture and cost. Capture them now at a headline level; the architect will detail them in the spec.
+
+| NFR | Requirement | Priority |
+|---|---|---|
+| Performance | e.g., Page load < 2s under 1000 concurrent users | H / M / L |
+| Availability | e.g., 99.9% uptime, 4h RTO | H / M / L |
+| Security | e.g., OWASP Top 10, penetration test required | H / M / L |
+| Compliance | e.g., GDPR, HIPAA, PCI-DSS, ISO 27001 | H / M / L |
+| Scalability | e.g., 10× current load within 18 months | H / M / L |
+| Data residency | e.g., EU only, no data outside <region> | H / M / L |
+| Accessibility | e.g., WCAG 2.1 AA | H / M / L |
+| Other | | |
+
+## Dependencies and integrations
+
+| System / Service | Type | Direction | Owner | Known constraints |
+|---|---|---|---|---|
+| | existing system / third-party API / data migration / infrastructure | inbound / outbound / bidirectional | client / provider / third party | |
+
+## Technical constraints
+
+> Any existing technology choices the solution must respect. These become hard constraints for the architect.
+
+- Existing tech stack: …
+- Preferred / mandated languages or frameworks: …
+- Deployment environment: …
+- Infrastructure constraints: …
+- Data migration requirements: …
+
+## Paid discovery recommendation
+
+> For large or technically uncertain scope, recommend a bounded paid discovery phase before the full SOW.
+
+- **Paid discovery recommended?** `yes | no`
+- **Rationale** (what unknowns prevent confident estimation?):
+- **Proposed format** (duration, deliverables, price):
+- **Deliverable at end of paid discovery**: architecture decision record + refined scope + updated estimate.
+
+## Open questions
+
+> Every unresolved question that will affect scope, estimate, or proposal. None may be left unowned.
+
+| ID | Question | Impact if unresolved | Owner | Due date |
+|---|---|---|---|---|
+| OQ-001 | | | | |
+| OQ-002 | | | | |
+
+## Workshop notes
+
+> Anything significant that came out of the workshop that doesn't fit elsewhere — decisions made, concerns raised, exact quotes that should inform the proposal tone.
+
+---
+
+## Quality gate
+
+- [ ] Problem statement distinguishes underlying problem from stated request.
+- [ ] Measurable success criteria stated.
+- [ ] Stakeholder map complete (user, approver, champion, veto identified).
+- [ ] In-scope list complete with MoSCoW classification.
+- [ ] Out-of-scope list is explicit and non-empty.
+- [ ] Grey-zone items listed with owners and due dates.
+- [ ] NFRs captured (at least security, compliance, performance, availability).
+- [ ] All dependencies and integrations listed.
+- [ ] Open questions owned and dated (none left unowned).
+- [ ] Paid discovery recommendation made (yes or no with rationale).
+- [ ] Client sign-off on scope boundary before advancing to Estimate.


### PR DESCRIPTION
## Summary

- Introduces a **Sales Cycle Track** — a pre-delivery commercial workflow for service providers (agencies, consultancies, dev shops) covering **Qualify → Scope → Estimate → Propose → Order**
- Backed by ADR-0006 with rationale, alternatives considered, and industry source citations (BANT/MEDDIC, PERT, PMI SOW best practices, Agile Estimating & Planning)
- The `order.md` **Project Kickoff Brief** is the canonical handoff from sales to delivery, seeding `/discovery:start` or `/spec:start`
- All decisions governed by research from 30+ industry sources (Loopio, PMI, Rocketlane, Relevant Software, Pragmatic Coders, DSDM, SAFe, etc.)

## What's included

| Layer | Files |
|---|---|
| **Methodology** | `docs/sales-cycle.md` — 5-phase definition, method library (BANT/MEDDIC/PERT/MoSCoW/SOW), quality gates, deal state machine |
| **Decision record** | `docs/adr/0006-add-sales-cycle-track-before-discovery.md` |
| **Templates (×6)** | `deal-state`, `qualification`, `scope`, `estimation`, `proposal`, `order` |
| **Agents (×4)** | `sales-qualifier`, `scoping-facilitator`, `estimator`, `proposal-writer` |
| **Commands (×6)** | `/sales:start`, `/sales:qualify`, `/sales:scope`, `/sales:estimate`, `/sales:propose`, `/sales:order` |
| **Skill** | `.claude/skills/sales-cycle/SKILL.md` — conversational conductor (parallel to `orchestrate` and `discovery-sprint`) |
| **Sink + CLAUDE.md** | Updated with `sales/<deal-slug>/` tree, ownership rules, and entry-point documentation |

## Design decisions

- **Separate sibling tree** (`sales/`) rather than extending Stage 1 or the Discovery Track — respects Article II (Separation of Concerns); commercial qualification and concept exploration are different activities
- **Hard human gates** at qualify verdict and order sign-off — agents prepare artifacts, humans make commercial decisions (Article VII)
- **Never sends documents** to external parties — all client-facing actions require explicit human action
- **`no-go` is a valid outcome** at any phase — preserved as historical context, framed as value delivered not failure
- **Paid discovery modelled** as an explicit recommendation in the scope template — resolves the "can't estimate without discovery, can't charge for discovery without a contract" tension

## Test plan

- [ ] Verify `docs/sales-cycle.md` is internally consistent (phases match quality gates, state machine matches `deal-state-template.md` schema)
- [ ] Verify `estimation-template.md` PERT formula is correct (`E = (O + 4M + P) / 6`)
- [ ] Confirm all 4 agents reference the correct templates and phase docs
- [ ] Confirm all 6 commands reference the correct upstream artifact preconditions
- [ ] Confirm `docs/sink.md` ownership table is complete for all 7 new artifact types
- [ ] Confirm `CLAUDE.md` entry points are correct and skip condition is documented

https://claude.ai/code/session_01XMfWFTtRh3dZiFpbqwZ74z

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMfWFTtRh3dZiFpbqwZ74z)_