### PR TITLE
chore: add JavaScript integrity checks

### DIFF
--- a/.claude/commands/README.md
+++ b/.claude/commands/README.md
@@ -2,46 +2,41 @@
 
 One command per workflow phase. Subdirectories namespace commands (`spec/specify.md` → `/spec:specify`, `discovery/frame.md` → `/discovery:frame`).
 
-## `/discovery:*` — pre-stage Discovery Track (opt-in)
+## Command inventory
 
-Run this track when the team has no brief yet — a blank page rather than a defined feature. Output is `chosen-brief.md` which seeds `/spec:idea`. See [`docs/discovery-track.md`](../../docs/discovery-track.md) and [ADR-0005](../../docs/adr/0005-add-discovery-track-before-stage-1.md).
+<!-- BEGIN GENERATED: command-inventory -->
+# Decisions:
+/adr:new
 
-| Command | Phase | Spawns agent |
-|---|---|---|
-| `/discovery:start <sprint-slug>` | bootstrap | — (scaffolds files) |
-| `/discovery:frame` | 1 — Frame | `facilitator` (consults `product-strategist`, `user-researcher`) |
-| `/discovery:diverge` | 2 — Diverge | `facilitator` (consults `divergent-thinker`, `game-designer`) |
-| `/discovery:converge` | 3 — Converge | `facilitator` (consults `critic`, `product-strategist`) |
-| `/discovery:prototype` | 4 — Prototype | `facilitator` (consults `prototyper`, `game-designer`) |
-| `/discovery:validate` | 5 — Validate | `facilitator` (consults `user-researcher`, `critic`) |
-| `/discovery:handoff` | handoff | `facilitator` (consults `product-strategist`) |
+# Discovery Track:
+/discovery:converge   /discovery:diverge    /discovery:frame
+/discovery:handoff    /discovery:prototype  /discovery:start
+/discovery:validate
 
-Conversational entry: the [`discovery-sprint`](../skills/discovery-sprint/SKILL.md) skill.
+# Portfolio Track:
+/portfolio:start  /portfolio:x      /portfolio:y
+/portfolio:z
 
-## `/spec:*` — workflow phases
+# Project Manager Track:
+/project:change    /project:close     /project:initiate
+/project:post      /project:report    /project:start
+/project:weekly
 
-| Command | Stage | Spawns agent |
-|---|---|---|
-| `/spec:start <slug>` | bootstrap | — (scaffolds files) |
-| `/spec:idea` | 1 | `analyst` |
-| `/spec:research` | 2 | `analyst` |
-| `/spec:requirements` | 3 | `pm` |
-| `/spec:design` | 4 | `ux-designer`, `ui-designer`, `architect` (sequenced) |
-| `/spec:specify` | 5 | `architect` |
-| `/spec:tasks` | 6 | `planner` |
-| `/spec:implement [task-id]` | 7 | `dev` |
-| `/spec:test` | 8 | `qa` |
-| `/spec:review` | 9 | `reviewer` |
-| `/spec:release` | 10 | `release-manager` |
-| `/spec:retro` | 11 | `retrospective` |
-| `/spec:clarify` | gate | active stage's agent |
-| `/spec:analyze` | gate | — (in-command consistency checks; no subagent spawned) |
+# Sales Cycle Track:
+/sales:estimate  /sales:order     /sales:propose
+/sales:qualify   /sales:scope     /sales:start
 
-## `/adr:*` — decisions
+# Lifecycle:
+/spec:analyze       /spec:clarify       /spec:design
+/spec:idea          /spec:implement     /spec:release
+/spec:requirements  /spec:research      /spec:retro
+/spec:review        /spec:specify       /spec:start
+/spec:tasks         /spec:test
 
-| Command | Purpose |
-|---|---|
-| `/adr:new "<title>"` | File a new ADR |
+# Stock-taking Track:
+/stock-taking:audit       /stock-taking:handoff     /stock-taking:scope
+/stock-taking:start       /stock-taking:synthesize
+<!-- END GENERATED: command-inventory -->
 
 ## Usage
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
 
 ## Checklist
 
-- [ ] `/verify` gate is green locally
+- [ ] `npm run verify` gate is green locally
 - [ ] Docs and steering files updated in this PR — no "I'll do it after"
 - [ ] ADR filed if this is an irreversible architectural decision (`/adr:new "<title>"`)
 - [ ] `workflow-state.md` updated if a stage changed

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,29 @@
+name: Verify
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify
+        run: npm run verify

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Concretely:
 1. **Branch.** Cut a fresh topic branch off the integration branch. Use one of the standard prefixes — see [`docs/branching.md`](./docs/branching.md).
 2. **Worktree.** Put the branch in `.worktrees/<slug>/`. See [`docs/worktrees.md`](./docs/worktrees.md).
 3. **Stage.** Walk the appropriate workflow stages for the change you're making. A typo fix doesn't need `/spec:research`; a new agent role does.
