### PR TITLE
Add Codex worktree and PR workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ Before doing any non-trivial work, read:
 - **Update workflow state.** When you finish or hand off a stage, update `specs/<feature>/workflow-state.md` so the next agent can resume.
 - **Escalate ambiguity.** Don't guess. Either ask the human or open a `clarifications` block in the active artifact.
 - **Branch per concern; verify before push.** Topic branches live in `.worktrees/<slug>/`; one concern per PR; `verify` green locally before opening a PR. Never `--no-verify`. See `docs/branching.md`, `docs/worktrees.md`, `docs/verify-gate.md`.
+- **Codex opens the PR.** For non-trivial repo changes, Codex creates its own worktree, commits, pushes, opens the pull request, reports the PR URL/status, and asks the human for the next step. See `docs/codex-workflow.md`.
 - **Memory edits are docs‑only.** Updates to `.claude/memory/` ride in their own PR with no changeset and no version bump. See `.claude/memory/feedback_memory_edits.md`.
 
 ## Repo conventions
@@ -60,5 +61,6 @@ Skills (`.claude/skills/`) are reusable how-tos any agent can invoke (`verify`, 
 ## Tool-specific notes
 
 - **Claude Code.** Subagents at `.claude/agents/`, slash commands at `.claude/commands/`, skills at `.claude/skills/`, operational memory at `.claude/memory/`, permission baseline at `.claude/settings.json`. `CLAUDE.md` imports this file plus the constitution and the memory index.
-- **Codex / Cursor / Aider.** This file is the primary context. Cursor users: `.cursor/rules/` may be added later if needed.
+- **Codex.** This file is the primary context. For delivery mechanics, follow [`docs/codex-workflow.md`](docs/codex-workflow.md): create a worktree, verify, push, open the PR, then ask for next steps.
+- **Cursor / Aider.** This file is the primary context. Cursor users: `.cursor/rules/` may be added later if needed.
 - **All tools.** Templates in `templates/` are framework-agnostic Markdown.

--- a/docs/branching.md
+++ b/docs/branching.md
@@ -45,6 +45,7 @@ These prefixes match the allowlist in `.claude/settings.json` and the regexes in
 4. **Verify before push.** See [`docs/verify-gate.md`](./verify-gate.md).
 5. **Resolve conflicts via merge, not rebase**, once a PR has open review threads. See [`feedback_parallel_pr_conflicts.md`](../.claude/memory/feedback_parallel_pr_conflicts.md).
 6. **Maintainer (or autonomous‑merge rule) merges**, not the author. See [`feedback_autonomous_merge.md`](../.claude/memory/feedback_autonomous_merge.md).
+7. **Codex opens the PR when it makes the change.** See [`docs/codex-workflow.md`](./codex-workflow.md) for the expected worktree → verify → push → PR → next-step loop.
 
 ## Why `develop` exists in Shape B
 

--- a/docs/codex-workflow.md
+++ b/docs/codex-workflow.md
@@ -1,0 +1,44 @@
+# Codex workflow
+
+This repo treats Codex as an autonomous topic-branch contributor. When a human asks Codex to make a non-trivial repo change, Codex should complete the full PR loop unless the human explicitly asks for local-only work.
+
+## Default delivery loop
+
+1. Read the required project context from `AGENTS.md`.
+2. Check the main checkout is clean enough to start and identify the integration branch (`main` for Shape A, `develop` for Shape B).
+3. Create a fresh worktree under `.worktrees/<slug>/` from the integration branch:
+
+   ```bash
+   git fetch origin
+   git worktree add .worktrees/<slug> -b <prefix>/<slug> origin/<integration-branch>
+   ```
+
+4. Work only inside that worktree.
+5. Keep the change to one concern and update the corresponding docs, state files, or issue records in the same branch.
+6. Run the relevant verification gate before pushing. If this template has no single `verify` command for the change type, run targeted checks and say exactly what passed.
+7. Commit with an imperative message that references relevant IDs or issue paths.
+8. Push the topic branch to `origin`.
+9. Open a pull request against the integration branch.
+10. Re-check PR mergeability or CI status when available.
+11. Final response must include the PR URL, branch, commit, verification result, and any remaining risk.
+12. Ask the human what they want next: review, merge, follow-up changes, or cleanup after merge.
+
+## When Codex should pause
+
+Pause and ask before continuing when:
+
+- The change would require direct push to `main` or `develop`.
+- Verification fails and the fix is unclear or out of scope.
+- The work requires an irreversible action: deploy, delete, force-push, publish externally, or merge without the repository's autonomous-merge criteria.
+- The requested change conflicts with the constitution, active spec state, or branch-per-concern rule.
+
+## PR body checklist
+
+Every Codex-opened PR should include:
+
+- Summary of the user-visible changes.
+- Verification commands or checks run.
+- Linked requirement, task, ADR, issue, or local issue file when one exists.
+- Known limitations or skipped checks.
+
+Codex should not stop at "pushed a branch" when GitHub access is available. The expected endpoint is an open PR and an explicit next-step prompt for the human.

--- a/docs/worktrees.md
+++ b/docs/worktrees.md
@@ -63,4 +63,5 @@ The default `.claude/settings.json` allows the worktree subcommands by name. The
 
 - [`feedback_worktrees_required.md`](../.claude/memory/feedback_worktrees_required.md) — the rule itself.
 - [`docs/branching.md`](./branching.md) — what "integration branch" means.
+- [`docs/codex-workflow.md`](./codex-workflow.md) — Codex's expected end-to-end worktree and PR loop.
 - [`.gitignore`](../.gitignore) — confirm `.worktrees/` is ignored before relying on it.


### PR DESCRIPTION
## Summary
- Add `docs/codex-workflow.md` with the expected Codex delivery loop: create worktree, verify, push, open PR, report status, ask next steps
- Reference the Codex workflow from `AGENTS.md`, `docs/branching.md`, and `docs/worktrees.md`

## Verification
- Changed-file local Markdown link check passed for `AGENTS.md`, `docs/codex-workflow.md`, `docs/branching.md`, and `docs/worktrees.md`

## Notes
- A repository-wide Markdown link scan still reports the pre-existing review issues fixed separately in PR #21; this PR stays scoped to the Codex workflow.