### PR TITLE
chore: improve repository script tooling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Concretely:
 | **Tighten an existing template.** | PR under `docs(templates): …`. Describe what was missing and why the template now catches it. |
 | **Add a new template / slash command / agent role.** | Open an ADR first. The constitution makes new roles ADR‑gated. |
 | **Add a new operational bot.** | Add `agents/operational/<name>/PROMPT.md` and `README.md`. Must follow the eight‑section common shape (see `agents/operational/README.md`). |
-| **Regenerate ADR or command inventories.** | Run `npm run fix:adr-index` or `npm run fix:commands`, review the generated block, then run `npm run verify`. |
+| **Regenerate ADR or command inventories.** | Run `npm run fix` for all generated inventories, or `npm run fix:adr-index` / `npm run fix:commands` for one surface, review the generated block, then run `npm run verify`. |
 | **Replace a stage in the workflow.** | ADR. Stages map 1:1 to quality gates and IDs; replacing one is a constitutional‑level change. |
 | **Tweak `.claude/settings.json` defaults.** | PR. Loosening a deny rule needs an ADR; tightening one does not. |
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ npm run verify
 ```
 
 `verify` is read-only. For deterministic local repairs, use `npm run fix:adr-index` to regenerate the ADR index and `npm run fix:commands` to regenerate command inventories, then run `npm run verify` again.
+Use `npm run fix` to run all generated-block repair helpers together. See [`scripts/README.md`](scripts/README.md) for the full script inventory.
 
 ---
 

--- a/docs/verify-gate.md
+++ b/docs/verify-gate.md
@@ -37,7 +37,7 @@ npm install
 npm run verify
 ```
 
-The check scripts are read-only and live in `scripts/`. Local repair helpers are intentionally separate: `npm run fix:adr-index` regenerates the ADR index and `npm run fix:commands` regenerates command inventories.
+The check scripts are read-only and live in `scripts/`. `npm run verify` uses a small Node runner that stops on the first failing check and prints the exact `npm run check:*` command to rerun while iterating. Local repair helpers are intentionally separate: `npm run fix` runs all generated-block repairs, `npm run fix:adr-index` regenerates the ADR index, and `npm run fix:commands` regenerates command inventories.
 
 ## Reporting
 

--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "verify": "npm run check:links && npm run check:adr-index && npm run check:commands && npm run check:frontmatter",
+    "verify": "node scripts/verify.js",
     "check:links": "node scripts/check-markdown-links.js",
     "check:adr-index": "node scripts/check-adr-index.js",
     "check:commands": "node scripts/check-command-docs.js",
     "check:frontmatter": "node scripts/check-frontmatter.js",
+    "fix": "node scripts/fix-generated.js",
     "fix:adr-index": "node scripts/fix-adr-index.js",
     "fix:commands": "node scripts/fix-command-docs.js"
   },

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,39 @@
+# Repository Scripts
+
+The scripts in this directory provide the template repository's local and CI integrity checks.
+
+## Verify
+
+Run the full read-only gate:
+
+```bash
+npm run verify
+```
+
+`verify` runs each `check:*` task in order and stops at the first failure. The failing task prints the command to rerun while iterating.
+
+## Checks
+
+| Script | Purpose |
+| --- | --- |
+| `npm run check:links` | Validate local Markdown links and anchors. |
+| `npm run check:adr-index` | Confirm `docs/adr/README.md` matches the ADR files. |
+| `npm run check:commands` | Confirm generated slash-command inventories are current. |
+| `npm run check:frontmatter` | Validate required frontmatter on state files, ADRs, and review artifacts. |
+
+## Generated Repairs
+
+Run all deterministic generated-block repairs:
+
+```bash
+npm run fix
+```
+
+Use narrower repair commands when you only want one generated surface:
+
+```bash
+npm run fix:adr-index
+npm run fix:commands
+```
+
+Review the diff after any fix command, then rerun `npm run verify`.

--- a/scripts/fix-generated.js
+++ b/scripts/fix-generated.js
@@ -1,0 +1,4 @@
+import { fixTasks } from "./lib/tasks.js";
+import { runNodeTasks } from "./lib/runner.js";
+
+runNodeTasks(fixTasks, { heading: "fix" });

--- a/scripts/lib/runner.js
+++ b/scripts/lib/runner.js
@@ -1,0 +1,32 @@
+import { spawnSync } from "node:child_process";
+
+export function runNodeTasks(tasks, options = {}) {
+  const { heading = "runner", stopOnFailure = true } = options;
+  const startedAt = Date.now();
+
+  for (const task of tasks) {
+    const taskStartedAt = Date.now();
+    console.log(`${heading}: ${task.name} (${task.label})`);
+    const result = spawnSync(process.execPath, [task.script], {
+      stdio: "inherit",
+      windowsHide: true,
+    });
+
+    const elapsed = formatDuration(Date.now() - taskStartedAt);
+    if (result.status !== 0) {
+      console.error(`${heading}: failed at ${task.name} after ${elapsed}`);
+      console.error(`reproduce: npm run ${task.name}`);
+      if (stopOnFailure) process.exit(result.status || 1);
+      continue;
+    }
+
+    console.log(`${heading}: ${task.name} passed in ${elapsed}`);
+  }
+
+  console.log(`${heading}: ok in ${formatDuration(Date.now() - startedAt)}`);
+}
+
+function formatDuration(milliseconds) {
+  if (milliseconds < 1000) return `${milliseconds}ms`;
+  return `${(milliseconds / 1000).toFixed(1)}s`;
+}

--- a/scripts/lib/tasks.js
+++ b/scripts/lib/tasks.js
@@ -1,0 +1,35 @@
+export const checkTasks = [
+  {
+    name: "check:links",
+    label: "Markdown links",
+    script: "scripts/check-markdown-links.js",
+  },
+  {
+    name: "check:adr-index",
+    label: "ADR index",
+    script: "scripts/check-adr-index.js",
+  },
+  {
+    name: "check:commands",
+    label: "Command inventories",
+    script: "scripts/check-command-docs.js",
+  },
+  {
+    name: "check:frontmatter",
+    label: "Frontmatter conventions",
+    script: "scripts/check-frontmatter.js",
+  },
+];
+
+export const fixTasks = [
+  {
+    name: "fix:adr-index",
+    label: "ADR index",
+    script: "scripts/fix-adr-index.js",
+  },
+  {
+    name: "fix:commands",
+    label: "Command inventories",
+    script: "scripts/fix-command-docs.js",
+  },
+];

--- a/scripts/verify.js
+++ b/scripts/verify.js
@@ -1,0 +1,4 @@
+import { checkTasks } from "./lib/tasks.js";
+import { runNodeTasks } from "./lib/runner.js";
+
+runNodeTasks(checkTasks, { heading: "verify" });


### PR DESCRIPTION
## Summary

- Add a shared script task manifest and Node runner for repository checks.
- Route `npm run verify` through the runner so failures report the focused `npm run check:*` command to reproduce.
- Add `npm run fix` to run all deterministic generated-block repair helpers together.
- Document the script inventory and update verify/contributing guidance.

## Verification

- `npm run fix`
- `npm run verify`
- `git diff --check`

## Notes

- This branch intentionally does not touch `feat/user-docs-diataxis` or its worktree.