### PR TITLE
chore: validate traceability ids

### DIFF
--- a/docs/verify-gate.md
+++ b/docs/verify-gate.md
@@ -37,7 +37,7 @@ npm install
 npm run verify
 ```
 
-The check scripts are read-only and live in `scripts/`. `npm run verify` uses a small Node runner that stops on the first failing check and prints the exact `npm run check:*` command to rerun while iterating. The template repo currently checks Markdown links, ADR index drift, command inventory drift, frontmatter conventions, and lifecycle workflow-state consistency. Local repair helpers are intentionally separate: `npm run fix` runs all generated-block repairs, `npm run fix:adr-index` regenerates the ADR index, and `npm run fix:commands` regenerates command inventories.
+The check scripts are read-only and live in `scripts/`. `npm run verify` uses a small Node runner that stops on the first failing check and prints the exact `npm run check:*` command to rerun while iterating. The template repo currently checks Markdown links, ADR index drift, command inventory drift, frontmatter conventions, lifecycle workflow-state consistency, and traceability ID references. Local repair helpers are intentionally separate: `npm run fix` runs all generated-block repairs, `npm run fix:adr-index` regenerates the ADR index, and `npm run fix:commands` regenerates command inventories.
 
 ## Reporting
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "check:commands": "node scripts/check-command-docs.js",
     "check:frontmatter": "node scripts/check-frontmatter.js",
     "check:specs": "node scripts/check-spec-state.js",
+    "check:traceability": "node scripts/check-traceability.js",
     "fix": "node scripts/fix-generated.js",
     "fix:adr-index": "node scripts/fix-adr-index.js",
     "fix:commands": "node scripts/fix-command-docs.js"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,6 +21,7 @@ npm run verify
 | `npm run check:commands` | Confirm generated slash-command inventories are current. |
 | `npm run check:frontmatter` | Validate required frontmatter on state files, ADRs, and review artifacts. |
 | `npm run check:specs` | Validate lifecycle `workflow-state.md` files and their artifact maps. |
+| `npm run check:traceability` | Validate lifecycle artifact IDs and local traceability references. |
 
 ## Generated Repairs
 

--- a/scripts/check-traceability.js
+++ b/scripts/check-traceability.js
@@ -1,0 +1,242 @@
+import fs from "node:fs";
+import path from "node:path";
+import {
+  extractFrontmatter,
+  failIfErrors,
+  parseSimpleYaml,
+  readText,
+  relativeToRoot,
+  walkFiles,
+} from "./lib/repo.js";
+
+const idPattern =
+  /\b(IDEA|RESEARCH|PRD|REQ|NFR|DESIGN|SPECDOC|SPEC|TASKS|T|IMPL-LOG|TESTPLAN|TESTREPORT|TEST|REVIEW|R|RTM|RELEASE|RETRO|CHECKLIST)-([A-Z][A-Z0-9]*)-(\d{3})\b/g;
+const idDefinitionPattern =
+  /^(IDEA|RESEARCH|PRD|REQ|NFR|DESIGN|SPECDOC|SPEC|TASKS|T|IMPL-LOG|TESTPLAN|TESTREPORT|TEST|REVIEW|R|RTM|RELEASE|RETRO|CHECKLIST)-([A-Z][A-Z0-9]*)-(\d{3})$/;
+const itemHeadingPattern = /^(#{2,4})\s+((REQ|NFR|SPEC|T|TEST)-([A-Z][A-Z0-9]*)-(\d{3}))\b/gm;
+const tableItemPattern =
+  /^\|\s*((REQ|NFR|SPEC|T|TEST)-([A-Z][A-Z0-9]*)-(\d{3}))\s*\|/gm;
+const fieldPattern = /^-\s+\*\*(Satisfies|Depends on|Links|Requirement):\*\*\s+(.+)$/gim;
+const workflowArtifacts = [
+  "idea.md",
+  "research.md",
+  "requirements.md",
+  "design.md",
+  "spec.md",
+  "tasks.md",
+  "implementation-log.md",
+  "test-plan.md",
+  "test-report.md",
+  "review.md",
+  "traceability.md",
+];
+const errors = [];
+
+for (const statePath of workflowStateFiles()) {
+  validateFeatureTraceability(statePath);
+}
+
+failIfErrors(errors, "check:traceability");
+
+function workflowStateFiles() {
+  return [...walkFiles("specs", isWorkflowState), ...walkFiles("examples", isWorkflowState)];
+}
+
+function isWorkflowState(filePath) {
+  return path.basename(filePath) === "workflow-state.md";
+}
+
+function validateFeatureTraceability(statePath) {
+  const stateRel = relativeToRoot(statePath);
+  const featureDir = path.dirname(statePath);
+  const stateFrontmatter = extractFrontmatter(readText(statePath));
+  if (!stateFrontmatter) {
+    errors.push(`${stateRel} is missing YAML frontmatter`);
+    return;
+  }
+
+  const state = parseSimpleYaml(stateFrontmatter.raw);
+  const area = String(state.area || "");
+  if (!area) {
+    errors.push(`${stateRel} missing frontmatter key: area`);
+    return;
+  }
+
+  const registry = new Map();
+  const artifactRecords = existingArtifactRecords(featureDir);
+
+  for (const record of artifactRecords) {
+    validateDocumentFrontmatter(record, state);
+    collectDocumentDefinition(record, state.area, registry);
+    collectHeadingDefinitions(record, area, registry);
+    collectTableDefinitions(record, area, registry);
+    validateIdAreas(record, area);
+  }
+
+  for (const record of artifactRecords) {
+    validateTraceFields(record, registry);
+  }
+}
+
+function existingArtifactRecords(featureDir) {
+  return workflowArtifacts
+    .map((artifact) => path.join(featureDir, artifact))
+    .filter((filePath) => fs.existsSync(filePath))
+    .map((filePath) => ({
+      filePath,
+      rel: relativeToRoot(filePath),
+      artifact: path.basename(filePath),
+      text: readText(filePath),
+    }));
+}
+
+function validateDocumentFrontmatter(record, state) {
+  const frontmatter = extractFrontmatter(record.text);
+  if (!frontmatter) return;
+
+  const data = parseSimpleYaml(frontmatter.raw);
+  if (data.feature && data.feature !== state.feature) {
+    errors.push(`${record.rel} frontmatter feature must match workflow feature: ${state.feature}`);
+  }
+  if (data.id) {
+    const areaMatch = String(data.id).match(/^[A-Z-]+-([A-Z][A-Z0-9]*)-\d{3}$/);
+    if (areaMatch && areaMatch[1] !== state.area) {
+      errors.push(`${record.rel} frontmatter id area ${areaMatch[1]} must match workflow area ${state.area}`);
+    }
+  }
+}
+
+function collectDocumentDefinition(record, area, registry) {
+  const frontmatter = extractFrontmatter(record.text);
+  if (!frontmatter) return;
+
+  const data = parseSimpleYaml(frontmatter.raw);
+  if (!data.id) return;
+
+  const match = String(data.id).match(idDefinitionPattern);
+  if (!match) return;
+
+  const [, kind, idArea] = match;
+  if (idArea !== area) return;
+  addDefinition(registry, data.id, kind, record);
+}
+
+function collectHeadingDefinitions(record, area, registry) {
+  for (const match of record.text.matchAll(itemHeadingPattern)) {
+    const [, , id, kind, idArea] = match;
+    if (idArea !== area) {
+      errors.push(`${record.rel} defines ${id}, but workflow area is ${area}`);
+      continue;
+    }
+
+    addDefinition(registry, id, kind, record);
+  }
+}
+
+function collectTableDefinitions(record, area, registry) {
+  const tableKinds = definitionTableKinds(record.artifact);
+  if (tableKinds.size === 0) return;
+
+  for (const match of record.text.matchAll(tableItemPattern)) {
+    const [, id, kind, idArea] = match;
+    if (!tableKinds.has(kind)) continue;
+    if (idArea !== area) {
+      errors.push(`${record.rel} defines ${id}, but workflow area is ${area}`);
+      continue;
+    }
+    addDefinition(registry, id, kind, record);
+  }
+}
+
+function definitionTableKinds(artifact) {
+  if (artifact === "requirements.md") return new Set(["NFR"]);
+  if (artifact === "spec.md") return new Set(["TEST"]);
+  if (artifact === "test-plan.md" || artifact === "test-report.md") return new Set(["TEST"]);
+  return new Set();
+}
+
+function addDefinition(registry, id, kind, record) {
+  const previous = registry.get(id);
+  if (previous) {
+    if (previous.rel !== record.rel) errors.push(`${record.rel} duplicates ${id}; first defined in ${previous.rel}`);
+    return;
+  }
+  registry.set(id, { ...record, id, kind });
+}
+
+function validateIdAreas(record, area) {
+  for (const match of record.text.matchAll(idPattern)) {
+    const [id, , idArea] = match;
+    if (idArea !== area) errors.push(`${record.rel} references ${id}, but workflow area is ${area}`);
+  }
+}
+
+function validateTraceFields(record, registry) {
+  const sections = splitItemSections(record);
+  for (const section of sections) {
+    validateSectionFields(record, section, registry);
+  }
+}
+
+function splitItemSections(record) {
+  const matches = [...record.text.matchAll(itemHeadingPattern)];
+  const sections = [];
+  for (let index = 0; index < matches.length; index += 1) {
+    const match = matches[index];
+    const next = matches[index + 1];
+    sections.push({
+      id: match[2],
+      kind: match[3],
+      body: record.text.slice(match.index, next?.index ?? record.text.length),
+    });
+  }
+  return sections;
+}
+
+function validateSectionFields(record, section, registry) {
+  const fields = [...section.body.matchAll(fieldPattern)];
+  if (requiresSatisfies(section.kind) && !fields.some((field) => field[1] === "Satisfies")) {
+    errors.push(`${record.rel} ${section.id} missing Satisfies field`);
+  }
+
+  for (const [, fieldName, value] of fields) {
+    const ids = idsIn(value);
+    if (ids.length === 0 && fieldName !== "Links") {
+      errors.push(`${record.rel} ${section.id} ${fieldName} field has no traceability IDs`);
+      continue;
+    }
+
+    for (const id of ids) {
+      validateReference(record, section, fieldName, id, registry);
+    }
+  }
+}
+
+function requiresSatisfies(kind) {
+  return kind === "REQ" || kind === "NFR" || kind === "SPEC" || kind === "T";
+}
+
+function idsIn(value) {
+  return [...value.matchAll(idPattern)].map((match) => match[0]);
+}
+
+function validateReference(record, section, fieldName, id, registry) {
+  const target = registry.get(id);
+  if (!target) {
+    errors.push(`${record.rel} ${section.id} ${fieldName} references unknown ${id}`);
+    return;
+  }
+
+  if (section.kind === "SPEC" && fieldName === "Satisfies" && !["REQ", "NFR"].includes(target.kind)) {
+    errors.push(`${record.rel} ${section.id} Satisfies should reference REQ/NFR IDs, got ${id}`);
+  }
+  if (section.kind === "T" && fieldName === "Satisfies" && !["REQ", "NFR", "SPEC"].includes(target.kind)) {
+    errors.push(`${record.rel} ${section.id} Satisfies should reference REQ/NFR/SPEC IDs, got ${id}`);
+  }
+  if (section.kind === "T" && fieldName === "Depends on" && target.kind !== "T") {
+    errors.push(`${record.rel} ${section.id} Depends on should reference T IDs, got ${id}`);
+  }
+  if (section.kind === "TEST" && fieldName === "Requirement" && !["REQ", "NFR"].includes(target.kind)) {
+    errors.push(`${record.rel} ${section.id} Requirement should reference REQ/NFR IDs, got ${id}`);
+  }
+}

--- a/scripts/lib/tasks.js
+++ b/scripts/lib/tasks.js
@@ -24,6 +24,11 @@ export const checkTasks = [
     label: "Spec workflow state",
     script: "scripts/check-spec-state.js",
   },
+  {
+    name: "check:traceability",
+    label: "Traceability IDs",
+    script: "scripts/check-traceability.js",
+  },
 ];
 
 export const fixTasks = [


### PR DESCRIPTION
## Summary

- Add `npm run check:traceability` for lifecycle artifacts under `specs/` and `examples/`.
- Validate document/frontmatter feature identity, traceability ID area consistency, duplicate item definitions, and local `Satisfies` / `Depends on` / `Requirement` references.
- Keep the check stage-aware by validating artifacts that already exist without requiring future tasks, tests, or RTM rows before the workflow reaches those stages.
- Wire the new check into `npm run verify` and document it in the scripts and verify-gate docs.

## Verification

- `npm run check:traceability`
- `npm run verify`
- `git diff --check`

## Notes

- This is not a full RTM generator. It establishes the mechanical ID/reference guardrails needed before generation is added.
- This branch intentionally does not touch `feat/user-docs-diataxis` or its worktree.