-4. **Verify.** Run the project's verify gate green before pushing. See [`docs/verify-gate.md`](./docs/verify-gate.md).
+4. **Verify.** Run `npm run verify` green before pushing. See [`docs/verify-gate.md`](./docs/verify-gate.md).
 5. **PR.** One concern per PR; never stack. See [`feedback_pr_hygiene.md`](./.claude/memory/feedback_pr_hygiene.md).
 6. **Review.** Address feedback with follow‑up commits, not rebases. See [`feedback_pr_workflow.md`](./.claude/memory/feedback_pr_workflow.md).
 7. **Merge.** Maintainer merges (or autonomous‑merge per [`feedback_autonomous_merge.md`](./.claude/memory/feedback_autonomous_merge.md)).
@@ -35,6 +35,7 @@ Concretely:
 | **Tighten an existing template.** | PR under `docs(templates): …`. Describe what was missing and why the template now catches it. |
 | **Add a new template / slash command / agent role.** | Open an ADR first. The constitution makes new roles ADR‑gated. |
 | **Add a new operational bot.** | Add `agents/operational/<name>/PROMPT.md` and `README.md`. Must follow the eight‑section common shape (see `agents/operational/README.md`). |
+| **Regenerate ADR or command inventories.** | Run `npm run fix:adr-index` or `npm run fix:commands`, review the generated block, then run `npm run verify`. |
 | **Replace a stage in the workflow.** | ADR. Stages map 1:1 to quality gates and IDs; replacing one is a constitutional‑level change. |
 | **Tweak `.claude/settings.json` defaults.** | PR. Loosening a deny rule needs an ADR; tightening one does not. |
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,19 @@ Claude guides you through the rest — asking the right questions, running the r
 
 ---
 
+## Repository checks
+
+This template includes a small Node/npm integrity suite for local use and CI:
+
+```bash
+npm install
+npm run verify
+```
+
+`verify` is read-only. For deterministic local repairs, use `npm run fix:adr-index` to regenerate the ADR index and `npm run fix:commands` to regenerate command inventories, then run `npm run verify` again.
+
+---
+
 ## Common starting points
 
 ### I know what I want to build
