### PR TITLE
Convert additional workflow diagrams to Mermaid

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,18 +92,38 @@ The workflow has two tracks:
 
 **Discovery Track** *(optional — use this when you don't have a clear brief yet)*
 
-```
-Frame → Diverge → Converge → Prototype → Validate → Handoff
+```mermaid
+flowchart LR
+    frame["Frame"]
+    diverge["Diverge"]
+    converge["Converge"]
+    prototype["Prototype"]
+    validate["Validate"]
+    handoff["Handoff"]
+
+    frame --> diverge --> converge --> prototype --> validate --> handoff
 ```
 
 Explore ideas, narrow them down, prototype the most promising one, validate assumptions, then produce a brief that feeds the next track.
 
 **Lifecycle Track** *(11 stages — use this when you have a brief)*
 
-```
-Idea → Research → Requirements → Design → Specification → Tasks
-                                                              ↓
-Retro ← Release ← Review  ←  Testing  ←  Implementation  ←──┘
+```mermaid
+flowchart LR
+    idea["Idea"]
+    research["Research"]
+    requirements["Requirements"]
+    design["Design"]
+    specification["Specification"]
+    tasks["Tasks"]
+    implementation["Implementation"]
+    testing["Testing"]
+    review["Review"]
+    release["Release"]
+    retro["Retro"]
+
+    idea --> research --> requirements --> design --> specification --> tasks
+    tasks --> implementation --> testing --> review --> release --> retro
 ```
 
 Each stage has **one owner** (a specialist AI agent), **one output** (a Markdown file in `specs/<feature>/`), and **one quality gate** before the next stage can begin. No stage is skipped; quality gates are non-negotiable.
@@ -207,20 +227,24 @@ New to this kind of workflow? Here's the jargon decoded:
 
 ## Workflow at a glance
 
-```
-                        [Discovery Track — opt-in]
-         Frame → Diverge → Converge → Prototype → Validate → Handoff
-                                                                 │
-                                                           (brief feeds ↓)
-┌──────────┐  ┌──────────┐  ┌──────────────┐  ┌──────────┐  ┌─────────────┐  ┌────────┐
-│ 1. Idea  │→ │2. Research│→ │3. Requirements│→ │ 4. Design│→ │5. Specification│→│6. Tasks│
-│ analyst  │  │ analyst  │  │ pm           │  │ux/ui/arch│  │ architect   │  │planner │
-└──────────┘  └──────────┘  └──────────────┘  └──────────┘  └─────────────┘  └────────┘
-                                                                                    │
-┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────────┐          │
-│11. Retro │← │10.Release│← │ 9. Review│← │ 8. Testing│← │7.Implementation│◄───────┘
-│ retro    │  │ rel-mgr  │  │ reviewer │  │ qa       │  │ dev          │
-└──────────┘  └──────────┘  └──────────┘  └──────────┘  └──────────────┘
+```mermaid
+flowchart TD
+    discovery["Discovery Track<br/>Frame -> Diverge -> Converge -> Prototype -> Validate -> Handoff"]
+    idea["1. Idea<br/>analyst"]
+    research["2. Research<br/>analyst"]
+    requirements["3. Requirements<br/>pm"]
+    design["4. Design<br/>ux / ui / architect"]
+    specification["5. Specification<br/>architect"]
+    tasks["6. Tasks<br/>planner"]
+    implementation["7. Implementation<br/>dev"]
+    testing["8. Testing<br/>qa"]
+    review["9. Review<br/>reviewer"]
+    release["10. Release<br/>release-manager"]
+    retro["11. Retrospective<br/>retrospective"]
+
+    discovery -->|brief feeds| idea
+    idea --> research --> requirements --> design --> specification --> tasks
+    tasks --> implementation --> testing --> review --> release --> retro
 ```
 
 Each arrow is a quality gate. See [`docs/workflow-overview.md`](docs/workflow-overview.md) for the full cheat sheet and slash command reference.

--- a/docs/project-track.md
+++ b/docs/project-track.md
@@ -43,22 +43,15 @@ Run the Project Manager Track when **any** of these conditions apply:
 
 ## 2. Relationship to the Specorator and Discovery Track
 
-```
-              ┌─────────────────────────────────────────────────────┐
-              │              PROJECT MANAGER TRACK                   │
-              │  projects/<slug>/                                    │
-              │  Project Description · Deliverables Map ·           │
-              │  Follow-Up Register · Health Register · weekly-log  │
-              │                              (project-manager agent) │
-              └──────────────────┬──────────────────────────────────┘
-                                 │ links to (never rewrites)
-          ┌──────────────────────┴──────────────────────────┐
-          │                                                 │
-  ┌───────▼──────────────┐                  ┌──────────────▼──────────────┐
-  │   DISCOVERY TRACK    │                  │   SPEC KIT (Stages 1–11)    │
-  │   discovery/<slug>/  │──chosen brief──▶ │   specs/<slug>/             │
-  │   Frame→...→Handoff  │                  │   Idea→Research→...→Retro   │
-  └──────────────────────┘                  └─────────────────────────────┘
+```mermaid
+flowchart TD
+    pm["Project Manager Track<br/>projects/&lt;slug&gt;<br/>Project Description + Deliverables Map + Follow-Up Register + Health Register + weekly-log<br/>Owner: project-manager"]
+    discovery["Discovery Track<br/>discovery/&lt;slug&gt;<br/>Frame -> ... -> Handoff"]
+    spec["Specorator Lifecycle<br/>specs/&lt;slug&gt;<br/>Idea -> Research -> ... -> Retro"]
+
+    pm -->|links to, never rewrites| discovery
+    pm -->|links to, never rewrites| spec
+    discovery -->|chosen brief| spec
 ```
 
 - The **project-manager** operates at the project envelope: scope, stakeholders, budget, risk/issue/change, periodic reporting.
@@ -89,33 +82,23 @@ Feature folders (`specs/`) and discovery folders (`discovery/`) remain at the re
 
 ## 4. Project lifecycle and state machine
 
-```
-              ┌─────────────┐
-/project:start│  scaffolded │
-              └──────┬──────┘
-                     │ /project:initiate
-              ┌──────▼──────┐
-              │  initiating │  project-description + deliverables-map + followup-register
-              └──────┬──────┘
-                     │ go/no-go: human sponsor approves (A08)
-              ┌──────▼──────┐
-              │  executing  │◀─────────────────────────────────────┐
-              └──────┬──────┘                                      │
-  /project:weekly    │  (recurring — every week)                   │
-  /project:report    │  (on demand)                                │
-  changes/issues ────┤  (on demand → followup-register)            │
-                     │                                             │
-              ┌──────▼──────┐                                      │
-              │  closing    │  project-closure.md drafted          │
-              └──────┬──────┘                                      │
-                     │ client sign-off (human)                     │
-              ┌──────▼──────┐
-              │   closed    │
-              └─────────────┘
-                     │ (post-project, months later)
-              ┌──────▼──────┐
-              │ post-project│  /project:post — benefit evaluation
-              └─────────────┘
+```mermaid
+flowchart TD
+    scaffolded["scaffolded"]
+    initiating["initiating<br/>project-description + deliverables-map + followup-register + health-register"]
+    executing["executing"]
+    closing["closing<br/>project-closure.md drafted"]
+    closed["closed"]
+    post["post-project<br/>benefit evaluation"]
+
+    scaffolded -->|/project:initiate| initiating
+    initiating -->|go/no-go approved by sponsor| executing
+    executing -->|/project:weekly recurring| executing
+    executing -->|/project:report on demand| executing
+    executing -->|changes and issues update followup-register| executing
+    executing -->|/project:close| closing
+    closing -->|client sign-off| closed
+    closed -->|/project:post after 3-6 months| post
 ```
 
 `project-state.md` records: current phase, linked feature folders, sponsor name, go/no-go history, and open blocking items.

--- a/docs/sales-cycle.md
+++ b/docs/sales-cycle.md
@@ -357,20 +357,29 @@ When starting a delivery workflow that originates from a sales deal:
 
 ## 8. Deal state machine
 
-```
-lead
-  └─ qualifying          (sales-qualifier running)
-       ├─ no-go          (close — record reason; preserve artifacts)
-       └─ go
-            └─ scoping   (scoping-facilitator running)
-                 └─ estimating  (estimator running)
-                      └─ proposing  (proposal-writer running)
-                           ├─ no-go     (close — record reason)
-                           ├─ on-hold   (suspend — record condition)
-                           └─ negotiating
-                                ├─ no-go
-                                ├─ on-hold
-                                └─ ordered   (delivery handoff triggered)
+```mermaid
+flowchart TD
+    lead["lead"]
+    qualifying["qualifying<br/>sales-qualifier running"]
+    scoping["scoping<br/>scoping-facilitator running"]
+    estimating["estimating<br/>estimator running"]
+    proposing["proposing<br/>proposal-writer running"]
+    negotiating["negotiating"]
+    no_go["no-go<br/>close, record reason, preserve artifacts"]
+    on_hold["on-hold<br/>suspend, record condition"]
+    ordered["ordered<br/>delivery handoff triggered"]
+
+    lead --> qualifying
+    qualifying -->|go| scoping
+    qualifying -->|no-go| no_go
+    scoping --> estimating
+    estimating --> proposing
+    proposing --> negotiating
+    proposing -->|no-go| no_go
+    proposing -->|on-hold| on_hold
+    negotiating -->|accepted| ordered
+    negotiating -->|no-go| no_go
+    negotiating -->|on-hold| on_hold
 ```
 
 ### deal-state.md YAML frontmatter schema

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -2,13 +2,16 @@
 
 Every artifact links back to its inputs. The chain:
 
-```
-Requirement (REQ-X-NNN)
-  └── Spec item (SPEC-X-NNN)
-        └── Task (T-X-NNN)
-              └── Code (file:line, commit SHA)
-                    └── Test (TEST-X-NNN)
-                          └── Review finding (R-X-NNN, optional)
+```mermaid
+flowchart TD
+    requirement["Requirement<br/>REQ-X-NNN"]
+    spec["Spec item<br/>SPEC-X-NNN"]
+    task["Task<br/>T-X-NNN"]
+    code["Code<br/>file:line, commit SHA"]
+    test["Test<br/>TEST-X-NNN"]
+    finding["Review finding<br/>R-X-NNN, optional"]
+
+    requirement --> spec --> task --> code --> test --> finding
 ```
 
 ## ID scheme

--- a/memory/constitution.md
+++ b/memory/constitution.md
@@ -38,13 +38,16 @@ Idea ≠ Research ≠ Requirements ≠ Design ≠ Specification
 
 Every artifact links to its inputs.
 
-```
-Requirement (REQ-X-NNN)
-  → Spec (SPEC-X-NNN)
-    → Task (T-X-NNN)
-      → Code (file:line)
-        → Test (TEST-X-NNN)
-          → Review finding (R-X-NNN)
+```mermaid
+flowchart TD
+    requirement["Requirement<br/>REQ-X-NNN"]
+    spec["Spec<br/>SPEC-X-NNN"]
+    task["Task<br/>T-X-NNN"]
+    code["Code<br/>file:line"]
+    test["Test<br/>TEST-X-NNN"]
+    finding["Review finding<br/>R-X-NNN"]
+
+    requirement --> spec --> task --> code --> test --> finding
 ```
 
 The traceability matrix in `specs/<feature>/traceability.md` is regenerable from the artifacts (document-level frontmatter plus marked-up per-item entries in body — see `docs/traceability.md`). No requirement may exist without a downstream chain by the time `/spec:review` runs.


### PR DESCRIPTION
## Summary
- Convert README discovery/lifecycle overview diagrams to Mermaid
- Convert project-track relationship and lifecycle state diagrams to Mermaid
- Convert the sales-cycle deal state machine to Mermaid
- Convert traceability chain diagrams in `docs/traceability.md` and `memory/constitution.md` to Mermaid

## Repo review notes
- Scanned Markdown fenced blocks and box-drawing/arrow patterns across the repo
- Left directory trees, CLI snippets, YAML examples, and output examples as code blocks because Mermaid would reduce readability
- PR #24 already handled `docs/specorator.md` and `docs/workflow-overview.md`; this PR targets the next clear candidates

## Verification
- Local Markdown link scan passed, excluding the known generated-template-relative `templates/discovery-frame-template.md` link
- Confirmed targeted old ASCII process/state diagrams no longer appear in the edited files
- Mermaid parser validation via `npx -p mermaid` is still blocked locally by npm `ECOMPROMISED: Lock compromised`, so parser execution did not run