### PR TITLE
chore(settings): fix $schema URL to json.schemastore.org

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://www.schemastore.org/claude-code-settings.json",
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "_comment": "Baseline permissions for projects using this workflow. Tighten by adding repo-specific allow/deny rules; do not loosen any deny rule without an ADR. See docs/branching.md for the branching model these rules assume. Permission rules are prefix matches against the literal command string — keep deny rules at the top of any new entries you add and verify that whitespace / short-flag aliases (-n for --no-verify, -f for --force) are also covered.",
 
   "permissions": {


### PR DESCRIPTION
## Summary
- /doctor flagged invalid `$schema` value in `.claude/settings.json`
- Switched from `www.schemastore.org` → `json.schemastore.org` per Claude Code settings schema spec

## Test plan
- [x] /doctor passes (diagnostics dismissed locally)