### PR TITLE
chore(repo): rename Spec Kit → Specorator + repo hygiene

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -42,7 +42,7 @@ The Discovery Track ([`docs/discovery-track.md`](../../docs/discovery-track.md),
 
 - **Frontmatter** uses Claude Code's standard fields: `name`, `description`, `tools`, `model`, optionally `color`.
 - **`description`** is written in the imperative — Claude reads it to decide *when* to spawn this agent.
-- **Body** is the system prompt. Keep it focused; rely on linked docs (`docs/spec-kit.md`, `docs/quality-framework.md`, the relevant template) for detail rather than restating.
+- **Body** is the system prompt. Keep it focused; rely on linked docs (`docs/specorator.md`, `docs/quality-framework.md`, the relevant template) for detail rather than restating.
 - **No agent edits another agent's outputs across stages.** Within a single stage, agents may collaborate on a shared artifact when explicitly sequenced — stage 4 (`/spec:design`) is the canonical example: `ux-designer` (Part A) → `ui-designer` (Part B) → `architect` (Part C) all extend the same `design.md`, each in their named section. Outside such explicit collaborations, if you need a sibling artifact updated, raise a clarification or hand back to the orchestrator.
 
 ## Tool restrictions are deliberate

--- a/.claude/agents/legacy-auditor.md
+++ b/.claude/agents/legacy-auditor.md
@@ -10,7 +10,7 @@ You are the **Legacy Auditor** for a Stock-taking Engagement.
 
 ## Scope
 
-You **investigate and document** what an existing system does. You do not prescribe what a new system should do. Your job is to produce an honest, evidence-based inventory that downstream tracks (Discovery or Spec Kit) can act from.
+You **investigate and document** what an existing system does. You do not prescribe what a new system should do. Your job is to produce an honest, evidence-based inventory that downstream tracks (Discovery or Specorator) can act from.
 
 You own these artifacts:
 

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -6,7 +6,7 @@ model: sonnet
 color: blue
 ---
 
-You are the **Orchestrator** for the Spec Kit workflow.
+You are the **Orchestrator** for the Specorator workflow.
 
 ## Scope
 
@@ -14,7 +14,7 @@ You **route** work; you do not **do** work. Your job is to look at the current s
 
 ## Read first
 
-- `docs/spec-kit.md` (the workflow definition)
+- `docs/specorator.md` (the workflow definition)
 - `memory/constitution.md`
 - `specs/<feature>/workflow-state.md` (the active state)
 

--- a/.claude/agents/portfolio-manager.md
+++ b/.claude/agents/portfolio-manager.md
@@ -1,6 +1,6 @@
 ---
 name: portfolio-manager
-description: Use when managing a portfolio of programs and projects at the X (6-monthly strategic), Y (monthly tactical), or Z (daily operational) cycle cadence defined in P5 Express. Produces portfolio-definition.md, portfolio-roadmap.md, portfolio-progress.md, portfolio-improvements.md, and portfolio-log.md under portfolio/<slug>/. Opt-in role — does not participate in the core Spec Kit 11-stage lifecycle.
+description: Use when managing a portfolio of programs and projects at the X (6-monthly strategic), Y (monthly tactical), or Z (daily operational) cycle cadence defined in P5 Express. Produces portfolio-definition.md, portfolio-roadmap.md, portfolio-progress.md, portfolio-improvements.md, and portfolio-log.md under portfolio/<slug>/. Opt-in role — does not participate in the core Specorator 11-stage lifecycle.
 tools: [Read, Edit, Write, Grep]
 model: sonnet
 color: purple
@@ -20,7 +20,7 @@ You operate at the **portfolio level** — programs and projects in aggregate.
 **You must not:**
 - Edit any file under `specs/<slug>/` — read-only for you.
 - Make prioritisation or stop/start decisions — surface options; the human (Portfolio Sponsor) decides.
-- Participate in Spec Kit lifecycle commands (Stages 1–11).
+- Participate in Specorator lifecycle commands (Stages 1–11).
 - Invent project health — cite the exact source artifact and date for every signal you report.
 
 ## The five P5 Express management documents

--- a/.claude/agents/project-manager.md
+++ b/.claude/agents/project-manager.md
@@ -12,7 +12,7 @@ Your methodology is **P3.Express** (https://p3.express/manual/v2/), specifically
 
 ## Scope
 
-You own **project-level governance** for a single client engagement stored under `projects/<slug>/`. You operate **across** Spec Kit features and Discovery Track sprints — linking to them but never editing their artifacts.
+You own **project-level governance** for a single client engagement stored under `projects/<slug>/`. You operate **across** Specorator features and Discovery Track sprints — linking to them but never editing their artifacts.
 
 You do **not**:
 - Write feature requirements (that is the `pm` agent at Stage 3).

--- a/.claude/commands/portfolio/start.md
+++ b/.claude/commands/portfolio/start.md
@@ -13,7 +13,7 @@ Bootstrap a new P5 Express portfolio. Read [`docs/portfolio-track.md`](../../../
 
 - `$1` — portfolio slug (kebab-case, ≤ 6 words, required). Name the **portfolio scope**, not a specific project.
   - Good: `platform-portfolio`, `client-services-q1`, `internal-tools-portfolio`
-  - Bad: `auth-feature`, `payments-redesign` (those are Spec Kit feature slugs)
+  - Bad: `auth-feature`, `payments-redesign` (those are Specorator feature slugs)
 
 ## Procedure
 

--- a/.claude/commands/project/post.md
+++ b/.claude/commands/project/post.md
@@ -50,4 +50,4 @@ Run this command 3–6 months after `/project:close`, and optionally once a year
 
 - Don't invent benefit metrics — mark as `TBD — awaiting data from <owner>` if unavailable.
 - Don't rewrite or erase the original closure document — append only.
-- Don't confuse post-project benefit tracking with project retrospective (Stage 11 of the Spec Kit) — they are complementary: Stage 11 retrospectives evaluate the delivery process; G01 evaluates the delivered value.
+- Don't confuse post-project benefit tracking with project retrospective (Stage 11 of the Specorator) — they are complementary: Stage 11 retrospectives evaluate the delivery process; G01 evaluates the delivered value.

--- a/.claude/commands/project/start.md
+++ b/.claude/commands/project/start.md
@@ -26,4 +26,4 @@ Bootstrap a new client engagement. Read [`docs/project-track.md`](../../../docs/
 
 - Don't create the four management documents yet — those are created by `/project:initiate`.
 - Don't push or commit — leave that to the user.
-- Don't start a project when the user already has a spec in flight with no client — recommend staying in the Spec Kit instead.
+- Don't start a project when the user already has a spec in flight with no client — recommend staying in the Specorator instead.

--- a/.claude/commands/stock-taking/handoff.md
+++ b/.claude/commands/stock-taking/handoff.md
@@ -1,5 +1,5 @@
 ---
-description: Stock-taking Track — Handoff. Invokes the legacy-auditor to produce stock-taking-inventory.md (the consolidated inventory) and recommend the downstream track (Discovery or Spec Kit).
+description: Stock-taking Track — Handoff. Invokes the legacy-auditor to produce stock-taking-inventory.md (the consolidated inventory) and recommend the downstream track (Discovery or Specorator).
 argument-hint: <project-slug>
 allowed-tools: [Read, Edit, Write, Bash]
 model: sonnet

--- a/.claude/memory/README.md
+++ b/.claude/memory/README.md
@@ -36,4 +36,4 @@ Every other file in this directory is an index or this README.
 - **Treat `feedback_*.md` as binding** unless the constitution overrides it.
 - **Treat `project_*.md` as freshness‑of‑last‑edit.** If it looks stale (e.g. references a release that already shipped), flag it and propose an update — don't silently work around it.
 
-See [`docs/spec-kit.md`](../../docs/spec-kit.md) for where memory fits in the wider workflow, and [`AGENTS.md`](../../AGENTS.md) for the operating rules that govern every agent.
+See [`docs/specorator.md`](../../docs/specorator.md) for where memory fits in the wider workflow, and [`AGENTS.md`](../../AGENTS.md) for the operating rules that govern every agent.

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -10,7 +10,7 @@
 
 Skills are the smallest unit of "we always do it this way". Anything you find yourself explaining to an agent more than twice belongs here.
 
-The catalog spans three families: a **workflow conductor** (the conversational entry to spec-kit), **practice skills** (the recurring techniques agents pull in mid-stage, mattpocock-style), and **operational skills** (the deterministic procedures that gate pre-PR and ADR work).
+The catalog spans three families: a **workflow conductor** (the conversational entry to specorator), **practice skills** (the recurring techniques agents pull in mid-stage, mattpocock-style), and **operational skills** (the deterministic procedures that gate pre-PR and ADR work).
 
 ## Layout
 
@@ -40,7 +40,7 @@ Skills MAY include supporting files (templates, scripts, fixtures) alongside `SK
 
 | Skill | Triggers when… | What it does |
 |---|---|---|
-| [`orchestrate/`](orchestrate/SKILL.md) | "start a feature", "kick off", "from scratch", "what's next?", "orchestrate" | Drives the full 11-stage Spec Kit workflow conversationally. Reads `workflow-state.md`, gates with `AskUserQuestion`, dispatches `/spec:*` commands in sequence. |
+| [`orchestrate/`](orchestrate/SKILL.md) | "start a feature", "kick off", "from scratch", "what's next?", "orchestrate" | Drives the full 11-stage Specorator workflow conversationally. Reads `workflow-state.md`, gates with `AskUserQuestion`, dispatches `/spec:*` commands in sequence. |
 | [`discovery-sprint/`](discovery-sprint/SKILL.md) | "design sprint", "ideation", "brainstorm new product ideas", "blank page", "discovery sprint" | Drives the 5-phase Discovery Track (Frame → Diverge → Converge → Prototype → Validate → Handoff) conversationally. Dispatches the `facilitator` and 6 specialist consults. Output: `chosen-brief.md` that feeds `/spec:idea`. **Skip when a brief already exists — go to `orchestrate`.** |
 
 ### Practice skills (used by stage agents)

--- a/.claude/skills/orchestrate/PHASES.md
+++ b/.claude/skills/orchestrate/PHASES.md
@@ -64,7 +64,7 @@ The slash commands are defined in `.claude/commands/spec/` and own the agent inv
 - **Pre-flight check:** confirm `review.md` verdict is `Approved` or `Approved with conditions` (per the verdict checkboxes in `templates/review-template.md`). If the verdict is `Blocked`, return to Stage 9 (Review) — do not dispatch `/spec:release`.
 
 ### Stage 11 — Learning (`/spec:retro`)
-- **Mandatory:** runs even on clean ships (per `docs/spec-kit.md` §3.11).
+- **Mandatory:** runs even on clean ships (per `docs/specorator.md` §3.11).
 - **Initial:** dispatch as-is.
 
 ## Cross-stage helpers

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: orchestrate
-description: Drive a feature end-to-end through the Spec Kit workflow (idea → retrospective) by gathering scope from the user up front, then dispatching the right stage subagent for each phase, persisting artifacts under specs/<slug>/, and gating between stages with the user. Use when the user wants to start a new feature, run the full workflow, drive something end-to-end, asks "what's next?" on an active feature, or mentions "orchestrate", "kick off", or "from scratch".
+description: Drive a feature end-to-end through the Specorator workflow (idea → retrospective) by gathering scope from the user up front, then dispatching the right stage subagent for each phase, persisting artifacts under specs/<slug>/, and gating between stages with the user. Use when the user wants to start a new feature, run the full workflow, drive something end-to-end, asks "what's next?" on an active feature, or mentions "orchestrate", "kick off", or "from scratch".
 argument-hint: [feature-slug or one-line goal]
 ---
 
 # Orchestrate
 
-You are the conductor of the Spec Kit workflow defined in `docs/spec-kit.md`. Your job is to **sequence** stages and **gate** between them — never to do the stage work yourself. Each stage runs in its specialist subagent (`.claude/agents/`); you only persist state, surface choices, and dispatch.
+You are the conductor of the Specorator workflow defined in `docs/specorator.md`. Your job is to **sequence** stages and **gate** between them — never to do the stage work yourself. Each stage runs in its specialist subagent (`.claude/agents/`); you only persist state, surface choices, and dispatch.
 
 `AskUserQuestion` only works in the main thread. Subagents cannot ask the user anything. So all clarification happens in *your* turn — before and between stages.
 
@@ -14,7 +14,7 @@ You are the conductor of the Spec Kit workflow defined in `docs/spec-kit.md`. Yo
 
 Always start by reading these (they're the contract you're enforcing):
 
-- `docs/spec-kit.md` — the 11-stage workflow definition.
+- `docs/specorator.md` — the 11-stage workflow definition.
 - `memory/constitution.md` — principles every stage must obey.
 - `docs/quality-framework.md` — gate criteria.
 - The active `specs/<slug>/workflow-state.md` (if resuming).
@@ -86,7 +86,7 @@ This is the one place the orchestrator owns artifact-content edits in `workflow-
 For each depth:
 
 - **Depth = Lean**: write minimal **stub artifacts** for `specs/<slug>/idea.md` and `specs/<slug>/research.md` containing one paragraph each: the user's brief (as `idea.md`'s content) and a one-line note (as `research.md`: "Lean depth — discovery skipped; scope captured directly in requirements"). Mark both `complete` in the YAML `artifacts:` map and the human-readable table. Add a `## Skips` line: `Lean depth — idea + research stubbed, full discovery skipped`. The PM agent will read the stubs and proceed with the brief as input.
-- **Depth = Spike**: Spike is "Idea + Research only", so stages 3–10 are never dispatched. Mark all 10 of `requirements.md`, `design.md`, `spec.md`, `tasks.md`, `implementation-log.md`, `test-plan.md`, `test-report.md`, `review.md`, `traceability.md`, `release-notes.md` as `skipped` in the `artifacts:` map and table. Add one `## Skips` entry: `spike depth — research-only run, no implementation`. (Stage 11 retrospective is never skipped per `docs/spec-kit.md` §3.11.)
+- **Depth = Spike**: Spike is "Idea + Research only", so stages 3–10 are never dispatched. Mark all 10 of `requirements.md`, `design.md`, `spec.md`, `tasks.md`, `implementation-log.md`, `test-plan.md`, `test-report.md`, `review.md`, `traceability.md`, `release-notes.md` as `skipped` in the `artifacts:` map and table. Add one `## Skips` entry: `spike depth — research-only run, no implementation`. (Stage 11 retrospective is never skipped per `docs/specorator.md` §3.11.)
 - **Depth = Standard**: nothing to mark.
 
 Bump `last_updated` to today; set `last_agent: orchestrator`. The schema fields (`status`, `current_stage`, top-level enum) are not changed by this step.
@@ -116,7 +116,7 @@ For each stage in the agreed sequence, in order:
      - Stage 7 (Implementation) — `/spec:test` needs implementation tasks marked `done`.
      - Stage 8 (Testing) — `/spec:review` requires `test-report.md` to have no S1/S2 open.
      - Stage 9 (Review) — `/spec:release` requires the review verdict to be `Approved` or `Approved with conditions` (`.claude/commands/spec/release.md` step 1). A `skipped` review has no verdict.
-     - Stage 11 (Learning) — never skipped per `docs/spec-kit.md` §3.11.
+     - Stage 11 (Learning) — never skipped per `docs/specorator.md` §3.11.
 
 ### Step 5 — Stage 4 (Design) special handling
 
@@ -151,5 +151,5 @@ If a subagent returns "blocked — needs human input" (e.g. the analyst can't re
 
 - `PHASES.md` — concrete dispatch templates per stage (what to pass as additional context).
 - `RESUME.md` — resume protocol against `workflow-state.md`.
-- `docs/spec-kit.md` — workflow contract.
+- `docs/specorator.md` — workflow contract.
 - `docs/sink.md` — markdown sink layout.

--- a/.claude/skills/portfolio-track/SKILL.md
+++ b/.claude/skills/portfolio-track/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: portfolio-track
-description: Drive a portfolio management cycle based on P5 Express (https://p5.express/). Detects which cycle is due (X: 6-monthly strategy, Y: monthly review, Z: daily operations) and dispatches /portfolio:x, /portfolio:y, or /portfolio:z. Use when the user says "run portfolio review", "update the portfolio", "check portfolio health", "portfolio cycle", or asks about portfolio status across multiple projects. Opt-in — does not affect the Spec Kit 11-stage lifecycle.
+description: Drive a portfolio management cycle based on P5 Express (https://p5.express/). Detects which cycle is due (X: 6-monthly strategy, Y: monthly review, Z: daily operations) and dispatches /portfolio:x, /portfolio:y, or /portfolio:z. Use when the user says "run portfolio review", "update the portfolio", "check portfolio health", "portfolio cycle", or asks about portfolio status across multiple projects. Opt-in — does not affect the Specorator 11-stage lifecycle.
 argument-hint: [portfolio-slug or "list"]
 ---
 
@@ -92,7 +92,7 @@ Then ask (single `AskUserQuestion`): "Run another cycle now, or done for today?"
 
 - Never run a cycle without user confirmation — always gate through `AskUserQuestion`.
 - Never edit portfolio artifacts directly — the `/portfolio:*` commands own those files.
-- Never modify `specs/` artifacts — portfolio track is read-only on the Spec Kit side.
+- Never modify `specs/` artifacts — portfolio track is read-only on the Specorator side.
 - Never recommend skipping the Portfolio Sponsor review for stop/start decisions — surface them as "Decisions required from Sponsor" and stop.
 - If `portfolio-definition.md` is missing, stop and tell the user to run `/portfolio:start` first.
 

--- a/.claude/skills/project-run/SKILL.md
+++ b/.claude/skills/project-run/SKILL.md
@@ -10,7 +10,7 @@
 
 It sequences specialist commands (`/project:*`) and gates with `AskUserQuestion` at every human-decision point (go/no-go, change approval, sign-off).
 
-This skill does **not** drive Spec Kit feature work (`/spec:*`) or Discovery Track sprints (`/discovery:*`) — it coordinates them from the project management layer.
+This skill does **not** drive Specorator feature work (`/spec:*`) or Discovery Track sprints (`/discovery:*`) — it coordinates them from the project management layer.
 
 ---
 
@@ -35,7 +35,7 @@ Run when:
 ### Phase 0 — Orientation
 
 1. Ask the user to describe the engagement in one paragraph: who is the client, what are they getting, when, and at what cost (if known).
-2. Confirm the user wants the full project management layer (not just a Spec Kit feature). If they're uncertain, explain the difference (see `docs/project-track.md` §1).
+2. Confirm the user wants the full project management layer (not just a Specorator feature). If they're uncertain, explain the difference (see `docs/project-track.md` §1).
 3. Ask for a project slug (engagement-level name, not solution name). Suggest corrections if needed.
 
 ### Phase 1 — Bootstrap and Initiation

--- a/.claude/skills/sales-cycle/SKILL.md
+++ b/.claude/skills/sales-cycle/SKILL.md
@@ -122,5 +122,5 @@ If a subagent returns blocked (e.g., a key MEDDIC dimension cannot be scored), s
 - `docs/sales-cycle.md` — full methodology: methods, quality gates, deal state machine.
 - `docs/sink.md` — artifact location map (including `sales/` tree).
 - `docs/discovery-track.md` — the downstream track for exploratory mandates.
-- `docs/spec-kit.md` — the downstream track for defined mandates.
+- `docs/specorator.md` — the downstream track for defined mandates.
 - `memory/constitution.md` — Article VII: humans own intent, priorities, and acceptance.

--- a/.claude/skills/tracer-bullet/SKILL.md
+++ b/.claude/skills/tracer-bullet/SKILL.md
@@ -32,7 +32,7 @@ For each behavior, draft a slice that:
 
 Sort slices by:
 
-1. **TDD discipline first** (per `docs/spec-kit.md` §3.6) — test tasks for a requirement come before implementation tasks for the same requirement.
+1. **TDD discipline first** (per `docs/specorator.md` §3.6) — test tasks for a requirement come before implementation tasks for the same requirement.
 2. **Dependency-respecting** — no slice unblocked before its dependencies.
 3. **Risk-first when ties** — the slice with the most uncertainty goes first so we learn early.
 4. **Smallest first within a risk tier** — a 2-hour slice before a half-day slice.
@@ -50,7 +50,7 @@ Write `specs/<slug>/tasks.md` from `templates/tasks-template.md`. For each slice
 - Test approach (RED test or characterization test).
 - Risk level (L/M/H — high if anything is unknown).
 - Blocked by (list of slice IDs).
-- Owner (agent role from spec-kit).
+- Owner (agent role from specorator).
 
 Include a **dependency graph** at the top of `tasks.md` (mermaid `flowchart` or simple ASCII).
 
@@ -65,6 +65,6 @@ End with a **Definition of done** section: the user-visible behaviors that prove
 
 ## Rules
 
-- Refer to behaviors and contracts. Avoid file paths and line numbers in the task description (per the `docs/spec-kit.md` discipline).
+- Refer to behaviors and contracts. Avoid file paths and line numbers in the task description (per the `docs/specorator.md` discipline).
 - Use vocabulary from `docs/UBIQUITOUS_LANGUAGE.md` exactly. If you need a new term, coin it via the `ubiquitous-language` skill before writing the task.
 - This skill produces `tasks.md`. The `dev` agent during `/spec:implement` is the one that walks the list with `tdd-cycle`.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: Something in the workflow is broken or behaving unexpectedly
+labels: bug
+---
+
+**What happened?**
+
+<!-- Describe what went wrong. -->
+
+**What did you expect?**
+
+**Steps to reproduce**
+
+1.
+2.
+3.
+
+**Environment**
+
+- Claude Code version:
+- Stage / skill / agent involved:
+- Any relevant `workflow-state.md` excerpt:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest an improvement to the workflow, agents, templates, or skills
+labels: enhancement
+---
+
+**Problem or gap**
+
+<!-- What is missing or painful today? -->
+
+**Proposed solution**
+
+**Alternatives considered**
+
+**Does this touch the constitution? (`memory/constitution.md`)**
+
+- [ ] Yes — an ADR will be needed before implementation
+- [ ] No

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## What does this PR do?
+
+<!-- Briefly describe the change and why. -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature / skill / agent
+- [ ] Documentation or template improvement
+- [ ] Workflow / process change (requires ADR if irreversible)
+- [ ] Other: ___
+
+## Checklist
+
+- [ ] `/verify` gate is green locally
+- [ ] Docs and steering files updated in this PR — no "I'll do it after"
+- [ ] ADR filed if this is an irreversible architectural decision (`/adr:new "<title>"`)
+- [ ] `workflow-state.md` updated if a stage changed
+- [ ] Examples in `examples/` updated or noted as unaffected

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Before doing any non-trivial work, read:
 
 1. **`memory/constitution.md`** — governing principles. Override only with explicit human approval.
 2. **`.claude/memory/MEMORY.md`** — operational memory: workflow rules + project state, indexed.
-3. **`docs/spec-kit.md`** — the full workflow definition.
+3. **`docs/specorator.md`** — the full workflow definition.
 4. **`docs/steering/`** — scoped context (product, tech, ux, quality, operations). Load only what's relevant to your task.
 5. **The current feature's `specs/<feature>/workflow-state.md`** — tells you which stage is active and what's already produced.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to Specorator are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+---
+
+## [v0.2] — 2026-04-27
+
+### Added
+- Skills layer: `orchestrate`, `discovery-sprint`, `stock-taking`, `sales-cycle`, `project-run`, `portfolio-track` workflow-conductor skills
+- Operational bots: `review-bot`, `docs-review-bot`, `plan-recon-bot`, `dep-triage-bot`, `actions-bump-bot`
+- Portfolio Manager Track ([ADR-0009](docs/adr/0009-add-portfolio-manager-role.md)) — P5 Express X/Y/Z cycles for multi-project management
+- Project Manager Track ([ADR-0008](docs/adr/0008-add-project-manager-track.md)) — P3.Express client engagement governance
+- Stock-taking Track ([ADR-0007](docs/adr/0007-add-stock-taking-track-for-legacy-projects.md)) — brownfield/legacy system inventory before ideation
+- Sales Cycle Track ([ADR-0006](docs/adr/0006-add-sales-cycle-track-before-discovery.md)) — Qualify → Scope → Estimate → Propose → Order
+- Discovery Track ([ADR-0005](docs/adr/0005-add-discovery-track-before-stage-1.md)) — Frame → Diverge → Converge → Prototype → Validate → Handoff
+- Branching, verify-gate, and worktree guides (`docs/branching.md`, `docs/verify-gate.md`, `docs/worktrees.md`)
+- `cli-todo` worked example (Stages 1–3 complete)
+
+---
+
+## [v0.1] — 2026-04-26
+
+### Added
+- Workflow definition: 11-stage SDLC lifecycle (Idea → Research → Requirements → Design → Specification → Tasks → Implementation → Testing → Review → Release → Learning)
+- Specialist agents for every stage (analyst, pm, ux-designer, ui-designer, architect, planner, dev, qa, reviewer, release-manager, sre, retrospective)
+- Orchestrator agent for cross-stage routing
+- Markdown templates for every stage artifact
+- EARS notation for functional requirements ([ADR-0003](docs/adr/0003-adopt-ears-for-functional-requirements.md))
+- Traceability matrix scheme (`REQ-X-NNN` → `T-X-NNN` → `TEST-X-NNN`)
+- Quality framework and per-stage gates
+- Architecture Decision Records — ADR-0001 through ADR-0004
+- `memory/constitution.md` — governing principles
+- `docs/steering/` — scoped agent context (product, tech, ux, quality, ops)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Entry point for Claude Code in this repository.
 
 ## What this repo is
 
-A template for **spec-driven, agentic software development**. The workflow itself is the deliverable. See `docs/spec-kit.md` for the full definition and `README.md` for the map of files.
+A template for **spec-driven, agentic software development**. The workflow itself is the deliverable. See `docs/specorator.md` for the full definition and `README.md` for the map of files.
 
 ## How to work here
 
@@ -47,7 +47,7 @@ In both modes:
 2. Each `/spec:*` command spawns its specialist subagent from `.claude/agents/`. Don't bypass — agent scoping is intentional.
 3. When you finish a stage, the slash command updates `workflow-state.md`. Don't edit it by hand mid-workflow.
 
-When you're managing **multiple parallel features** or working as a **service provider** across client portfolios, run the **Portfolio Track** (opt-in, above the Spec Kit):
+When you're managing **multiple parallel features** or working as a **service provider** across client portfolios, run the **Portfolio Track** (opt-in, above the Specorator):
 
 - **Conversational:** say "run portfolio review", "update the portfolio", or "check portfolio health" and the [`portfolio-track`](.claude/skills/portfolio-track/SKILL.md) skill will detect the active portfolio and dispatch the right cycle.
 - **Manual:** `/portfolio:start <slug>` (bootstrap), then `/portfolio:x` (6-monthly strategy), `/portfolio:y` (monthly review), `/portfolio:z` (daily ops). See [`docs/portfolio-track.md`](docs/portfolio-track.md) and [ADR-0009](docs/adr/0009-add-portfolio-manager-role.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Read these in order:
 1. [`README.md`](./README.md) — what this repo is and where everything lives.
 2. [`AGENTS.md`](./AGENTS.md) — operating rules every agent (and human) follows.
 3. [`memory/constitution.md`](./memory/constitution.md) — governing principles. Override only with an ADR.
-4. [`docs/spec-kit.md`](./docs/spec-kit.md) — the full workflow definition.
+4. [`docs/specorator.md`](./docs/specorator.md) — the full workflow definition.
 5. [`.claude/memory/MEMORY.md`](./.claude/memory/MEMORY.md) — operational memory (workflow rules + project state).
 
 ## How the contribution workflow works

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Spec Kit — Agentic Development Workflow
+# Specorator — Agentic Development Workflow
 
-**Build software the right way with AI.** Spec Kit is a ready-to-use workflow template that keeps humans in charge of *what* to build while AI agents handle the heavy lifting of *how*.
+![Version](https://img.shields.io/badge/version-v0.2-blue) ![License](https://img.shields.io/badge/license-MIT-green)
+
+**Build software the right way with AI.** Specorator is a ready-to-use workflow template that keeps humans in charge of *what* to build while AI agents handle the heavy lifting of *how*.
 
 > **Status:** v0.2 — Foundation + Skills layer. Intentionally generic and starting-point-y — fork it, adapt it, make it yours.
 
@@ -8,7 +10,7 @@
 
 ## What is this?
 
-Most AI coding tools jump straight to writing code — often the wrong code. Spec Kit flips that: **specs first, code second**.
+Most AI coding tools jump straight to writing code — often the wrong code. Specorator flips that: **specs first, code second**.
 
 Every feature follows a structured journey — understand the problem, research the options, write clear requirements, design a solution, *then* build it. AI agents (powered by Claude) assist at every step while staying in their lane. You remain in charge of intent, priorities, and sign-off.
 
@@ -261,7 +263,7 @@ The artifact format (Markdown files in `specs/<feature>/`) and the ID scheme (`R
 
 | Path | What it is |
 |---|---|
-| [`docs/spec-kit.md`](docs/spec-kit.md) | Full workflow definition — read this before any non-trivial work |
+| [`docs/specorator.md`](docs/specorator.md) | Full workflow definition — read this before any non-trivial work |
 | [`docs/discovery-track.md`](docs/discovery-track.md) | Discovery Track detail and phase-by-phase guide |
 | [`docs/workflow-overview.md`](docs/workflow-overview.md) | One-page visual + cheat sheet + slash command list |
 | [`docs/quality-framework.md`](docs/quality-framework.md) | Quality dimensions, gates, and Definition of Done per stage |

--- a/agents/operational/docs-review-bot/README.md
+++ b/agents/operational/docs-review-bot/README.md
@@ -33,5 +33,5 @@ On a young repo (< 6 months) the bot mostly finds dead links from rapid renames.
 
 ## See also
 
-- [`docs/spec-kit.md`](../../../docs/spec-kit.md) — the source of truth for what each doc *should* say.
+- [`docs/specorator.md`](../../../docs/specorator.md) — the source of truth for what each doc *should* say.
 - [`feedback_docs_with_pr.md`](../../../.claude/memory/feedback_docs_with_pr.md) — the rule that prevents most drift in the first place.

--- a/docs/adr/0002-adopt-spec-driven-development.md
+++ b/docs/adr/0002-adopt-spec-driven-development.md
@@ -15,7 +15,7 @@ Accepted
 
 ## Context
 
-LLM coding agents are fast but fail predictably when given vague intent. They confabulate requirements, drift from design, and produce plausible-but-wrong code. Several mature patterns address this — GitHub Spec Kit, Amazon Kiro, BMAD-METHOD — and converge on the same insight: **treat specifications as the source of truth and code as their artifact**.
+LLM coding agents are fast but fail predictably when given vague intent. They confabulate requirements, drift from design, and produce plausible-but-wrong code. Several mature patterns address this — GitHub Specorator, Amazon Kiro, BMAD-METHOD — and converge on the same insight: **treat specifications as the source of truth and code as their artifact**.
 
 Alternatives considered:
 
@@ -47,14 +47,14 @@ Per-feature work product lives at `specs/<feature-slug>/`. State is tracked in `
 - Pros: rich role separation, sharded artifacts.
 - Cons: heavy for small teams, persona explosion duplicates concerns.
 
-### Option C — GitHub Spec Kit flow (constitution → specify → plan → tasks → implement)
+### Option C — GitHub Specorator flow (constitution → specify → plan → tasks → implement)
 
 - Pros: production-grade tool support, slash-command UX.
 - Cons: doesn't natively cover UX/UI, testing, release, retrospective.
 
 ### Option D — Eleven-stage hybrid (chosen)
 
-- Pros: full SDLC coverage; explicit testing, review, release, retro stages; compatible with Spec Kit / Kiro / BMAD conventions; agent-friendly because each stage has narrow scope.
+- Pros: full SDLC coverage; explicit testing, review, release, retro stages; compatible with Specorator / Kiro / BMAD conventions; agent-friendly because each stage has narrow scope.
 - Cons: more stages than strictly necessary for trivial work — mitigated by explicit "skip" support in `workflow-state.md`.
 
 ## Consequences
@@ -82,6 +82,6 @@ Per-feature work product lives at `specs/<feature-slug>/`. State is tracked in `
 
 ## References
 
-- [GitHub Spec Kit](https://github.com/github/spec-kit)
+- [GitHub Specorator](https://github.com/github/specorator)
 - [Amazon Kiro — Specs](https://kiro.dev/docs/specs/)
 - [BMAD-METHOD](https://github.com/bmad-code-org/BMAD-METHOD)

--- a/docs/adr/0003-adopt-ears-for-functional-requirements.md
+++ b/docs/adr/0003-adopt-ears-for-functional-requirements.md
@@ -27,7 +27,7 @@ EARS (Easy Approach to Requirements Syntax, Mavin et al., Rolls-Royce, 2009) con
 
 EARS clauses map 1:1 to acceptance tests, which makes traceability and verification mechanical.
 
-Kiro mandates EARS. GitHub Spec Kit has it as an open RFC. The pattern is now the de facto standard for spec-driven workflows.
+Kiro mandates EARS. GitHub Specorator has it as an open RFC. The pattern is now the de facto standard for spec-driven workflows.
 
 ## Decision
 

--- a/docs/adr/0005-add-discovery-track-before-stage-1.md
+++ b/docs/adr/0005-add-discovery-track-before-stage-1.md
@@ -19,7 +19,7 @@ Accepted
 
 ## Context
 
-The Spec Kit defined in [`docs/spec-kit.md`](../spec-kit.md) starts at **Stage 1 — Idea**, whose owning agent (`analyst`) reads a brief and structures it into `idea.md`. The brief itself is assumed to exist: there is no stage in the kit for *generating* a brief, *choosing between candidate concepts*, or *de-risking the riskiest assumption* before a feature folder is opened.
+The Specorator defined in [`docs/specorator.md`](../specorator.md) starts at **Stage 1 — Idea**, whose owning agent (`analyst`) reads a brief and structures it into `idea.md`. The brief itself is assumed to exist: there is no stage in the kit for *generating* a brief, *choosing between candidate concepts*, or *de-risking the riskiest assumption* before a feature folder is opened.
 
 In practice, teams that adopt this kit are arriving with two different shapes of upstream work:
 
@@ -28,7 +28,7 @@ In practice, teams that adopt this kit are arriving with two different shapes of
 
 Existing literature treats these as two distinct activities:
 
-- The **Double Diamond** (Design Council, 2005) splits a project into two diamonds — *Discover / Define* and *Develop / Deliver* — with divergent then convergent thinking in each. The Spec Kit today only models the second diamond. ([Design Council — Framework for Innovation](https://www.designcouncil.org.uk/our-resources/framework-for-innovation/))
+- The **Double Diamond** (Design Council, 2005) splits a project into two diamonds — *Discover / Define* and *Develop / Deliver* — with divergent then convergent thinking in each. The Specorator today only models the second diamond. ([Design Council — Framework for Innovation](https://www.designcouncil.org.uk/our-resources/framework-for-innovation/))
 - The **Google Design Sprint** (Knapp et al., 2016; AJ&Smart's 4-day "2.0" variant, 2018) is a timeboxed first-diamond ritual: Map → Sketch → Decide → Prototype → Test, ending with evidence about whether a concept is worth pursuing. ([GV — The Design Sprint](https://www.gv.com/sprint/), [AJ&Smart — Design Sprint 2.0](https://ajsmart.com/design-sprint-2-0/))
 - **Continuous Discovery** (Torres, *Continuous Discovery Habits*, 2021) and the **Opportunity Solution Tree** model the activity of converting an outcome into opportunities into solutions into experiments — a portfolio activity that is structurally upstream of "feature." ([Product Talk — Opportunity Solution Trees](https://www.producttalk.org/opportunity-solution-trees/))
 - Game design adds a complementary lens: **MDA** (Hunicke, LeBlanc, Zubek, 2004) — Mechanics, Dynamics, Aesthetics — and **Schell's 100 Lenses** (Schell, *The Art of Game Design*, 2008) frame ideation around what experience the user actually has, which is exactly the gap that JTBD-only framing leaves. ([MDA paper](https://users.cs.northwestern.edu/~hunicke/MDA.pdf), [Schell — Art of Game Design](https://schellgames.com/art-of-game-design))
@@ -136,7 +136,7 @@ How will we know this decision is being honoured?
 ## References
 
 - Constitution: [`memory/constitution.md`](../../memory/constitution.md) — Articles II (Separation of Concerns), III (Incremental Progression), VI (Agent Specialisation), VII (Human Oversight).
-- [`docs/spec-kit.md`](../spec-kit.md) — the 11-stage workflow this track precedes.
+- [`docs/specorator.md`](../specorator.md) — the 11-stage workflow this track precedes.
 - [`docs/discovery-track.md`](../discovery-track.md) — the full methodology, phase definitions, and source list.
 - [ADR-0002](0002-adopt-spec-driven-development.md) — the meta-decision that artifacts precede code; this ADR extends it: discovery precedes artifacts.
 - [ADR-0004](0004-adopt-operational-agents-alongside-lifecycle-agents.md) — the precedent for sibling agent classes outside the lifecycle table.

--- a/docs/adr/0006-add-sales-cycle-track-before-discovery.md
+++ b/docs/adr/0006-add-sales-cycle-track-before-discovery.md
@@ -19,7 +19,7 @@ Accepted
 
 ## Context
 
-The Spec Kit workflow (Stages 1–11) and the Discovery Track (pre-Stage 1) both assume that the decision to build something has already been made and a project mandate exists. They are delivery-side workflows.
+The Specorator workflow (Stages 1–11) and the Discovery Track (pre-Stage 1) both assume that the decision to build something has already been made and a project mandate exists. They are delivery-side workflows.
 
 Service providers — development agencies, consulting firms, independent studios — face a structurally prior problem: **they first need to win the project**. Before a spec folder is opened, before a discovery sprint is run, a commercial process must happen:
 
@@ -142,7 +142,7 @@ How will we know this decision is being honoured?
 ## References
 
 - Constitution: [`memory/constitution.md`](../../memory/constitution.md) — Articles II (Separation of Concerns), III (Incremental Progression), VI (Agent Specialisation), VII (Human Oversight), IX (Reversibility).
-- [`docs/spec-kit.md`](../spec-kit.md) — the 11-stage delivery workflow this track precedes.
+- [`docs/specorator.md`](../specorator.md) — the 11-stage delivery workflow this track precedes.
 - [`docs/discovery-track.md`](../discovery-track.md) — the discovery track this track may feed into.
 - [ADR-0005](0005-add-discovery-track-before-stage-1.md) — the precedent for a sibling pre-stage track.
 - [ADR-0004](0004-adopt-operational-agents-alongside-lifecycle-agents.md) — the precedent for sibling agent classes outside the lifecycle table.

--- a/docs/adr/0007-add-stock-taking-track-for-legacy-projects.md
+++ b/docs/adr/0007-add-stock-taking-track-for-legacy-projects.md
@@ -19,7 +19,7 @@ Accepted
 
 ## Context
 
-Both the Spec Kit (Stages 1–11) and the Discovery Track (ADR-0005) assume the team is starting from a blank canvas with respect to prior system reality. Stage 2 (Research) can surface *alternatives*, and the Discovery Track can surface *opportunities*, but neither provides a structured way to answer: **"what exactly do we already have?"**
+Both the Specorator (Stages 1–11) and the Discovery Track (ADR-0005) assume the team is starting from a blank canvas with respect to prior system reality. Stage 2 (Research) can surface *alternatives*, and the Discovery Track can surface *opportunities*, but neither provides a structured way to answer: **"what exactly do we already have?"**
 
 In practice, many projects are not greenfield. A new product must be built on top of, alongside, or as a replacement for one or more existing systems. The inputs to any subsequent planning work are only as good as the team's understanding of:
 
@@ -36,7 +36,7 @@ Without this inventory, teams risk:
 3. **Data migration under-estimation** — the classic "just migrate the data" assumption that blows budgets.
 4. **Requirements that repeat known failures** — missing the lessons already encoded in the existing system's painful workarounds.
 
-The Discovery Track (ADR-0005) solves "what should we build?" The Spec Kit solves "how do we build it correctly?" This ADR introduces the **Stock-taking Track** to solve "what do we already have?" — a prerequisite for both when legacy context exists.
+The Discovery Track (ADR-0005) solves "what should we build?" The Specorator solves "how do we build it correctly?" This ADR introduces the **Stock-taking Track** to solve "what do we already have?" — a prerequisite for both when legacy context exists.
 
 The track is informed by established practices for legacy assessment:
 
@@ -47,7 +47,7 @@ The track is informed by established practices for legacy assessment:
 - **Strangler Fig pattern** context-mapping for identifying what to replace vs. retain. ([Fowler, *StranglerFigApplication*, 2004](https://martinfowler.com/bliki/StranglerFigApplication.html))
 - **Technical Debt Quadrant** for classifying debt along deliberate/inadvertent and reckless/prudent axes. ([Fowler, *Technical Debt Quadrant*, 2009](https://martinfowler.com/bliki/TechnicalDebtQuadrant.html))
 
-This is a **discovery-of-what-exists** activity, structurally different from both the *discovery-of-what-to-build* activity (Discovery Track) and the *specification-of-what-to-build* activity (Spec Kit). Merging it into either would violate **Article II — Separation of Concerns**.
+This is a **discovery-of-what-exists** activity, structurally different from both the *discovery-of-what-to-build* activity (Discovery Track) and the *specification-of-what-to-build* activity (Specorator). Merging it into either would violate **Article II — Separation of Concerns**.
 
 ## Decision
 
@@ -61,13 +61,13 @@ We adopt a **Stock-taking Track** as a sibling to the 11-stage lifecycle workflo
   | 1 | Scope | Define what is being inventoried — systems, processes, boundaries, stakeholders, and what is explicitly out of scope | `scope.md` |
   | 2 | Audit | Investigate in depth — processes, use-cases, integrations, data landscape, pain points, technical debt | `audit.md` |
   | 3 | Synthesize | Distil findings into a structured inventory — gap analysis, constraints, opportunities, migration considerations | `synthesis.md` |
-  | — | Handoff | Produce the consolidated `stock-taking-inventory.md` and recommend the next track (Discovery or Spec Kit) | `stock-taking-inventory.md` |
+  | — | Handoff | Produce the consolidated `stock-taking-inventory.md` and recommend the next track (Discovery or Specorator) | `stock-taking-inventory.md` |
 
 - The track is owned by a single specialist agent, **`legacy-auditor`**, which shadows the human role of a Business/Systems Analyst or Enterprise Architect engaged in a legacy assessment. The agent carries all three phases; no facilitator-over-specialist split is used here because the domain expertise is concentrated (unlike the Discovery Track's multi-discipline divergence).
 
 - Slash commands `/stock:start`, `/stock:scope`, `/stock:audit`, `/stock:synthesize`, `/stock:handoff` are added under `.claude/commands/stock-taking/`. Conversational entry is the `stock-taking` skill.
 
-- The track ends with `/stock:handoff` writing `stock-taking-inventory.md`. The inventory's `recommended_next` field declares whether the team should proceed to the Discovery Track (`/discovery:start`) or directly to the Spec Kit (`/spec:start` + `/spec:idea`).
+- The track ends with `/stock:handoff` writing `stock-taking-inventory.md`. The inventory's `recommended_next` field declares whether the team should proceed to the Discovery Track (`/discovery:start`) or directly to the Specorator (`/spec:start` + `/spec:idea`).
 
 - A stock-taking engagement is **always project-level, not feature-level**. It scopes to a system or system cluster. Multiple features may emerge from a single engagement and fan out into multiple `specs/<feature>/` or `discovery/<sprint>/` folders.
 
@@ -115,21 +115,21 @@ Add `stock-taking/<project-slug>/` at the repo root. New `/stock:*` slash comman
 ### Neutral
 
 - The `stock-taking/` directory sits at the repo root, parallel to `specs/` and `discovery/`. Its naming ("stock-taking") deliberately signals the *activity*, not the output domain.
-- The Handoff phase is the *only* link between the stock-taking tree and the downstream trees. No `specs/<slug>/` or `discovery/<sprint>/` directory exists before handoff. After handoff, the inventory is referenced from `chosen-brief.md` (if proceeding via Discovery) or `idea.md` (if proceeding directly to Spec Kit) `inputs:` frontmatter.
+- The Handoff phase is the *only* link between the stock-taking tree and the downstream trees. No `specs/<slug>/` or `discovery/<sprint>/` directory exists before handoff. After handoff, the inventory is referenced from `chosen-brief.md` (if proceeding via Discovery) or `idea.md` (if proceeding directly to Specorator) `inputs:` frontmatter.
 
 ## Compliance
 
 How will we know this decision is being honoured?
 
 - **The reviewer** (Stage 9) flags any `idea.md` or `frame.md` that references an existing system but lacks `inputs: [stock-taking/<project-slug>/stock-taking-inventory.md]` in its frontmatter — the inventory should be the input, not tribal knowledge.
-- **The orchestrator** detects active stock-taking engagements (status `active` in `stock-taking-state.md`) and surfaces them before routing to the Discovery Track or Spec Kit.
+- **The orchestrator** detects active stock-taking engagements (status `active` in `stock-taking-state.md`) and surfaces them before routing to the Discovery Track or Specorator.
 - **The `legacy-auditor` agent** enforces its own boundary: it does not write to `specs/<feature>/` or `discovery/<sprint>/`, and does not author requirements, design decisions, or solution proposals. Findings that look like requirements are captured as "candidate requirements" in `synthesis.md` and handed off to the appropriate downstream track.
 - **The retrospective** (Stage 11) includes a stock-taking section when the feature originated from a legacy-system engagement, capturing whether the inventory was accurate and what was missed.
 
 ## References
 
 - Constitution: [`memory/constitution.md`](../../memory/constitution.md) — Articles II (Separation of Concerns), III (Incremental Progression), VI (Agent Specialisation), VII (Human Oversight).
-- [`docs/spec-kit.md`](../spec-kit.md) — the 11-stage workflow this track precedes.
+- [`docs/specorator.md`](../specorator.md) — the 11-stage workflow this track precedes.
 - [`docs/discovery-track.md`](../discovery-track.md) — the Discovery Track this track may precede.
 - [`docs/stock-taking-track.md`](../stock-taking-track.md) — the full methodology for this track.
 - [ADR-0002](0002-adopt-spec-driven-development.md) — specs are source of truth; this ADR extends it: inventory precedes specs when legacy systems are involved.

--- a/docs/adr/0008-add-project-manager-track.md
+++ b/docs/adr/0008-add-project-manager-track.md
@@ -19,7 +19,7 @@ Accepted
 
 ## Context
 
-The Spec Kit (Stages 1–11) and the Discovery Track (ADR-0005) together address the full software development lifecycle — from blank-page ideation through feature delivery. Both tracks are scoped to **product** concerns: what to build, how to build it, and whether it was built correctly.
+The Specorator (Stages 1–11) and the Discovery Track (ADR-0005) together address the full software development lifecycle — from blank-page ideation through feature delivery. Both tracks are scoped to **product** concerns: what to build, how to build it, and whether it was built correctly.
 
 Teams using this template in a **service-provider context** — i.e., building software for clients rather than for an internal product — have a set of concerns that neither track addresses:
 
@@ -78,7 +78,7 @@ We adopt a **Project Manager Track** as an opt-in sibling to the 11-stage lifecy
 
   The P3.Express design decision: risks, issues, change requests, and lessons all share a **single Follow-Up Register** (`followup-register.md`). There are no separate `risk-register.md`, `issue-log.md`, or `change-log.md` files.
 
-- The track is **opt-in**. Teams using the Spec Kit for internal product development and teams with a brief already established may skip it entirely. No existing workflow is affected.
+- The track is **opt-in**. Teams using the Specorator for internal product development and teams with a brief already established may skip it entirely. No existing workflow is affected.
 - State lives in **`projects/<slug>/project-state.md`**, owned by `/project:*` commands.
 - The project-manager agent carries a **`WebSearch` and `WebFetch`** tool because client-side research (market data, public company information, technology scouting) is a legitimate PM task in a service-provider context. All other lifecycle agents lack this tool.
 - Feature work (`specs/<slug>/`) and discovery work (`discovery/<slug>/`) remain owned by their own agents. The `project-manager` **links to** but does not rewrite those artifacts.

--- a/docs/adr/0009-add-portfolio-manager-role.md
+++ b/docs/adr/0009-add-portfolio-manager-role.md
@@ -16,7 +16,7 @@ Accepted
 
 ## Context
 
-The Spec Kit models one feature's journey from idea to retrospective (Stages 1–11). Organisations using the kit as a **service provider** or running **multiple parallel features** need a second level of management — one that looks across the portfolio of programs and projects rather than within a single feature.
+The Specorator models one feature's journey from idea to retrospective (Stages 1–11). Organisations using the kit as a **service provider** or running **multiple parallel features** need a second level of management — one that looks across the portfolio of programs and projects rather than within a single feature.
 
 P5 Express (https://p5.express/) is a minimalist, practical portfolio management system. Its philosophy matches the kit's own design principles: small surface area, clear cadences, named documents, named roles. It defines:
 
@@ -28,7 +28,7 @@ The existing kit's design prohibits adding workflow layers without an ADR (AGENT
 
 ## Decision
 
-Add an **opt-in portfolio track** parallel to the Spec Kit lifecycle (Stages 1–11) and the Discovery Track (pre-stage 1). It:
+Add an **opt-in portfolio track** parallel to the Specorator lifecycle (Stages 1–11) and the Discovery Track (pre-stage 1). It:
 
 - Lives at `portfolio/<portfolio-slug>/` at the repo root, parallel to `specs/` and `discovery/`.
 - Is driven by four slash commands (`/portfolio:start`, `/portfolio:x`, `/portfolio:y`, `/portfolio:z`) and a conversational conductor skill (`portfolio-track`).
@@ -39,7 +39,7 @@ Add an **opt-in portfolio track** parallel to the Spec Kit lifecycle (Stages 1�
 The track is:
 
 - **Opt-in** — users who never invoke `/portfolio:start` are not affected. No changes to existing workflow commands or agents.
-- **Non-invasive** — read-only access to the Spec Kit artifact tree.
+- **Non-invasive** — read-only access to the Specorator artifact tree.
 - **Cadence-driven** — separate commands for each cycle prevent conflating strategic (6-monthly) with operational (daily) work.
 - **P5 Express–aligned** — activity names (X1/X2/X3, Y1–Y4, Z1–Z3) and the five documents follow the P5 Express manual directly.
 
@@ -48,12 +48,12 @@ The track is:
 1. **Embed portfolio concerns in the orchestrator.** Rejected — the orchestrator scopes to one feature; mixing portfolio-level concerns would violate Article II (Separation of Concerns) of the constitution.
 2. **Use an external tool (Jira roadmap, ProductPlan, etc.).** Rejected — the kit's philosophy is all artifacts in the repo as versioned markdown; externalising would break traceability and the single-source-of-truth principle.
 3. **Build a custom portfolio methodology.** Rejected — P5 Express already exists, is minimalist, fits the kit's philosophy, and is free and open under Creative Commons Attribution. No benefit to reinventing it.
-4. **Make portfolio management a stage in the Spec Kit lifecycle.** Rejected — portfolio management is orthogonal to feature development; it operates at a different level of abstraction, a different cadence, and a different ownership model. It must not become a mandatory gate on feature delivery.
+4. **Make portfolio management a stage in the Specorator lifecycle.** Rejected — portfolio management is orthogonal to feature development; it operates at a different level of abstraction, a different cadence, and a different ownership model. It must not become a mandatory gate on feature delivery.
 
 ## Consequences
 
 **Positive:**
-- Service providers and multi-team organisations get a structured, cadence-aware layer above the Spec Kit with no changes to the existing 11-stage workflow.
+- Service providers and multi-team organisations get a structured, cadence-aware layer above the Specorator with no changes to the existing 11-stage workflow.
 - Portfolio artifacts are versioned in the repo alongside feature specs, preserving the single-repo philosophy.
 - The `portfolio-manager` agent synthesises health signals from many `workflow-state.md` files without duplicating or modifying them.
 - P5 Express's Portfolio Sponsor role reinforces the constitution's Article VII (Human Oversight): humans own intent, priorities, and acceptance.
@@ -61,7 +61,7 @@ The track is:
 **Negative:**
 - The template directory and `.claude/` directories grow: 1 agent, 4 commands, 6 templates, 1 skill, 1 track doc.
 - Users must explicitly invoke `/portfolio:start`; there is no auto-discovery of existing `specs/` projects into a portfolio.
-- Portfolio documents are not linked into the Spec Kit traceability chain (REQ → SPEC → T → code → TEST). They operate at a higher level and use their own ID scheme (P-NNN, I-NNN).
+- Portfolio documents are not linked into the Specorator traceability chain (REQ → SPEC → T → code → TEST). They operate at a higher level and use their own ID scheme (P-NNN, I-NNN).
 
 ## References
 

--- a/docs/discovery-track.md
+++ b/docs/discovery-track.md
@@ -2,7 +2,7 @@
 
 **Version:** 0.1 · **Status:** Draft · **Stability:** Opt-in · **ADR:** [ADR-0005](adr/0005-add-discovery-track-before-stage-1.md)
 
-A pre-workflow track for teams arriving at the Spec Kit with a **blank page** rather than a brief. Produces a vetted, prototype-validated concept that feeds `/spec:idea` as input.
+A pre-workflow track for teams arriving at the Specorator with a **blank page** rather than a brief. Produces a vetted, prototype-validated concept that feeds `/spec:idea` as input.
 
 > If you already have a brief, **skip this track** and go straight to `/spec:start` + `/spec:idea`.
 
@@ -21,7 +21,7 @@ A pre-workflow track for teams arriving at the Spec Kit with a **blank page** ra
 
 ## 1. Why a Discovery Track
 
-The Spec Kit's eleven stages assume a brief exists. The **Discovery Track** is what produces that brief.
+The Specorator's eleven stages assume a brief exists. The **Discovery Track** is what produces that brief.
 
 It applies when:
 
@@ -240,7 +240,7 @@ A sprint exits Phase 5 with one of three terminal states:
 - **No-go** — every candidate failed validation; the sprint records what was learned and closes. This is a successful sprint outcome.
 - **Pivot** — the validation surfaced a different opportunity than what was framed. The sprint either re-runs Phase 1 with the new framing or closes and a fresh sprint is opened.
 
-The Handoff phase is **not optional** when the outcome is Go. A "soft handoff" (one channel message saying "we picked X, build it") is exactly the loss-of-context the Spec Kit exists to prevent.
+The Handoff phase is **not optional** when the outcome is Go. A "soft handoff" (one channel message saying "we picked X, build it") is exactly the loss-of-context the Specorator exists to prevent.
 
 ---
 

--- a/docs/portfolio-track.md
+++ b/docs/portfolio-track.md
@@ -2,7 +2,7 @@
 
 **Version:** 0.1 · **Status:** Draft · **Stability:** Opt-in · **ADR:** [ADR-0009](adr/0009-add-portfolio-manager-role.md)
 
-An opt-in management track for organisations running **multiple parallel features** or acting as **service providers** managing portfolios on behalf of clients. It operates above the Spec Kit 11-stage lifecycle — one portfolio manages many features — and produces the five management documents defined by [P5 Express](https://p5.express/).
+An opt-in management track for organisations running **multiple parallel features** or acting as **service providers** managing portfolios on behalf of clients. It operates above the Specorator 11-stage lifecycle — one portfolio manages many features — and produces the five management documents defined by [P5 Express](https://p5.express/).
 
 > If you are managing a single feature, **skip this track** and go straight to `/spec:start`.
 
@@ -14,18 +14,18 @@ An opt-in management track for organisations running **multiple parallel feature
 4. [The five documents](#4-the-five-documents)
 5. [Roles](#5-roles)
 6. [Quality gates](#6-quality-gates)
-7. [Connecting to the Spec Kit](#7-connecting-to-the-spec-kit)
+7. [Connecting to the Specorator](#7-connecting-to-the-specorator)
 8. [Sources and further reading](#8-sources-and-further-reading)
 
 ---
 
 ## 1. Why a Portfolio Track
 
-The Spec Kit's eleven stages assume a single feature in flight. Once you're managing **multiple features in parallel** — for your own product, for clients, or across business units — you need a second level of management that looks across the whole portfolio rather than inside any one feature.
+The Specorator's eleven stages assume a single feature in flight. Once you're managing **multiple features in parallel** — for your own product, for clients, or across business units — you need a second level of management that looks across the whole portfolio rather than inside any one feature.
 
 The Portfolio Track applies when:
 
-- You are a **service provider** and each client engagement is a Spec Kit feature running in parallel with others.
+- You are a **service provider** and each client engagement is a Specorator feature running in parallel with others.
 - Your organisation has a **portfolio manager role** (or equivalent) responsible for value delivery across multiple features or programs.
 - You need to answer questions like: "Which projects should we stop? Which should we accelerate? Where are resources contended across projects?"
 - You need to produce **stakeholder communications** summarising overall portfolio health on a regular cadence.
@@ -40,7 +40,7 @@ The track is opinionated about three things:
 
 1. **Cadence-driven.** Strategic decisions (stop/start/pivot) belong to a 6-monthly review cycle; progress signals belong to a monthly review cycle; operational decisions (resource balance, follow-ups) belong to a daily cycle. Mixing cadences produces noise.
 2. **Surfaces, never decides.** The `portfolio-manager` agent surfaces data and proposes options; the **Portfolio Sponsor** (always human) makes stop/start/pivot decisions. This enforces Article VII of the constitution (Human Oversight).
-3. **Read-only on the Spec Kit side.** The portfolio track reads `specs/*/workflow-state.md` and other spec artifacts for health signals, but never modifies them. The boundary is hard by design (agent tool scope).
+3. **Read-only on the Specorator side.** The portfolio track reads `specs/*/workflow-state.md` and other spec artifacts for health signals, but never modifies them. The boundary is hard by design (agent tool scope).
 
 ---
 
@@ -178,14 +178,14 @@ Each cycle produces documents that must meet these criteria before the cycle is 
 
 ---
 
-## 7. Connecting to the Spec Kit
+## 7. Connecting to the Specorator
 
-The portfolio track and the Spec Kit are **parallel, non-overlapping layers**.
+The portfolio track and the Specorator are **parallel, non-overlapping layers**.
 
 ```
 Portfolio Track (portfolio/<slug>/)
     ↕ reads only (health signals)
-Spec Kit (specs/<feature-slug>/)
+Specorator (specs/<feature-slug>/)
     ↕ reads only (brief from chosen-brief.md, optional)
 Discovery Track (discovery/<sprint-slug>/)
 ```
@@ -210,5 +210,5 @@ Discovery Track (discovery/<sprint-slug>/)
 - [P5 Express manual](https://p5.express/manual/) — cycle activities (X1/X2/X3, Y1–Y4, Z1–Z3) and document definitions.
 - [ADR-0009](adr/0009-add-portfolio-manager-role.md) — the decision record for adding this track.
 - [ADR-0005](adr/0005-add-discovery-track-before-stage-1.md) — the Discovery Track ADR (same opt-in parallel-track pattern).
-- `docs/spec-kit.md` — the Spec Kit 11-stage lifecycle that the portfolio track sits above.
+- `docs/specorator.md` — the Specorator 11-stage lifecycle that the portfolio track sits above.
 - `docs/sink.md` — where all artifacts (including `portfolio/`) live in the repo.

--- a/docs/project-track.md
+++ b/docs/project-track.md
@@ -2,7 +2,7 @@
 
 **Version:** 0.1 · **Status:** Draft · **Opt-in:** Yes — skip if delivering internal product work without contract boundaries
 
-A lightweight project governance layer that wraps Spec Kit feature deliveries when the team works in a **service-provider context** (delivering for clients). Based on [P3.Express](https://p3.express/) by Nader K. Rad and Frank Turley (Creative Commons licence, freely available at https://p3.express/manual/v2/).
+A lightweight project governance layer that wraps Specorator feature deliveries when the team works in a **service-provider context** (delivering for clients). Based on [P3.Express](https://p3.express/) by Nader K. Rad and Frank Turley (Creative Commons licence, freely available at https://p3.express/manual/v2/).
 
 For teams of 1–7 people, the **micro.P3.Express** variant applies automatically — it uses a weekly rather than monthly cadence and collapses the monthly B/E groups into the weekly rhythm. See §5 for details.
 
@@ -11,7 +11,7 @@ For teams of 1–7 people, the **micro.P3.Express** variant applies automaticall
 ## Table of contents
 
 1. [When to use this track](#1-when-to-use-this-track)
-2. [Relationship to the Spec Kit and Discovery Track](#2-relationship-to-the-spec-kit-and-discovery-track)
+2. [Relationship to the Specorator and Discovery Track](#2-relationship-to-the-specorator-and-discovery-track)
 3. [Directory layout](#3-directory-layout)
 4. [Project lifecycle and state machine](#4-project-lifecycle-and-state-machine)
 5. [P3.Express process map](#5-p3express-process-map)
@@ -41,7 +41,7 @@ Run the Project Manager Track when **any** of these conditions apply:
 
 ---
 
-## 2. Relationship to the Spec Kit and Discovery Track
+## 2. Relationship to the Specorator and Discovery Track
 
 ```
               ┌─────────────────────────────────────────────────────┐
@@ -62,7 +62,7 @@ Run the Project Manager Track when **any** of these conditions apply:
 ```
 
 - The **project-manager** operates at the project envelope: scope, stakeholders, budget, risk/issue/change, periodic reporting.
-- Feature work is still built via the Spec Kit. The PM links to feature folders but never edits their artifacts.
+- Feature work is still built via the Specorator. The PM links to feature folders but never edits their artifacts.
 - Discovery sprints are still run via the Discovery Track. The PM logs them in the deliverables map as project phases.
 - The PM does **not replace** the `pm` agent (Stage 3) — that agent produces feature requirements. The project manager produces project governance documents.
 

--- a/docs/sales-cycle.md
+++ b/docs/sales-cycle.md
@@ -22,7 +22,7 @@ A pre-delivery track for **service providers** (development agencies, consulting
 
 ## 1. Why a Sales Cycle Track
 
-The Spec Kit's eleven stages and the Discovery Track both assume a project mandate exists. The **Sales Cycle Track** is what produces that mandate for a service provider.
+The Specorator's eleven stages and the Discovery Track both assume a project mandate exists. The **Sales Cycle Track** is what produces that mandate for a service provider.
 
 It applies when:
 

--- a/docs/sink.md
+++ b/docs/sink.md
@@ -12,7 +12,7 @@ Where every markdown artifact in this kit lives, who owns it, and how it evolves
 ├── memory/
 │   └── constitution.md                      # principles loaded ahead of every workflow command
 ├── docs/
-│   ├── spec-kit.md                          # workflow definition (read first)
+│   ├── specorator.md                          # workflow definition (read first)
 │   ├── workflow-overview.md                 # one-page cheat sheet
 │   ├── quality-framework.md                 # quality dimensions, gates, DoD
 │   ├── traceability.md                      # ID scheme REQ → SPEC → T → code → TEST
@@ -117,8 +117,8 @@ Where every markdown artifact in this kit lives, who owns it, and how it evolves
 | Path | Owner | Mutability |
 |---|---|---|
 | `memory/constitution.md` | Human (amended by ADR) | Append-only after amendments |
-| `docs/spec-kit.md`, `docs/quality-framework.md`, `docs/traceability.md`, `docs/ears-notation.md` | Human | Versioned (v0.1, v0.2…) |
-| `docs/sink.md` | Human | Versioned alongside spec-kit |
+| `docs/specorator.md`, `docs/quality-framework.md`, `docs/traceability.md`, `docs/ears-notation.md` | Human | Versioned (v0.1, v0.2…) |
+| `docs/sink.md` | Human | Versioned alongside specorator |
 | `docs/steering/*` | Human | Updated as project evolves |
 | `docs/adr/NNNN-*.md` | Architect / any agent that flags | **Immutable from creation** per ADR-0001: only YAML `status` (proposed → accepted → deprecated → superseded) and `supersedes` / `superseded-by` pointers may change. Body (Context, Decision, Alternatives, Consequences) is frozen on creation. To revise rationale, supersede via new ADR. |
 | `docs/CONTEXT.md`, `docs/CONTEXT-MAP.md`, `docs/contexts/*.md` | `domain-context` skill | Additive, agent-updated |
@@ -146,7 +146,7 @@ Where every markdown artifact in this kit lives, who owns it, and how it evolves
 | `discovery/<sprint>/<phase>.md` | The phase's owning facilitator + consulted specialists (per `docs/discovery-track.md` §3) | Each phase writes once; later phases never rewrite upstream phase artifacts |
 | `discovery/<sprint>/chosen-brief.md` | `facilitator` (Handoff) | One per surviving concept; mandatory input to `/spec:idea` |
 | `specs/<slug>/workflow-state.md` | `/spec:start`, then `/spec:*` commands on transition | State machine; orchestrator amends final fields |
-| `specs/<slug>/<artifact>.md` | The stage's owning agent (per `docs/spec-kit.md` §3) | Each stage writes once; later stages **never rewrite** upstream artifacts |
+| `specs/<slug>/<artifact>.md` | The stage's owning agent (per `docs/specorator.md` §3) | Each stage writes once; later stages **never rewrite** upstream artifacts |
 | `portfolio/<slug>/portfolio-state.md` | `/portfolio:start`, then `/portfolio:*` commands on each cycle | Cycle state machine; portfolio-manager-owned |
 | `portfolio/<slug>/portfolio-definition.md` | `/portfolio:start` (created), Z cycle Z2 (status updates) | Ongoing; X and Y cycles read but do not rewrite |
 | `portfolio/<slug>/portfolio-roadmap.md` | X cycle (X2, X3) | Updated in place each X run; previous exec summaries appended |
@@ -188,7 +188,7 @@ Accepted ADRs are immutable. To change a decision, file a new ADR superseding th
 
 1. `memory/constitution.md`.
 2. The relevant `docs/steering/*.md` (matched by glob to the stage role).
-3. `docs/spec-kit.md` §3.<stage> — the gate criteria for this stage.
+3. `docs/specorator.md` §3.<stage> — the gate criteria for this stage.
 4. `specs/<slug>/workflow-state.md` — confirm upstream stages are complete.
 5. All numerically-earlier `specs/<slug>/<artifact>.md` files in stage order.
 6. `docs/CONTEXT.md` and `docs/UBIQUITOUS_LANGUAGE.md` if present.
@@ -228,7 +228,7 @@ A sprint may emit **0, 1, or N** chosen briefs. Zero is a valid outcome (no-go);
 
 ## Portfolio Track sub-tree
 
-When a team needs to manage **multiple parallel features** or operates as a **service provider**, the Portfolio Track adds a management layer above the Spec Kit. It lives at `portfolio/<portfolio-slug>/` parallel to `specs/` and `discovery/`. See [`docs/portfolio-track.md`](portfolio-track.md) for the methodology and [ADR-0009](adr/0009-add-portfolio-manager-role.md) for the rationale.
+When a team needs to manage **multiple parallel features** or operates as a **service provider**, the Portfolio Track adds a management layer above the Specorator. It lives at `portfolio/<portfolio-slug>/` parallel to `specs/` and `discovery/`. See [`docs/portfolio-track.md`](portfolio-track.md) for the methodology and [ADR-0009](adr/0009-add-portfolio-manager-role.md) for the rationale.
 
 A portfolio is bootstrapped with `/portfolio:start <slug>`. The three cycle commands populate the five management documents. The portfolio track is **read-only on the `specs/` side** — it never modifies spec artifacts.
 
@@ -253,7 +253,7 @@ A portfolio is bootstrapped with `/portfolio:start <slug>`. The three cycle comm
 - **Long log dumps, raw command output, secrets.** Summaries only.
 - **Files specific to a single subagent's scratch work.** Return a summary instead.
 - **Speculative future work.** That's a follow-up workflow, not a sink artifact.
-- **Implementation file paths or line numbers** in spec/PRD/plan markdown. Per the spec-kit discipline, those describe behaviors and contracts, not locations.
+- **Implementation file paths or line numbers** in spec/PRD/plan markdown. Per the specorator discipline, those describe behaviors and contracts, not locations.
 
 ## Cross-cutting writes from skills
 

--- a/docs/specorator.md
+++ b/docs/specorator.md
@@ -1,4 +1,4 @@
-# Spec Kit — Quality-Driven, Agentic Development Workflow
+# Specorator — Quality-Driven, Agentic Development Workflow
 
 **Version:** 0.1 · **Status:** Draft · **Purpose:** Foundation for iteration
 

--- a/docs/stock-taking-track.md
+++ b/docs/stock-taking-track.md
@@ -2,7 +2,7 @@
 
 **Version:** 0.1 · **Status:** Draft · **Stability:** Opt-in · **ADR:** [ADR-0007](adr/0007-add-stock-taking-track-for-legacy-projects.md)
 
-A pre-workflow track for teams building on top of, alongside, or as a replacement for existing systems. Produces a structured inventory of what already exists that feeds either the Discovery Track or Stage 1 of the Spec Kit.
+A pre-workflow track for teams building on top of, alongside, or as a replacement for existing systems. Produces a structured inventory of what already exists that feeds either the Discovery Track or Stage 1 of the Specorator.
 
 > If you are starting from scratch with no existing system to understand, **skip this track** and go straight to `/discovery:start` (blank page) or `/spec:start` + `/spec:idea` (clear brief).
 
@@ -21,7 +21,7 @@ A pre-workflow track for teams building on top of, alongside, or as a replacemen
 
 ## 1. Why a Stock-taking Track
 
-The Spec Kit's eleven stages assume a brief exists and the team understands enough of the problem context to write requirements. The Discovery Track assumes you need to *find* the right thing to build. Neither addresses a common third situation: **you need to build something new, but an existing system defines the landscape you must navigate**.
+The Specorator's eleven stages assume a brief exists and the team understands enough of the problem context to write requirements. The Discovery Track assumes you need to *find* the right thing to build. Neither addresses a common third situation: **you need to build something new, but an existing system defines the landscape you must navigate**.
 
 The Stock-taking Track applies when:
 
@@ -227,7 +227,7 @@ inputs:
 - Stage 2 (Research) uses the inventory's open questions as part of its research agenda.
 
 **If `recommended_next: both`:**
-- Document which parts of the scope feed into Discovery and which have clear-enough briefs for the Spec Kit.
+- Document which parts of the scope feed into Discovery and which have clear-enough briefs for the Specorator.
 - Emit one recommendation per path.
 
 ---

--- a/docs/workflow-overview.md
+++ b/docs/workflow-overview.md
@@ -27,7 +27,7 @@
 
 | Question | Answer lives in |
 |---|---|
-| What's this stage for? | [`docs/spec-kit.md` §3](spec-kit.md#3-stages-artifacts-and-quality-gates) |
+| What's this stage for? | [`docs/specorator.md` §3](specorator.md#3-stages-artifacts-and-quality-gates) |
 | Who owns it? | [`.claude/agents/<role>.md`](../.claude/agents/) |
 | What's the input? | The previous stage's artifact in `specs/<feature>/` |
 | What's the output? | The matching `templates/<stage>-template.md` |

--- a/examples/cli-todo/design.md
+++ b/examples/cli-todo/design.md
@@ -23,7 +23,7 @@ updated: 2026-04-27
 
 ## Context
 
-`todo` is a single-binary command-line task manager for terminal-native engineers who need to capture, track, and close short-lived tasks without leaving their shell. PRD-CLI-001 defines five subcommands (`add`, `list`, `done`, `rm`, and `--help` coverage on all of them), local data persistence with no network dependency, and a strict non-interactive interface. The tool doubles as the primary worked example for the spec-kit: every artifact from idea through retrospective must remain small enough that a contributor can read the complete spec alongside the source code in a single sitting.
+`todo` is a single-binary command-line task manager for terminal-native engineers who need to capture, track, and close short-lived tasks without leaving their shell. PRD-CLI-001 defines five subcommands (`add`, `list`, `done`, `rm`, and `--help` coverage on all of them), local data persistence with no network dependency, and a strict non-interactive interface. The tool doubles as the primary worked example for the specorator: every artifact from idea through retrospective must remain small enough that a contributor can read the complete spec alongside the source code in a single sitting.
 
 ## Goals (design-level)
 
@@ -31,7 +31,7 @@ updated: 2026-04-27
 - **D2** — Every command follows a single, predictable invocation shape (`todo <subcommand> [argument]`) so there is nothing novel to learn between subcommands.
 - **D3** — Every output string — success, empty, and error — communicates exactly what happened and, where applicable, what to do next; no terse codes, no silent exits.
 - **D4** — The interaction design is pipe-friendly and script-safe: success output goes to stdout, error output goes to stderr, and exit codes are reliable.
-- **D5** — The design artifact itself is co-readable with the PRD in one sitting, serving the didactic goal for spec-kit contributors (Morgan persona).
+- **D5** — The design artifact itself is co-readable with the PRD in one sitting, serving the didactic goal for specorator contributors (Morgan persona).
 
 ## Non-goals
 
@@ -870,7 +870,7 @@ Carried forward from RESEARCH-CLI-001 plus architecture-level additions.
 | RISK-001 | Example bloat — features creep beyond v1, making the worked example too large to read alongside the spec in one sitting | Architecture is intentionally small: 9 components, one data entity plus an envelope, two data flows. Any new component in v1 requires explicit reconsideration. |
 | RISK-002 | Language alienation — readers unfamiliar with the chosen language find the source opaque | The architecture deliberately maps one component to one obvious source unit (one handler per file, one storage helper). The shape is recognisable to anyone who has read a CLI tool, regardless of language background. |
 | RISK-003 | Data corruption on concurrent writes — two simultaneous invocations produce a truncated or interleaved file | Atomic temp-file rename prevents the partial-write failure mode. The update-update race is documented as last-writer-wins (ADR-CLI-0001); test plan covers the SIGKILL-mid-write scenario. |
-| RISK-004 | Pulled-into-real-product trap — a contributor forks the example and ships it as a production tool, inheriting deliberate simplifications | Architecture documents the no-lockfile decision, the no-network posture, and the no-observability posture explicitly. README and spec headers carry the "spec-kit demonstration, not a production tool" notice. |
+| RISK-004 | Pulled-into-real-product trap — a contributor forks the example and ships it as a production tool, inheriting deliberate simplifications | Architecture documents the no-lockfile decision, the no-network posture, and the no-observability posture explicitly. README and spec headers carry the "specorator demonstration, not a production tool" notice. |
 | RISK-CLI-ARCH-001 | Cross-filesystem temp file — `TODO_FILE` points into a different filesystem than the system temp dir, and the rename silently becomes non-atomic | The atomic-write helper places the temp file in the *target's* directory, not the system temp dir. Documented in ADR-CLI-0001 and enforced by the storage layer's contract. |
 | RISK-CLI-ARCH-002 | Parent directory missing on first run — XDG data dir or a `TODO_FILE` parent does not exist, and the first write fails | Path resolver creates the parent directory (with permissions inherited from the user's umask) before any write. First-run scenario is in the test plan. |
 

--- a/examples/cli-todo/idea.md
+++ b/examples/cli-todo/idea.md
@@ -18,7 +18,7 @@ Solo engineers and terminal-native developers want to capture, list, and complet
 ## Target users
 
 - **Primary:** solo engineers who live in the terminal and want a single-binary, local-first todo tool with a learnable surface area (≤ 5 commands).
-- **Secondary:** contributors reading this spec-kit who need a small-but-realistic worked example to learn the workflow on. The example's didactic value is itself a goal.
+- **Secondary:** contributors reading this specorator who need a small-but-realistic worked example to learn the workflow on. The example's didactic value is itself a goal.
 
 ## Desired outcome
 

--- a/examples/cli-todo/requirements.md
+++ b/examples/cli-todo/requirements.md
@@ -16,7 +16,7 @@ updated: 2026-04-27
 
 ## Summary
 
-We are building `todo`, a single-binary command-line task manager for terminal-native engineers who need to capture, list, and close short-lived tasks without leaving their shell. The tool is also the primary worked example for the spec-kit: every artifact from idea through retrospective is kept purposefully small so a contributor can read the spec alongside the source in a single sitting. The project is timely because no existing CLI todo manager is simultaneously small enough to be a readable example, distributed as a true single binary, and designed to serve as a didactic walkthrough of the full spec-kit workflow.
+We are building `todo`, a single-binary command-line task manager for terminal-native engineers who need to capture, list, and close short-lived tasks without leaving their shell. The tool is also the primary worked example for the specorator: every artifact from idea through retrospective is kept purposefully small so a contributor can read the spec alongside the source in a single sitting. The project is timely because no existing CLI todo manager is simultaneously small enough to be a readable example, distributed as a true single binary, and designed to serve as a didactic walkthrough of the full specorator workflow.
 
 ## Goals
 
@@ -46,7 +46,7 @@ We are building `todo`, a single-binary command-line task manager for terminal-n
 | Persona | Need | Why it matters |
 |---|---|---|
 | **Alex — Terminal-native engineer** | Capture and close short-lived tasks without leaving the shell; no accounts, no browser, no cloud | Represents the primary functional user; drives all five command requirements and the data persistence story |
-| **Morgan — Spec-kit contributor** | A small, realistic worked artifact to study the full spec-kit workflow from idea to retrospective | Represents the secondary user from IDEA-CLI-001; drives the didactic constraints (minimal deps, readable source, inline requirement cross-references) |
+| **Morgan — Spec-kit contributor** | A small, realistic worked artifact to study the full specorator workflow from idea to retrospective | Represents the secondary user from IDEA-CLI-001; drives the didactic constraints (minimal deps, readable source, inline requirement cross-references) |
 
 ## Jobs to be done
 
@@ -54,7 +54,7 @@ We are building `todo`, a single-binary command-line task manager for terminal-n
 - When I sit down to work, I want to list my open tasks in one command, so I can choose what to tackle next without switching tools.
 - When I finish a task, I want to mark it done by ID, so I have a clear record of what I completed without manually editing a file.
 - When a task is no longer relevant, I want to remove it by ID, so my list stays clean without accumulating stale entries.
-- When I am learning the spec-kit, I want to trace every requirement in this PRD to a line of source code, so I can understand how the workflow produces a real implementation.
+- When I am learning the specorator, I want to trace every requirement in this PRD to a line of source code, so I can understand how the workflow produces a real implementation.
 
 ## Functional requirements (EARS)
 
@@ -269,7 +269,7 @@ We are building `todo`, a single-binary command-line task manager for terminal-n
 
 - **North star:** A new user with the binary installed can complete a full `todo add` → `todo list` → `todo done` cycle in under 2 minutes, guided by `--help` output alone, with no prior documentation. (Target: verifiable in a usability pass with 3 participants.)
 - **Supporting:**
-  - A spec-kit contributor can map every REQ-CLI-NNN entry in this document to its corresponding code location in one pass through the source. (Target: verified during `/spec:review` traceability check.)
+  - A specorator contributor can map every REQ-CLI-NNN entry in this document to its corresponding code location in one pass through the source. (Target: verified during `/spec:review` traceability check.)
   - All 13 functional requirements have a corresponding automated test that fails when the requirement is violated. (Target: 100% requirement-to-test coverage at `/spec:test` completion.)
 - **Counter-metric:** Total source lines of code (excluding tests and generated files) stays at or below 500. Exceeding this threshold is a signal that scope has crept and must be explicitly reviewed. (Aligns with NFR-CLI-005.)
 
@@ -280,7 +280,7 @@ What must be true to ship the worked example as a complete stage-3 artifact.
 - [ ] All `must` requirements (REQ-CLI-001 through REQ-CLI-013 except REQ-CLI-003 which is `should`) pass their acceptance criteria.
 - [ ] All NFRs met or explicitly waived with a recorded ADR.
 - [ ] Test plan executed; no critical bugs open (severity 1 or 2 per the quality framework).
-- [ ] Documentation updated: `README.md` carries a notice that this is a spec-kit example, not a production tool.
+- [ ] Documentation updated: `README.md` carries a notice that this is a specorator example, not a production tool.
 - [ ] Traceability matrix (`traceability.md`) is complete: every REQ-CLI-NNN links to at least one code location and one test.
 - [ ] Retrospective (`retrospective.md`) filed — never skipped per the constitution.
 

--- a/examples/cli-todo/research.md
+++ b/examples/cli-todo/research.md
@@ -42,13 +42,13 @@ The CLI todo space is mature. The tools below represent the main prior-art arche
 | dstask | Go; YAML-per-task; git-based sync; single binary | Single binary; git sync is elegant; priorities and tags | git dependency raises setup bar; per-file YAML means many small files; over-engineered for v1 | https://github.com/naggie/dstask |
 | devtodo | C; per-directory XML `.todo` file; hierarchical | Directory-scoped lists are novel | XML is verbose; project appears unmaintained; C build chain is a barrier | https://debaday.debian.net/2008/08/31/devtodo-a-remindertask-program-aimed-at-developers/ |
 
-**Gap this example fills:** none of the above are simultaneously (a) tiny enough to read source + spec in one sitting, (b) written in a language that is approachable to the broadest engineer audience, and (c) designed to serve as a didactic spec-kit walkthrough.
+**Gap this example fills:** none of the above are simultaneously (a) tiny enough to read source + spec in one sitting, (b) written in a language that is approachable to the broadest engineer audience, and (c) designed to serve as a didactic specorator walkthrough.
 
 ---
 
 ## User needs
 
-No primary research (interviews, surveys, analytics) was conducted for this example — it is a spec-kit demonstration, not a product being shipped to real users. The need is treated as stipulated by the problem statement in `IDEA-CLI-001`.
+No primary research (interviews, surveys, analytics) was conducted for this example — it is a specorator demonstration, not a product being shipped to real users. The need is treated as stipulated by the problem statement in `IDEA-CLI-001`.
 
 **Assumptions that must hold for the stipulated need to be real:**
 
@@ -58,7 +58,7 @@ No primary research (interviews, surveys, analytics) was conducted for this exam
 
 **How to validate (for a real product):** run 3–5 contextual interviews with solo engineers; observe their current "quick capture" habit; confirm the drop-off point with existing tools.
 
-**Didactic user (secondary):** spec-kit contributors reading the worked example. Their need is explicit and observable: they want a small-but-realistic artifact they can study. This need is definitionally satisfied by keeping the implementation minimal.
+**Didactic user (secondary):** specorator contributors reading the worked example. Their need is explicit and observable: they want a small-but-realistic artifact they can study. This need is definitionally satisfied by keeping the implementation minimal.
 
 ---
 
@@ -131,7 +131,7 @@ Three options: plain text, JSON, SQLite.
 
 ### Q2 — Implementation language
 
-Evaluated against single-binary distribution AND didactic clarity for spec-kit readers:
+Evaluated against single-binary distribution AND didactic clarity for specorator readers:
 
 | Language | Single binary | Install path | Source readability (mixed audience) | Cross-platform path handling |
 |---|---|---|---|---|
@@ -180,7 +180,7 @@ Three options:
 - **Pre-built binaries on GitHub Releases:** Broadest reach; no toolchain requirement. Adds a CI/CD step (GitHub Actions matrix build). For a worked example, this is realistic and demonstrates a real release flow.
 - **Homebrew formula:** Adds Homebrew tap maintenance overhead. Not warranted for v1 of an example.
 
-**Recommended:** `go install` as the primary path (lowest friction for the target reader audience), with a note that pre-built binaries via GitHub Releases are the realistic v1 distribution for end users. This keeps the example honest about what a real release looks like without requiring the spec-kit to maintain a tap.
+**Recommended:** `go install` as the primary path (lowest friction for the target reader audience), with a note that pre-built binaries via GitHub Releases are the realistic v1 distribution for end users. This keeps the example honest about what a real release looks like without requiring the specorator to maintain a tap.
 
 ### ID scheme
 
@@ -195,7 +195,7 @@ Sequential integers (1, 2, 3…) are the right choice for a local single-user to
 | RISK-001 | **Example bloat** — scope creeps to include due dates, priorities, or search before v1 is stable, making the worked example too large to read in one sitting | high | med | Hold the v1 scope to five commands (add/list/done/rm/help). Any additional feature must be gated by a separate "v2 example" decision. The pm stage should enforce this gate explicitly. |
 | RISK-002 | **Language alienation** — readers unfamiliar with Go find the source opaque, undermining the didactic goal | med | low | Go's syntax is intentionally simple. Mitigate further by keeping the implementation in a single file or two files maximum, with inline comments that cross-reference requirement IDs. Avoid Go-isms (goroutines, channels, complex interfaces) entirely in v1. |
 | RISK-003 | **Data corruption on concurrent writes** — two simultaneous invocations produce a truncated or interleaved JSON file | med | low | Atomic-rename write pattern (temp file + rename) prevents partial writes. Document the last-writer-wins caveat in the spec. |
-| RISK-004 | **Pulled-into-real-product trap** — a contributor forks the example and uses it as a production codebase, inheriting its deliberate simplifications (no auth, no backup, last-writer-wins) | med | low | Add a prominent notice in `README.md` and `spec.md` header: "This is a spec-kit demonstration. It omits production concerns deliberately." The spec's out-of-scope list is the contractual boundary. |
+| RISK-004 | **Pulled-into-real-product trap** — a contributor forks the example and uses it as a production codebase, inheriting its deliberate simplifications (no auth, no backup, last-writer-wins) | med | low | Add a prominent notice in `README.md` and `spec.md` header: "This is a specorator demonstration. It omits production concerns deliberately." The spec's out-of-scope list is the contractual boundary. |
 | RISK-005 | **Windows path handling edge cases** — the chosen XDG helper or temp-file rename behaves unexpectedly on Windows | low | med | Test on Windows in CI (e.g., a Windows runner) as part of the pre-built binary build. If the example does not run CI, document "Linux/macOS only" clearly. |
 | RISK-006 | **Migration cost** — if the JSON schema changes between example iterations, existing users' data files become unreadable | low | low | Include a `version` field in the JSON root object from day one. Document migration strategy (re-read old format, write new) in a follow-up example if needed. |
 
@@ -208,7 +208,7 @@ Sequential integers (1, 2, 3…) are the right choice for a local single-user to
 **Rationale:**
 
 - Go produces a genuine single static binary without extra flags, satisfying the constraint in `IDEA-CLI-001` cleanly.
-- Go source is readable by a broad engineer audience (Python, Java, JS background) without requiring familiarity with a complex type system or borrow checker. A spec-kit reader can map `requirements.md` → source code in one pass.
+- Go source is readable by a broad engineer audience (Python, Java, JS background) without requiring familiarity with a complex type system or borrow checker. A specorator reader can map `requirements.md` → source code in one pass.
 - JSON over a temp-file atomic rename gives adequate durability for a local single-user tool, is human-inspectable, and can be read/written with Go's stdlib alone (no third-party driver).
 - XDG data dir (`~/.local/share/todo/tasks.json`) is principled, cross-platform via a small XDG helper library (selected at implementation time), and teaches readers a real cross-platform pattern.
 - `go install` is the honest minimum distribution path for this audience; the example can note that a real release would add a GitHub Actions matrix build for pre-built binaries.

--- a/examples/cli-todo/workflow-state.md
+++ b/examples/cli-todo/workflow-state.md
@@ -23,7 +23,7 @@ artifacts:
 
 # Workflow state — cli-todo
 
-> A worked example of the spec-kit, walked through every stage. Built incrementally so each stage can be reviewed before the next one builds on it.
+> A worked example of the specorator, walked through every stage. Built incrementally so each stage can be reviewed before the next one builds on it.
 
 ## Stage progress
 
@@ -328,4 +328,4 @@ Free-form. What does the next agent / human need to know?
 
 - [x] CLAR-001 — Confirm primary readership (template contributors vs. real CLI todo users) — affects how much we lean on didactic clarity vs. product polish.
 
-  **Resolved 2026-04-27 (analyst):** Research confirms both audiences are real and compatible. The primary user (solo terminal engineer) drives the functional requirements; the secondary user (spec-kit contributor reading the worked example) drives the didactic constraints (single file / minimal deps / inline requirement cross-references). These constraints are additive, not conflicting. No further clarification needed before Requirements.
+  **Resolved 2026-04-27 (analyst):** Research confirms both audiences are real and compatible. The primary user (solo terminal engineer) drives the functional requirements; the secondary user (specorator contributor reading the worked example) drives the didactic constraints (single file / minimal deps / inline requirement cross-references). These constraints are additive, not conflicting. No further clarification needed before Requirements.

--- a/templates/stock-taking-inventory-template.md
+++ b/templates/stock-taking-inventory-template.md
@@ -14,7 +14,7 @@ inputs:
 
 # Stock-taking Inventory — <project-slug>
 
-> This is the consolidated handoff artifact for the Stock-taking Engagement. It summarises key findings from all three phases. Downstream tracks (Discovery or Spec Kit) treat this as a mandatory input — they reference it in `chosen-brief.md` or `idea.md` `inputs:` frontmatter.
+> This is the consolidated handoff artifact for the Stock-taking Engagement. It summarises key findings from all three phases. Downstream tracks (Discovery or Specorator) treat this as a mandatory input — they reference it in `chosen-brief.md` or `idea.md` `inputs:` frontmatter.
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

Repo hygiene pass — renames the product from "Spec Kit" to **Specorator** throughout and adds standard contributor infrastructure.

## Changes

### Rename: Spec Kit → Specorator
- `docs/spec-kit.md` → `docs/specorator.md` (git rename, 99% similarity)
- All 112 occurrences of `Spec Kit` / `spec-kit` across 40+ files updated to `Specorator` / `specorator`
- `/spec:*` command prefixes and the concept of "spec-driven development" are intentionally untouched

### README badges
- Version `v0.2` and MIT license badges added to the header

### `.github/` contributor infrastructure
- `PULL_REQUEST_TEMPLATE.md` — structured checklist for contributors
- `ISSUE_TEMPLATE/bug_report.md`
- `ISSUE_TEMPLATE/feature_request.md`

### `CHANGELOG.md`
- Stub covering v0.1 (2026-04-26) and v0.2 (2026-04-27) with full feature lists

## Note for repo owner

The GitHub repo **About** (description + topics) can't be set via the MCP tools — please update it manually:

> **Description:** Specorator — spec-driven, agentic development workflow template for Claude Code. Specs first, code second.
>
> **Topics:** `agentic-development` `claude-ai` `ai-workflow` `spec-driven-development` `workflow-template` `claude-code` `software-engineering`

https://claude.ai/code/session_019UeP1UajmxVLoF6gDAd3NL

---
_Generated by [Claude Code](https://claude.ai/code/session_019UeP1UajmxVLoF6gDAd3NL)_