@@ -253,20 +266,41 @@ Each arrow is a quality gate. See [`docs/workflow-overview.md`](docs/workflow-ov
 
 ## Slash commands reference
 
+<!-- BEGIN GENERATED: slash-commands -->
 ```
-# Discovery Track (when you don't have a brief yet):
-/discovery:start <sprint>    /discovery:converge      /discovery:validate
-/discovery:frame             /discovery:prototype     /discovery:handoff
-/discovery:diverge
+# Decisions:
+/adr:new
 
-# Lifecycle (Stages 1–11):
-/spec:start <slug>           /spec:tasks              /spec:retro
-/spec:idea                   /spec:implement [task]   /spec:clarify
-/spec:research               /spec:test               /spec:analyze
-/spec:requirements           /spec:review             /adr:new "<title>"
-/spec:design                 /spec:release
-/spec:specify
+# Discovery Track:
+/discovery:converge   /discovery:diverge    /discovery:frame
+/discovery:handoff    /discovery:prototype  /discovery:start
+/discovery:validate
+
+# Portfolio Track:
+/portfolio:start  /portfolio:x      /portfolio:y
+/portfolio:z
+
+# Project Manager Track:
+/project:change    /project:close     /project:initiate
+/project:post      /project:report    /project:start
+/project:weekly
+
+# Sales Cycle Track:
+/sales:estimate  /sales:order     /sales:propose
+/sales:qualify   /sales:scope     /sales:start
+
+# Lifecycle:
+/spec:analyze       /spec:clarify       /spec:design
+/spec:idea          /spec:implement     /spec:release
+/spec:requirements  /spec:research      /spec:retro
+/spec:review        /spec:specify       /spec:start
+/spec:tasks         /spec:test
+
+# Stock-taking Track:
+/stock-taking:audit       /stock-taking:handoff     /stock-taking:scope
+/stock-taking:start       /stock-taking:synthesize
 ```
+<!-- END GENERATED: slash-commands -->
 
 You can also trigger everything conversationally — the `orchestrate` and `discovery-sprint` skills listen for natural language and dispatch the right command.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -4,13 +4,19 @@ Records of architecturally significant decisions. Format follows Michael Nygard'
 
 ## Index
 
+<!-- BEGIN GENERATED: adr-index -->
 | # | Title | Status |
 |---|---|---|
 | [0001](0001-record-architecture-decisions.md) | Record architecture decisions | Accepted |
-| [0002](0002-adopt-spec-driven-development.md) | Adopt spec-driven development | Accepted |
-| [0003](0003-adopt-ears-for-functional-requirements.md) | Adopt EARS for functional requirements | Accepted |
+| [0002](0002-adopt-spec-driven-development.md) | Adopt spec-driven development as the workflow spine | Accepted |
+| [0003](0003-adopt-ears-for-functional-requirements.md) | Adopt EARS notation for functional requirements | Accepted |
 | [0004](0004-adopt-operational-agents-alongside-lifecycle-agents.md) | Adopt operational agents alongside lifecycle agents | Accepted |
 | [0005](0005-add-discovery-track-before-stage-1.md) | Add a Discovery Track that precedes Stage 1 (Idea) | Accepted |
+| [0006](0006-add-sales-cycle-track-before-discovery.md) | Add a Sales Cycle Track that precedes the Discovery Track and Stage 1 | Accepted |
+| [0007](0007-add-stock-taking-track-for-legacy-projects.md) | Add a Stock-taking Track for projects that build on existing systems | Accepted |
+| [0008](0008-add-project-manager-track.md) | Add an opt-in Project Manager Track based on P3.Express | Accepted |
+| [0009](0009-add-portfolio-manager-role.md) | Add opt-in Portfolio Manager role and P5 Express portfolio track | Accepted |
+<!-- END GENERATED: adr-index -->
 
 ## Conventions
 

--- a/docs/verify-gate.md
+++ b/docs/verify-gate.md
@@ -28,6 +28,17 @@ The exact command differs per language:
 
 The composite name (`verify`) is the contract. Whatever lives behind it is the project's choice.
 
+## This template repo
+
+This repository implements its own verify gate with Node/npm:
+
+```bash
+npm install
+npm run verify
+```
+
+The check scripts are read-only and live in `scripts/`. Local repair helpers are intentionally separate: `npm run fix:adr-index` regenerates the ADR index and `npm run fix:commands` regenerates command inventories.
+
 ## Reporting
 
 When an agent runs verify, it reports:

--- a/docs/workflow-overview.md
+++ b/docs/workflow-overview.md
@@ -90,24 +90,41 @@ Plus body sections (Skips, Blocks, Hand-off notes, Open clarifications). Canonic
 
 ## Slash commands
 
+<!-- BEGIN GENERATED: slash-commands -->
 ```
-# Pre-everything Stock-taking Track (opt-in, for legacy/brownfield projects):
-/stock:start <project>      /stock:audit               /stock:handoff
-/stock:scope                /stock:synthesize
+# Decisions:
+/adr:new
 
-# Pre-stage Discovery Track (opt-in, when no brief exists yet):
-/discovery:start <sprint>   /discovery:converge        /discovery:validate
-/discovery:frame            /discovery:prototype       /discovery:handoff
-/discovery:diverge
+# Discovery Track:
+/discovery:converge   /discovery:diverge    /discovery:frame
+/discovery:handoff    /discovery:prototype  /discovery:start
+/discovery:validate
+
+# Portfolio Track:
+/portfolio:start  /portfolio:x      /portfolio:y
+/portfolio:z
+
+# Project Manager Track:
+/project:change    /project:close     /project:initiate
+/project:post      /project:report    /project:start
+/project:weekly
+
+# Sales Cycle Track:
+/sales:estimate  /sales:order     /sales:propose
+/sales:qualify   /sales:scope     /sales:start
 
 # Lifecycle:
-/spec:start <slug>          /spec:tasks                /spec:retro
-/spec:idea                  /spec:implement [task-id]  /spec:clarify
-/spec:research              /spec:test                 /spec:analyze
-/spec:requirements          /spec:review               /adr:new "<title>"
-/spec:design                /spec:release
-/spec:specify
+/spec:analyze       /spec:clarify       /spec:design
+/spec:idea          /spec:implement     /spec:release
+/spec:requirements  /spec:research      /spec:retro
+/spec:review        /spec:specify       /spec:start
+/spec:tasks         /spec:test
+
+# Stock-taking Track:
+/stock-taking:audit       /stock-taking:handoff     /stock-taking:scope
+/stock-taking:start       /stock-taking:synthesize
 ```
+<!-- END GENERATED: slash-commands -->
 
 ## Per-stage Definition of Done (one-liner each)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,15 @@
+{
+  "name": "agentic-workflow",
+  "version": "0.2.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agentic-workflow",
+      "version": "0.2.0",
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "agentic-workflow",
+  "version": "0.2.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "verify": "npm run check:links && npm run check:adr-index && npm run check:commands && npm run check:frontmatter",
+    "check:links": "node scripts/check-markdown-links.js",
+    "check:adr-index": "node scripts/check-adr-index.js",
+    "check:commands": "node scripts/check-command-docs.js",
+    "check:frontmatter": "node scripts/check-frontmatter.js",
+    "fix:adr-index": "node scripts/fix-adr-index.js",
+    "fix:commands": "node scripts/fix-command-docs.js"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/scripts/check-adr-index.js
+++ b/scripts/check-adr-index.js
@@ -1,0 +1,40 @@
+import path from "node:path";
+import { getAdrs, renderAdrIndex } from "./lib/adr.js";
+import { failIfErrors, readText, repoRoot } from "./lib/repo.js";
+
+const readmePath = path.join(repoRoot, "docs/adr/README.md");
+const readme = readText(readmePath);
+const expected = renderAdrIndex();
+const errors = [];
+
+for (const adr of getAdrs()) {
+  const row = `| [${adr.number}](${adr.fileName}) | ${adr.title} | ${adr.status} |`;
+  if (!readme.includes(row)) {
+    errors.push(`docs/adr/README.md missing or stale ADR index row: ${row}`);
+  }
+}
+
+const indexedNumbers = [...readme.matchAll(/\|\s*\[(\d{4})\]\((0\d{3}-.+?\.md)\)/g)].map(
+  (match) => match[1],
+);
+const adrNumbers = new Set(getAdrs().map((adr) => adr.number));
+for (const number of indexedNumbers) {
+  if (!adrNumbers.has(number)) {
+    errors.push(`docs/adr/README.md indexes ADR ${number}, but no matching ADR file exists`);
+  }
+}
+
+if (!readme.includes("<!-- BEGIN GENERATED: adr-index -->")) {
+  errors.push("docs/adr/README.md missing generated block marker: adr-index");
+}
+
+if (errors.length === 0) {
+  const blockMatch = readme.match(
+    /<!-- BEGIN GENERATED: adr-index -->\n([\s\S]*?)\n<!-- END GENERATED: adr-index -->/,
+  );
+  if (blockMatch && blockMatch[1].trimEnd() !== expected.trimEnd()) {
+    errors.push("docs/adr/README.md generated ADR index differs from repository ADR files");
+  }
+}
+
+failIfErrors(errors, "check:adr-index");

--- a/scripts/check-command-docs.js
+++ b/scripts/check-command-docs.js
@@ -1,0 +1,39 @@
+import path from "node:path";
+import { getCommands, renderCommandInventory } from "./lib/commands.js";
+import { failIfErrors, readText, repoRoot } from "./lib/repo.js";
+
+const docs = [
+  [".claude/commands/README.md", "command-inventory", renderCommandInventory()],
+  ["README.md", "slash-commands", renderCommandInventory({ fenced: true })],
+  ["docs/workflow-overview.md", "slash-commands", renderCommandInventory({ fenced: true })],
+];
+
+const errors = [];
+const commands = getCommands();
+
+for (const [relativePath, marker, expected] of docs) {
+  const text = readText(path.join(repoRoot, relativePath));
+  if (!text.includes(`<!-- BEGIN GENERATED: ${marker} -->`)) {
+    errors.push(`${relativePath} missing generated block marker: ${marker}`);
+    continue;
+  }
+
+  const blockMatch = text.match(
+    new RegExp(`<!-- BEGIN GENERATED: ${marker} -->\\n([\\s\\S]*?)\\n<!-- END GENERATED: ${marker} -->`),
+  );
+  if (!blockMatch) {
+    errors.push(`${relativePath} has malformed generated block: ${marker}`);
+    continue;
+  }
+  if (blockMatch[1].trimEnd() !== expected.trimEnd()) {
+    errors.push(`${relativePath} generated command inventory is stale`);
+  }
+
+  for (const item of commands) {
+    if (!blockMatch[1].includes(item.command)) {
+      errors.push(`${relativePath} generated command inventory missing ${item.command}`);
+    }
+  }
+}
+
+failIfErrors(errors, "check:commands");

--- a/scripts/check-frontmatter.js
+++ b/scripts/check-frontmatter.js
@@ -1,0 +1,132 @@
+import path from "node:path";
+import {
+  extractFrontmatter,
+  failIfErrors,
+  markdownFiles,
+  parseSimpleYaml,
+  readText,
+  relativeToRoot,
+} from "./lib/repo.js";
+
+const artifactStatuses = new Set(["pending", "in-progress", "complete", "skipped", "blocked"]);
+const workflowStages = new Set([
+  "idea",
+  "research",
+  "requirements",
+  "design",
+  "specification",
+  "tasks",
+  "implementation",
+  "testing",
+  "review",
+  "release",
+  "learning",
+]);
+const workflowStatuses = new Set(["active", "blocked", "paused", "done"]);
+const errors = [];
+
+for (const filePath of markdownFiles()) {
+  const rel = relativeToRoot(filePath);
+  const text = readText(filePath);
+  const frontmatter = extractFrontmatter(text);
+
+  if (isAdr(rel)) {
+    requireFrontmatter(rel, frontmatter);
+    if (frontmatter) validateAdr(rel, parseSimpleYaml(frontmatter.raw));
+  }
+
+  if (rel.endsWith("workflow-state.md")) {
+    requireFrontmatter(rel, frontmatter);
+    if (frontmatter) validateWorkflowState(rel, parseSimpleYaml(frontmatter.raw));
+  }
+
+  if (isTrackState(rel)) {
+    requireFrontmatter(rel, frontmatter);
+    if (frontmatter) validateTrackState(rel, parseSimpleYaml(frontmatter.raw));
+  }
+
+  if (rel.startsWith("docs/daily-reviews/") && path.basename(rel) !== "README.md") {
+    requireFrontmatter(rel, frontmatter);
+    if (frontmatter) validateDailyReview(rel, parseSimpleYaml(frontmatter.raw));
+  }
+}
+
+failIfErrors(errors, "check:frontmatter");
+
+function isAdr(rel) {
+  return /^docs\/adr\/0\d{3}-.+\.md$/.test(rel);
+}
+
+function requireFrontmatter(rel, frontmatter) {
+  if (!frontmatter) errors.push(`${rel} is missing YAML frontmatter`);
+}
+
+function validateAdr(rel, data) {
+  const required = ["id", "title", "status", "date"];
+  for (const key of required) {
+    if (data[key] === undefined || data[key] === "") errors.push(`${rel} missing frontmatter key: ${key}`);
+  }
+
+  const fileNumber = path.basename(rel).slice(0, 4);
+  if (data.id !== `ADR-${fileNumber}`) {
+    errors.push(`${rel} frontmatter id must be ADR-${fileNumber}`);
+  }
+
+  const status = String(data.status || "").toLowerCase();
+  if (!["proposed", "accepted", "deprecated"].includes(status) && !status.startsWith("superseded")) {
+    errors.push(`${rel} has unsupported ADR status: ${data.status}`);
+  }
+}
+
+function validateWorkflowState(rel, data) {
+  for (const key of ["current_stage", "status", "last_updated", "last_agent", "artifacts"]) {
+    if (data[key] === undefined || data[key] === "") errors.push(`${rel} missing frontmatter key: ${key}`);
+  }
+
+  if (data.current_stage && !workflowStages.has(String(data.current_stage))) {
+    errors.push(`${rel} has unsupported current_stage: ${data.current_stage}`);
+  }
+  if (data.status && !workflowStatuses.has(String(data.status))) {
+    errors.push(`${rel} has unsupported status: ${data.status}`);
+  }
+  if (data.artifacts && typeof data.artifacts === "object") {
+    for (const [artifact, status] of Object.entries(data.artifacts)) {
+      if (!artifactStatuses.has(String(status))) {
+        errors.push(`${rel} artifact ${artifact} has unsupported status: ${status}`);
+      }
+    }
+  }
+}
+
+function validateDailyReview(rel, data) {
+  for (const key of ["date", "head_sha", "issue", "finding_count"]) {
+    if (data[key] === undefined || data[key] === "") errors.push(`${rel} missing frontmatter key: ${key}`);
+  }
+  if (data.head_sha && !/^[0-9a-f]{40}$/i.test(String(data.head_sha))) {
+    errors.push(`${rel} head_sha must be a 40-character SHA`);
+  }
+  if (data.issue !== null && !/^#\d+$/.test(String(data.issue))) {
+    errors.push(`${rel} issue must be #NNN or null`);
+  }
+  if (data.finding_count !== undefined && !Number.isInteger(Number(data.finding_count))) {
+    errors.push(`${rel} finding_count must be an integer`);
+  }
+}
+
+function isTrackState(rel) {
+  return /(^|\/)(discovery-state|stock-taking-state|project-state|portfolio-state|deal-state)\.md$/.test(rel);
+}
+
+function validateTrackState(rel, data) {
+  const required = ["status", "last_updated", "last_agent", "artifacts"];
+  for (const key of required) {
+    if (data[key] === undefined || data[key] === "") errors.push(`${rel} missing frontmatter key: ${key}`);
+  }
+  if (data.artifacts && typeof data.artifacts === "object") {
+    for (const [artifact, status] of Object.entries(data.artifacts)) {
+      if (!artifactStatuses.has(String(status))) {
+        errors.push(`${rel} artifact ${artifact} has unsupported status: ${status}`);
+      }
+    }
+  }
+}

--- a/scripts/check-markdown-links.js
+++ b/scripts/check-markdown-links.js
@@ -16,8 +16,16 @@ for (const filePath of markdownFiles()) {
       if (shouldIgnoreTarget(target)) continue;
 
       const [targetPath, rawAnchor] = target.split("#");
+      const decodedPath = safeDecode(targetPath);
+      const decodedAnchor = safeDecode(rawAnchor);
+
+      if (!decodedPath.ok || !decodedAnchor.ok) {
+        errors.push(`${relativeToRoot(filePath)}:${lineIndex + 1} has invalid URI escape in link ${target}`);
+        continue;
+      }
+
       const resolvedPath = targetPath
-        ? path.resolve(path.dirname(filePath), decodeURIComponent(targetPath))
+        ? path.resolve(path.dirname(filePath), decodedPath.value)
         : filePath;
 
       if (targetPath && !fs.existsSync(resolvedPath)) {
@@ -27,7 +35,7 @@ for (const filePath of markdownFiles()) {
 
       if (rawAnchor && fs.existsSync(resolvedPath)) {
         const anchors = collectAnchors(readText(resolvedPath));
-        const anchor = decodeURIComponent(rawAnchor).toLowerCase();
+        const anchor = decodedAnchor.value.toLowerCase();
         if (!anchors.has(anchor)) {
           errors.push(`${relativeToRoot(filePath)}:${lineIndex + 1} links to missing anchor ${target}`);
         }
@@ -37,6 +45,15 @@ for (const filePath of markdownFiles()) {
 }
 
 failIfErrors(errors, "check:links");
+
+function safeDecode(value) {
+  if (value === undefined) return { ok: true, value: "" };
+  try {
+    return { ok: true, value: decodeURIComponent(value) };
+  } catch {
+    return { ok: false, value };
+  }
+}
 
 function shouldIgnoreTarget(target) {
   if (!target || target.startsWith("#")) return false;

--- a/scripts/check-markdown-links.js
+++ b/scripts/check-markdown-links.js
@@ -1,0 +1,86 @@
+import fs from "node:fs";
+import path from "node:path";
+import { failIfErrors, markdownFiles, readText, relativeToRoot, repoRoot } from "./lib/repo.js";
+
+const errors = [];
+const linkPattern = /!?\[[^\]]*?\]\(([^)\s]+(?:\s+"[^"]*")?)\)/g;
+
+for (const filePath of markdownFiles()) {
+  const text = readText(filePath);
+  const lines = text.split(/\r?\n/);
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+    const line = lines[lineIndex];
+    for (const match of line.matchAll(linkPattern)) {
+      const rawTarget = match[1].replace(/\s+"[^"]*"$/, "").trim();
+      const target = rawTarget.replace(/^<|>$/g, "");
+      if (shouldIgnoreTarget(target)) continue;
+
+      const [targetPath, rawAnchor] = target.split("#");
+      const resolvedPath = targetPath
+        ? path.resolve(path.dirname(filePath), decodeURIComponent(targetPath))
+        : filePath;
+
+      if (targetPath && !fs.existsSync(resolvedPath)) {
+        errors.push(`${relativeToRoot(filePath)}:${lineIndex + 1} links to missing file ${target}`);
+        continue;
+      }
+
+      if (rawAnchor && fs.existsSync(resolvedPath)) {
+        const anchors = collectAnchors(readText(resolvedPath));
+        const anchor = decodeURIComponent(rawAnchor).toLowerCase();
+        if (!anchors.has(anchor)) {
+          errors.push(`${relativeToRoot(filePath)}:${lineIndex + 1} links to missing anchor ${target}`);
+        }
+      }
+    }
+  }
+}
+
+failIfErrors(errors, "check:links");
+
+function shouldIgnoreTarget(target) {
+  if (!target || target.startsWith("#")) return false;
+  if (/^(https?:|mailto:|app:|plugin:)/.test(target)) return true;
+  if (target.includes("<") || target.includes(">")) return true;
+  if (target.includes("$")) return true;
+  if (target.includes("feature-slug") || target.includes("sprint-slug")) return true;
+  if (target.includes("slug/") || target.includes("slug.md")) return true;
+  return false;
+}
+
+function collectAnchors(markdown) {
+  const anchors = new Set();
+  const used = new Map();
+  for (const line of markdown.split(/\r?\n/)) {
+    const match = line.match(/^(#{1,6})\s+(.+)$/);
+    if (!match) continue;
+    for (const base of slugVariants(match[2])) {
+      const count = used.get(base) || 0;
+      used.set(base, count + 1);
+      anchors.add(count === 0 ? base : `${base}-${count}`);
+    }
+  }
+  return anchors;
+}
+
+function slugVariants(heading) {
+  const cleaned = heading
+    .trim()
+    .replace(/<[^>]+>/g, "")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\*([^*]+)\*/g, "$1")
+    .toLowerCase();
+
+  return new Set([
+    githubSlug(cleaned),
+    githubSlug(cleaned.replace(/[‑‒–—―]/gu, "-")),
+    githubSlug(cleaned.replace(/[‑‒–—―]/gu, "")),
+  ]);
+}
+
+function githubSlug(value) {
+  return value
+    .replace(/[^\p{L}\p{N}\s-]/gu, "")
+    .trim()
+    .replace(/\s/gu, "-");
+}

--- a/scripts/fix-adr-index.js
+++ b/scripts/fix-adr-index.js
@@ -1,0 +1,14 @@
+import path from "node:path";
+import { renderAdrIndex } from "./lib/adr.js";
+import { readText, replaceGeneratedBlock, repoRoot, writeText } from "./lib/repo.js";
+
+const readmePath = path.join(repoRoot, "docs/adr/README.md");
+const current = readText(readmePath);
+const next = replaceGeneratedBlock(current, "adr-index", renderAdrIndex());
+
+if (next === current) {
+  console.log("fix:adr-index: no changes");
+} else {
+  writeText(readmePath, next);
+  console.log("fix:adr-index: updated docs/adr/README.md");
+}

--- a/scripts/fix-command-docs.js
+++ b/scripts/fix-command-docs.js
@@ -1,0 +1,23 @@
+import path from "node:path";
+import { renderCommandInventory } from "./lib/commands.js";
+import { readText, replaceGeneratedBlock, repoRoot, writeText } from "./lib/repo.js";
+
+const docs = [
+  [".claude/commands/README.md", "command-inventory", renderCommandInventory()],
+  ["README.md", "slash-commands", renderCommandInventory({ fenced: true })],
+  ["docs/workflow-overview.md", "slash-commands", renderCommandInventory({ fenced: true })],
+];
+
+let changed = false;
+for (const [relativePath, marker, content] of docs) {
+  const filePath = path.join(repoRoot, relativePath);
+  const current = readText(filePath);
+  const next = replaceGeneratedBlock(current, marker, content);
+  if (next !== current) {
+    writeText(filePath, next);
+    changed = true;
+    console.log(`fix:commands: updated ${relativePath}`);
+  }
+}
+
+if (!changed) console.log("fix:commands: no changes");

--- a/scripts/lib/adr.js
+++ b/scripts/lib/adr.js
@@ -1,0 +1,52 @@
+import fs from "node:fs";
+import path from "node:path";
+import { extractFrontmatter, parseSimpleYaml, readText, repoRoot } from "./repo.js";
+
+export function getAdrs() {
+  const dir = path.join(repoRoot, "docs/adr");
+  return fs
+    .readdirSync(dir)
+    .filter((name) => /^0\d{3}-.+\.md$/.test(name))
+    .sort()
+    .map((fileName) => {
+      const filePath = path.join(dir, fileName);
+      const text = readText(filePath);
+      const frontmatter = extractFrontmatter(text);
+      const yaml = frontmatter ? parseSimpleYaml(frontmatter.raw) : {};
+      const number = fileName.slice(0, 4);
+      const title = yaml.title || titleFromHeading(text) || fileName;
+      const status = normalizeStatus(yaml.status || statusFromBody(text) || "unknown");
+      return { number, fileName, title, status };
+    });
+}
+
+export function renderAdrIndex() {
+  const rows = [
+    "| # | Title | Status |",
+    "|---|---|---|",
+    ...getAdrs().map(
+      (adr) => `| [${adr.number}](${adr.fileName}) | ${adr.title} | ${adr.status} |`,
+    ),
+  ];
+  return rows.join("\n");
+}
+
+function titleFromHeading(text) {
+  const match = text.match(/^#\s+ADR-\d{4}\s+—\s+(.+)$/m);
+  return match ? match[1].trim() : null;
+}
+
+function statusFromBody(text) {
+  const match = text.match(/^## Status\s+([\s\S]*?)(?:\n## |\n---|$)/m);
+  if (!match) return null;
+  const firstLine = match[1].trim().split(/\r?\n/)[0];
+  return firstLine || null;
+}
+
+export function normalizeStatus(value) {
+  if (!value) return value;
+  return String(value)
+    .split(/\s+/)
+    .map((part) => (part ? part[0].toUpperCase() + part.slice(1).toLowerCase() : part))
+    .join(" ");
+}

--- a/scripts/lib/commands.js
+++ b/scripts/lib/commands.js
@@ -1,0 +1,63 @@
+import path from "node:path";
+import { repoRoot, walkFiles } from "./repo.js";
+
+const labels = new Map([
+  ["adr", "Decisions"],
+  ["discovery", "Discovery Track"],
+  ["portfolio", "Portfolio Track"],
+  ["project", "Project Manager Track"],
+  ["sales", "Sales Cycle Track"],
+  ["spec", "Lifecycle"],
+  ["stock-taking", "Stock-taking Track"],
+]);
+
+export function getCommands() {
+  return walkFiles(".claude/commands", (file) => file.endsWith(".md"))
+    .filter((file) => path.basename(file) !== "README.md")
+    .map((file) => {
+      const rel = path.relative(path.join(repoRoot, ".claude/commands"), file);
+      const parts = rel.split(path.sep);
+      const namespace = parts[0];
+      const name = path.basename(parts[1] || parts[0], ".md");
+      return {
+        namespace,
+        name,
+        command: `/${namespace}:${name}`,
+      };
+    })
+    .sort((a, b) => a.command.localeCompare(b.command));
+}
+
+export function renderCommandInventory({ fenced = false } = {}) {
+  const groups = new Map();
+  for (const command of getCommands()) {
+    if (!groups.has(command.namespace)) groups.set(command.namespace, []);
+    groups.get(command.namespace).push(command);
+  }
+  const sections = [];
+
+  for (const [namespace, commands] of [...groups.entries()].sort()) {
+    const label = labels.get(namespace) || namespace;
+    sections.push(`# ${label}:`);
+    sections.push(wrapCommands(commands.map((item) => item.command)));
+    sections.push("");
+  }
+
+  const content = sections.join("\n").trimEnd();
+  return fenced ? `\`\`\`\n${content}\n\`\`\`` : content;
+}
+
+function wrapCommands(commands) {
+  const width = Math.max(...commands.map((command) => command.length), 1) + 2;
+  const lines = [];
+  for (let index = 0; index < commands.length; index += 3) {
+    lines.push(
+      commands
+        .slice(index, index + 3)
+        .map((command) => command.padEnd(width, " "))
+        .join("")
+        .trimEnd(),
+    );
+  }
+  return lines.join("\n");
+}

--- a/scripts/lib/repo.js
+++ b/scripts/lib/repo.js
@@ -89,7 +89,7 @@ export function parseSimpleYaml(raw) {
       if (typeof data[currentKey] !== "object" || Array.isArray(data[currentKey])) {
         data[currentKey] = {};
       }
-      data[currentKey][nested[1].trim()] = parseYamlScalar(nested[2].trim());
+      data[currentKey][nested[1].trim()] = parseYamlScalar(stripInlineComment(nested[2]).trim());
       continue;
     }
 
@@ -97,11 +97,27 @@ export function parseSimpleYaml(raw) {
     if (!match) continue;
 
     currentKey = match[1].trim();
-    const value = match[2].trim();
+    const value = stripInlineComment(match[2]).trim();
     data[currentKey] = value === "" ? {} : parseYamlScalar(value);
   }
 
   return data;
+}
+
+function stripInlineComment(value) {
+  let quote = null;
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    const previous = value[index - 1];
+    if ((char === '"' || char === "'") && previous !== "\\") {
+      quote = quote === char ? null : quote || char;
+      continue;
+    }
+    if (char === "#" && !quote && (index === 0 || /\s/.test(previous))) {
+      return value.slice(0, index);
+    }
+  }
+  return value;
 }
 
 function parseYamlScalar(value) {

--- a/scripts/lib/repo.js
+++ b/scripts/lib/repo.js
@@ -1,0 +1,131 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+const ignoredDirs = new Set([
+  ".git",
+  ".worktrees",
+  "node_modules",
+  "dist",
+  "build",
+  "target",
+  "coverage",
+]);
+
+export function toPosix(filePath) {
+  return filePath.split(path.sep).join("/");
+}
+
+export function relativeToRoot(filePath) {
+  return toPosix(path.relative(repoRoot, filePath));
+}
+
+export function readText(filePath) {
+  return fs.readFileSync(filePath, "utf8");
+}
+
+export function writeText(filePath, text) {
+  fs.writeFileSync(filePath, text, "utf8");
+}
+
+export function walkFiles(startDir, predicate = () => true) {
+  const results = [];
+  const root = path.join(repoRoot, startDir);
+  if (!fs.existsSync(root)) return results;
+
+  function walk(current) {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        if (!ignoredDirs.has(entry.name)) walk(full);
+        continue;
+      }
+      if (entry.isFile() && predicate(full)) results.push(full);
+    }
+  }
+
+  walk(root);
+  return results.sort((a, b) => relativeToRoot(a).localeCompare(relativeToRoot(b)));
+}
+
+export function markdownFiles() {
+  return walkFiles(".", (file) => file.endsWith(".md"));
+}
+
+export function failIfErrors(errors, heading) {
+  if (errors.length === 0) {
+    console.log(`${heading}: ok`);
+    return;
+  }
+
+  console.error(`${heading}: ${errors.length} error(s)`);
+  for (const error of errors) console.error(`- ${error}`);
+  process.exit(1);
+}
+
+export function extractFrontmatter(text) {
+  if (!text.startsWith("---\n") && !text.startsWith("---\r\n")) return null;
+  const normalized = text.replace(/\r\n/g, "\n");
+  const end = normalized.indexOf("\n---\n", 4);
+  if (end === -1) return null;
+  return {
+    raw: normalized.slice(4, end),
+    body: normalized.slice(end + 5),
+  };
+}
+
+export function parseSimpleYaml(raw) {
+  const data = {};
+  const lines = raw.split("\n");
+  let currentKey = null;
+
+  for (const line of lines) {
+    if (!line.trim() || line.trim().startsWith("#")) continue;
+
+    const nested = line.match(/^  ([^:]+):\s*(.*)$/);
+    if (nested && currentKey) {
+      if (typeof data[currentKey] !== "object" || Array.isArray(data[currentKey])) {
+        data[currentKey] = {};
+      }
+      data[currentKey][nested[1].trim()] = parseYamlScalar(nested[2].trim());
+      continue;
+    }
+
+    const match = line.match(/^([^:\s][^:]*):\s*(.*)$/);
+    if (!match) continue;
+
+    currentKey = match[1].trim();
+    const value = match[2].trim();
+    data[currentKey] = value === "" ? {} : parseYamlScalar(value);
+  }
+
+  return data;
+}
+
+function parseYamlScalar(value) {
+  if (value === "~" || value === "null") return null;
+  if (value === "[]" || value === "{}") return value === "[]" ? [] : {};
+  if (/^\d+$/.test(value)) return Number(value);
+  if (/^\[.*\]$/.test(value)) {
+    const inner = value.slice(1, -1).trim();
+    if (!inner) return [];
+    return inner.split(",").map((item) => parseYamlScalar(item.trim()));
+  }
+  return value.replace(/^["']|["']$/g, "");
+}
+
+export function replaceGeneratedBlock(text, name, content) {
+  const begin = `<!-- BEGIN GENERATED: ${name} -->`;
+  const end = `<!-- END GENERATED: ${name} -->`;
+  const pattern = new RegExp(`${escapeRegExp(begin)}[\\s\\S]*?${escapeRegExp(end)}`);
+  if (!pattern.test(text)) {
+    throw new Error(`Missing generated block markers for ${name}`);
+  }
+  return text.replace(pattern, `${begin}\n${content.trimEnd()}\n${end}`);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/templates/discovery-frame-template.md
+++ b/templates/discovery-frame-template.md
@@ -15,7 +15,7 @@ updated: YYYY-MM-DD
 # Frame — <Sprint title>
 
 > Phase 1 — *Discover + Define.* Turn an outcome into testable opportunity statements.
-> Methods used here are described in [`docs/discovery-track.md`](../../docs/discovery-track.md#5-method-library).
+> Methods used here are described in [`docs/discovery-track.md`](../docs/discovery-track.md#5-method-library).
 
 ## Strategic outcome
 


### PR DESCRIPTION
## Summary

- Add a Node/npm verify gate with focused read-only integrity checks for Markdown links, ADR index drift, command inventory drift, and frontmatter/state conventions.
- Add explicit local repair helpers for generated ADR and command inventory blocks.
- Add a GitHub Actions workflow that runs `npm ci` and `npm run verify` on PRs and pushes to `main`.
- Regenerate the ADR index and command inventories, update docs for the concrete npm workflow, and fix one broken local template link.

## Verification

- `npm run fix:adr-index` -> no changes after generated block update
- `npm run fix:commands` -> no changes after generated block update
- `git diff --check`
- `npm run verify`

## Notes

- CI is read-only and does not implement scheduled operational bots in this first pass.
- The fix helpers only rewrite marked generated blocks.