### PR TITLE
docs(scripts): add generated API docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ Thumbs.db
 *.swp
 *.swo
 
+# Dependencies
+node_modules/
+
 # Claude Code local state
 .claude/settings.local.json
 .claude/.session/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Concretely:
 | **Tighten an existing template.** | PR under `docs(templates): …`. Describe what was missing and why the template now catches it. |
 | **Add a new template / slash command / agent role.** | Open an ADR first. The constitution makes new roles ADR‑gated. |
 | **Add a new operational bot.** | Add `agents/operational/<name>/PROMPT.md` and `README.md`. Must follow the eight‑section common shape (see `agents/operational/README.md`). |
-| **Regenerate ADR or command inventories.** | Run `npm run fix` for all generated inventories, or `npm run fix:adr-index` / `npm run fix:commands` for one surface, review the generated block, then run `npm run verify`. |
+| **Regenerate generated docs.** | Run `npm run fix` for all generated surfaces, or `npm run fix:adr-index` / `npm run fix:commands` / `npm run fix:script-docs` for one surface, review the generated output, then run `npm run verify`. |
 | **Replace a stage in the workflow.** | ADR. Stages map 1:1 to quality gates and IDs; replacing one is a constitutional‑level change. |
 | **Tweak `.claude/settings.json` defaults.** | PR. Loosening a deny rule needs an ADR; tightening one does not. |
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ npm install
 npm run verify
 ```
 
-`verify` is read-only. For deterministic local repairs, use `npm run fix:adr-index` to regenerate the ADR index and `npm run fix:commands` to regenerate command inventories, then run `npm run verify` again.
+`verify` is read-only. For deterministic local repairs, use `npm run fix:adr-index` to regenerate the ADR index, `npm run fix:commands` to regenerate command inventories, and `npm run fix:script-docs` to regenerate script API docs from JSDoc blocks, then run `npm run verify` again.
 Use `npm run fix` to run all generated-block repair helpers together. See [`scripts/README.md`](scripts/README.md) for the full script inventory.
 
 ---

--- a/docs/scripts/README.md
+++ b/docs/scripts/README.md
@@ -1,3 +1,7 @@
+**agentic-workflow**
+
+***
+
 # Repository Scripts
 
 The scripts in this directory provide the template repository's local and CI integrity checks.

--- a/docs/scripts/check-adr-index/README.md
+++ b/docs/scripts/check-adr-index/README.md
@@ -1,0 +1,7 @@
+[**agentic-workflow**](../README.md)
+
+***
+
+[agentic-workflow](../modules.md) / check-adr-index
+
+# check-adr-index

--- a/docs/scripts/check-command-docs/README.md
+++ b/docs/scripts/check-command-docs/README.md
@@ -1,0 +1,7 @@
+[**agentic-workflow**](../README.md)
+
+***
+
+[agentic-workflow](../modules.md) / check-command-docs
+
+# check-command-docs

--- a/docs/scripts/check-frontmatter/README.md
+++ b/docs/scripts/check-frontmatter/README.md
@@ -1,0 +1,7 @@
+[**agentic-workflow**](../README.md)
+
+***
+
+[agentic-workflow](../modules.md) / check-frontmatter
+
+# check-frontmatter

--- a/docs/scripts/check-markdown-links/README.md
+++ b/docs/scripts/check-markdown-links/README.md
@@ -1,0 +1,7 @@
+[**agentic-workflow**](../README.md)
+
+***
+
+[agentic-workflow](../modules.md) / check-markdown-links
+
+# check-markdown-links

--- a/docs/scripts/check-script-docs/README.md
+++ b/docs/scripts/check-script-docs/README.md
@@ -1,0 +1,7 @@
+[**agentic-workflow**](../README.md)
+
+***
+
+[agentic-workflow](../modules.md) / check-script-docs
+
+# check-script-docs

--- a/docs/scripts/check-spec-state/README.md
+++ b/docs/scripts/check-spec-state/README.md
@@ -1,0 +1,7 @@
+[**agentic-workflow**](../README.md)
+
+***
+
+[agentic-workflow](../modules.md) / check-spec-state
+
+# check-spec-state

--- a/docs/scripts/check-traceability/README.md
+++ b/docs/scripts/check-traceability/README.md
@@ -1,0 +1,7 @@
+[**agentic-workflow**](../README.md)
+
+***
+
+[agentic-workflow](../modules.md) / check-traceability
+
+# check-traceability

--- a/docs/scripts/fix-adr-index/README.md
+++ b/docs/scripts/fix-adr-index/README.md
@@ -1,0 +1,7 @@
+[**agentic-workflow**](../README.md)
+
+***
+
+[agentic-workflow](../modules.md) / fix-adr-index
+
+# fix-adr-index

--- a/docs/scripts/fix-command-docs/README.md
+++ b/docs/scripts/fix-command-docs/README.md
@@ -1,0 +1,7 @@
+[**agentic-workflow**](../README.md)
+
+***
+
+[agentic-workflow](../modules.md) / fix-command-docs
+
+# fix-command-docs

--- a/docs/scripts/fix-generated/README.md
+++ b/docs/scripts/fix-generated/README.md
@@ -1,0 +1,7 @@
+[**agentic-workflow**](../README.md)
+
+***
+
+[agentic-workflow](../modules.md) / fix-generated
+
+# fix-generated

--- a/docs/scripts/fix-script-docs/README.md
+++ b/docs/scripts/fix-script-docs/README.md
@@ -1,0 +1,7 @@
+[**agentic-workflow**](../README.md)
+
+***
+
+[agentic-workflow](../modules.md) / fix-script-docs
+
+# fix-script-docs

--- a/docs/scripts/lib/adr/README.md
+++ b/docs/scripts/lib/adr/README.md
@@ -1,0 +1,17 @@
+[**agentic-workflow**](../../README.md)
+
+***
+
+[agentic-workflow](../../modules.md) / lib/adr
+
+# lib/adr
+
+## Interfaces
+
+- [AdrRecord](interfaces/AdrRecord.md)
+
+## Functions
+
+- [getAdrs](functions/getAdrs.md)
+- [normalizeStatus](functions/normalizeStatus.md)
+- [renderAdrIndex](functions/renderAdrIndex.md)

--- a/docs/scripts/lib/adr/functions/getAdrs.md
+++ b/docs/scripts/lib/adr/functions/getAdrs.md
@@ -1,0 +1,17 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/adr](../README.md) / getAdrs
+
+# Function: getAdrs()
+
+> **getAdrs**(): [`AdrRecord`](../interfaces/AdrRecord.md)[]
+
+Read ADR metadata from `docs/adr`.
+
+## Returns
+
+[`AdrRecord`](../interfaces/AdrRecord.md)[]
+
+ADR records sorted by filename.

--- a/docs/scripts/lib/adr/functions/normalizeStatus.md
+++ b/docs/scripts/lib/adr/functions/normalizeStatus.md
@@ -1,0 +1,25 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/adr](../README.md) / normalizeStatus
+
+# Function: normalizeStatus()
+
+> **normalizeStatus**(`value`): `unknown`
+
+Convert an ADR status string to title case for stable generated output.
+
+## Parameters
+
+### value
+
+`unknown`
+
+Raw status value from frontmatter or body text.
+
+## Returns
+
+`unknown`
+
+Title-cased status string, or the original falsy value.

--- a/docs/scripts/lib/adr/functions/renderAdrIndex.md
+++ b/docs/scripts/lib/adr/functions/renderAdrIndex.md
@@ -1,0 +1,17 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/adr](../README.md) / renderAdrIndex
+
+# Function: renderAdrIndex()
+
+> **renderAdrIndex**(): `string`
+
+Render the generated ADR index table used by `docs/adr/README.md`.
+
+## Returns
+
+`string`
+
+Markdown table containing ADR number, title, and status.

--- a/docs/scripts/lib/adr/interfaces/AdrRecord.md
+++ b/docs/scripts/lib/adr/interfaces/AdrRecord.md
@@ -1,0 +1,39 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/adr](../README.md) / AdrRecord
+
+# Interface: AdrRecord
+
+## Properties
+
+### fileName
+
+> **fileName**: `string`
+
+Markdown filename below `docs/adr`.
+
+***
+
+### number
+
+> **number**: `string`
+
+Four-digit ADR number from the filename.
+
+***
+
+### status
+
+> **status**: `unknown`
+
+Normalized status from frontmatter, body text, or fallback.
+
+***
+
+### title
+
+> **title**: `unknown`
+
+Title from frontmatter, heading text, or filename fallback.

--- a/docs/scripts/lib/commands/README.md
+++ b/docs/scripts/lib/commands/README.md
@@ -1,0 +1,16 @@
+[**agentic-workflow**](../../README.md)
+
+***
+
+[agentic-workflow](../../modules.md) / lib/commands
+
+# lib/commands
+
+## Interfaces
+
+- [CommandRecord](interfaces/CommandRecord.md)
+
+## Functions
+
+- [getCommands](functions/getCommands.md)
+- [renderCommandInventory](functions/renderCommandInventory.md)

--- a/docs/scripts/lib/commands/functions/getCommands.md
+++ b/docs/scripts/lib/commands/functions/getCommands.md
@@ -1,0 +1,17 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/commands](../README.md) / getCommands
+
+# Function: getCommands()
+
+> **getCommands**(): [`CommandRecord`](../interfaces/CommandRecord.md)[]
+
+Discover slash-command Markdown files under `.claude/commands`.
+
+## Returns
+
+[`CommandRecord`](../interfaces/CommandRecord.md)[]
+
+Command records sorted by slash-command name.

--- a/docs/scripts/lib/commands/functions/renderCommandInventory.md
+++ b/docs/scripts/lib/commands/functions/renderCommandInventory.md
@@ -1,0 +1,29 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/commands](../README.md) / renderCommandInventory
+
+# Function: renderCommandInventory()
+
+> **renderCommandInventory**(`options?`): `string`
+
+Render the slash-command inventory block used in generated documentation.
+
+## Parameters
+
+### options?
+
+Rendering options.
+
+#### fenced?
+
+`boolean` = `false`
+
+Wrap the inventory in a Markdown code fence.
+
+## Returns
+
+`string`
+
+Markdown inventory grouped by command namespace.

--- a/docs/scripts/lib/commands/interfaces/CommandRecord.md
+++ b/docs/scripts/lib/commands/interfaces/CommandRecord.md
@@ -1,0 +1,31 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/commands](../README.md) / CommandRecord
+
+# Interface: CommandRecord
+
+## Properties
+
+### command
+
+> **command**: `string`
+
+Slash-command invocation, such as `/spec:idea`.
+
+***
+
+### name
+
+> **name**: `string`
+
+Command name without the `.md` extension.
+
+***
+
+### namespace
+
+> **namespace**: `string`
+
+Command namespace, such as `spec` or `adr`.

--- a/docs/scripts/lib/repo/README.md
+++ b/docs/scripts/lib/repo/README.md
@@ -1,0 +1,28 @@
+[**agentic-workflow**](../../README.md)
+
+***
+
+[agentic-workflow](../../modules.md) / lib/repo
+
+# lib/repo
+
+## Interfaces
+
+- [FrontmatterBlock](interfaces/FrontmatterBlock.md)
+
+## Variables
+
+- [repoRoot](variables/repoRoot.md)
+
+## Functions
+
+- [extractFrontmatter](functions/extractFrontmatter.md)
+- [failIfErrors](functions/failIfErrors.md)
+- [markdownFiles](functions/markdownFiles.md)
+- [parseSimpleYaml](functions/parseSimpleYaml.md)
+- [readText](functions/readText.md)
+- [relativeToRoot](functions/relativeToRoot.md)
+- [replaceGeneratedBlock](functions/replaceGeneratedBlock.md)
+- [toPosix](functions/toPosix.md)
+- [walkFiles](functions/walkFiles.md)
+- [writeText](functions/writeText.md)

--- a/docs/scripts/lib/repo/functions/extractFrontmatter.md
+++ b/docs/scripts/lib/repo/functions/extractFrontmatter.md
@@ -1,0 +1,25 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/repo](../README.md) / extractFrontmatter
+
+# Function: extractFrontmatter()
+
+> **extractFrontmatter**(`text`): [`FrontmatterBlock`](../interfaces/FrontmatterBlock.md) \| `null`
+
+Extract YAML frontmatter from a Markdown document.
+
+## Parameters
+
+### text
+
+`string`
+
+Markdown document contents.
+
+## Returns
+
+[`FrontmatterBlock`](../interfaces/FrontmatterBlock.md) \| `null`
+
+Frontmatter and body, or null when no frontmatter block exists.

--- a/docs/scripts/lib/repo/functions/failIfErrors.md
+++ b/docs/scripts/lib/repo/functions/failIfErrors.md
@@ -1,0 +1,29 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/repo](../README.md) / failIfErrors
+
+# Function: failIfErrors()
+
+> **failIfErrors**(`errors`, `heading`): `void`
+
+Print accumulated validation errors and terminate the current Node process.
+
+## Parameters
+
+### errors
+
+`string`[]
+
+Human-readable validation errors.
+
+### heading
+
+`string`
+
+Check name shown before the result.
+
+## Returns
+
+`void`

--- a/docs/scripts/lib/repo/functions/markdownFiles.md
+++ b/docs/scripts/lib/repo/functions/markdownFiles.md
@@ -1,0 +1,17 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/repo](../README.md) / markdownFiles
+
+# Function: markdownFiles()
+
+> **markdownFiles**(): `string`[]
+
+List all Markdown files tracked by repository checks.
+
+## Returns
+
+`string`[]
+
+Absolute paths to Markdown files.

--- a/docs/scripts/lib/repo/functions/parseSimpleYaml.md
+++ b/docs/scripts/lib/repo/functions/parseSimpleYaml.md
@@ -1,0 +1,29 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/repo](../README.md) / parseSimpleYaml
+
+# Function: parseSimpleYaml()
+
+> **parseSimpleYaml**(`raw`): `Record`\<`string`, `unknown`\>
+
+Parse the small YAML subset used by repository state files.
+
+This parser intentionally supports only the structures needed by local
+checks: scalar keys, one-level nested maps, inline arrays, quoted strings,
+integers, and null markers.
+
+## Parameters
+
+### raw
+
+`string`
+
+Raw frontmatter without delimiter lines.
+
+## Returns
+
+`Record`\<`string`, `unknown`\>
+
+Parsed YAML data.

--- a/docs/scripts/lib/repo/functions/readText.md
+++ b/docs/scripts/lib/repo/functions/readText.md
@@ -1,0 +1,25 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/repo](../README.md) / readText
+
+# Function: readText()
+
+> **readText**(`filePath`): `string`
+
+Read a UTF-8 text file.
+
+## Parameters
+
+### filePath
+
+`string`
+
+File path to read.
+
+## Returns
+
+`string`
+
+File contents.

--- a/docs/scripts/lib/repo/functions/relativeToRoot.md
+++ b/docs/scripts/lib/repo/functions/relativeToRoot.md
@@ -1,0 +1,25 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/repo](../README.md) / relativeToRoot
+
+# Function: relativeToRoot()
+
+> **relativeToRoot**(`filePath`): `string`
+
+Format an absolute repository path as a stable path relative to the repo root.
+
+## Parameters
+
+### filePath
+
+`string`
+
+Absolute or repository-root-relative path.
+
+## Returns
+
+`string`
+
+POSIX-style path relative to [repoRoot](../variables/repoRoot.md).

--- a/docs/scripts/lib/repo/functions/replaceGeneratedBlock.md
+++ b/docs/scripts/lib/repo/functions/replaceGeneratedBlock.md
@@ -1,0 +1,41 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/repo](../README.md) / replaceGeneratedBlock
+
+# Function: replaceGeneratedBlock()
+
+> **replaceGeneratedBlock**(`text`, `name`, `content`): `string`
+
+Replace a named generated Markdown block.
+
+## Parameters
+
+### text
+
+`string`
+
+Source document containing generated block markers.
+
+### name
+
+`string`
+
+Marker name from `BEGIN GENERATED: <name>`.
+
+### content
+
+`string`
+
+Generated content to place between markers.
+
+## Returns
+
+`string`
+
+Updated document contents.
+
+## Throws
+
+When the named block markers are missing.

--- a/docs/scripts/lib/repo/functions/toPosix.md
+++ b/docs/scripts/lib/repo/functions/toPosix.md
@@ -1,0 +1,25 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/repo](../README.md) / toPosix
+
+# Function: toPosix()
+
+> **toPosix**(`filePath`): `string`
+
+Convert a platform-specific path to a slash-delimited path for Markdown output.
+
+## Parameters
+
+### filePath
+
+`string`
+
+Path using the current operating system separator.
+
+## Returns
+
+`string`
+
+The same path using `/` separators.

--- a/docs/scripts/lib/repo/functions/walkFiles.md
+++ b/docs/scripts/lib/repo/functions/walkFiles.md
@@ -1,0 +1,32 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/repo](../README.md) / walkFiles
+
+# Function: walkFiles()
+
+> **walkFiles**(`startDir`, `predicate?`): `string`[]
+
+Recursively list files below a repository directory while skipping generated
+and dependency folders.
+
+## Parameters
+
+### startDir
+
+`string`
+
+Directory to walk, relative to [repoRoot](../variables/repoRoot.md).
+
+### predicate?
+
+(`filePath`) => `boolean`
+
+Optional file filter.
+
+## Returns
+
+`string`[]
+
+Absolute file paths sorted by repository-relative path.

--- a/docs/scripts/lib/repo/functions/writeText.md
+++ b/docs/scripts/lib/repo/functions/writeText.md
@@ -1,0 +1,29 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/repo](../README.md) / writeText
+
+# Function: writeText()
+
+> **writeText**(`filePath`, `text`): `void`
+
+Write a UTF-8 text file.
+
+## Parameters
+
+### filePath
+
+`string`
+
+File path to write.
+
+### text
+
+`string`
+
+Complete replacement contents.
+
+## Returns
+
+`void`

--- a/docs/scripts/lib/repo/interfaces/FrontmatterBlock.md
+++ b/docs/scripts/lib/repo/interfaces/FrontmatterBlock.md
@@ -1,0 +1,23 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/repo](../README.md) / FrontmatterBlock
+
+# Interface: FrontmatterBlock
+
+## Properties
+
+### body
+
+> **body**: `string`
+
+Markdown content after the frontmatter block.
+
+***
+
+### raw
+
+> **raw**: `string`
+
+YAML text between delimiter lines.

--- a/docs/scripts/lib/repo/variables/repoRoot.md
+++ b/docs/scripts/lib/repo/variables/repoRoot.md
@@ -1,0 +1,14 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/repo](../README.md) / repoRoot
+
+# Variable: repoRoot
+
+> `const` **repoRoot**: `string`
+
+Absolute filesystem path to the repository root.
+
+Script helpers resolve all checked and generated paths from this directory so
+commands behave the same regardless of the caller's current working directory.

--- a/docs/scripts/lib/runner/README.md
+++ b/docs/scripts/lib/runner/README.md
@@ -1,0 +1,11 @@
+[**agentic-workflow**](../../README.md)
+
+***
+
+[agentic-workflow](../../modules.md) / lib/runner
+
+# lib/runner
+
+## Functions
+
+- [runNodeTasks](functions/runNodeTasks.md)

--- a/docs/scripts/lib/runner/functions/runNodeTasks.md
+++ b/docs/scripts/lib/runner/functions/runNodeTasks.md
@@ -1,0 +1,43 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/runner](../README.md) / runNodeTasks
+
+# Function: runNodeTasks()
+
+> **runNodeTasks**(`tasks`, `options?`): `void`
+
+Run a list of Node-backed repository tasks in sequence.
+
+Each task is executed with the current Node binary. The runner prints a
+concise reproduce command when a task fails, which keeps `npm run verify`
+output actionable.
+
+## Parameters
+
+### tasks
+
+`object`[]
+
+Tasks to execute.
+
+### options?
+
+Runner behavior.
+
+#### heading?
+
+`string`
+
+Prefix for progress messages.
+
+#### stopOnFailure?
+
+`boolean`
+
+Exit immediately when a task fails.
+
+## Returns
+
+`void`

--- a/docs/scripts/lib/tasks/README.md
+++ b/docs/scripts/lib/tasks/README.md
@@ -1,0 +1,16 @@
+[**agentic-workflow**](../../README.md)
+
+***
+
+[agentic-workflow](../../modules.md) / lib/tasks
+
+# lib/tasks
+
+## Interfaces
+
+- [NodeTask](interfaces/NodeTask.md)
+
+## Variables
+
+- [checkTasks](variables/checkTasks.md)
+- [fixTasks](variables/fixTasks.md)

--- a/docs/scripts/lib/tasks/interfaces/NodeTask.md
+++ b/docs/scripts/lib/tasks/interfaces/NodeTask.md
@@ -1,0 +1,31 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/tasks](../README.md) / NodeTask
+
+# Interface: NodeTask
+
+## Properties
+
+### label
+
+> **label**: `string`
+
+Human-readable task label.
+
+***
+
+### name
+
+> **name**: `string`
+
+npm script name used in reproduce output.
+
+***
+
+### script
+
+> **script**: `string`
+
+Repository-relative Node script path.

--- a/docs/scripts/lib/tasks/variables/checkTasks.md
+++ b/docs/scripts/lib/tasks/variables/checkTasks.md
@@ -1,0 +1,14 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/tasks](../README.md) / checkTasks
+
+# Variable: checkTasks
+
+> `const` **checkTasks**: [`NodeTask`](../interfaces/NodeTask.md)[]
+
+Read-only checks executed by `npm run verify`.
+
+Keep this list in the order checks should fail during local iteration: cheap
+generated-output checks first, broader consistency checks last.

--- a/docs/scripts/lib/tasks/variables/fixTasks.md
+++ b/docs/scripts/lib/tasks/variables/fixTasks.md
@@ -1,0 +1,11 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/tasks](../README.md) / fixTasks
+
+# Variable: fixTasks
+
+> `const` **fixTasks**: [`NodeTask`](../interfaces/NodeTask.md)[]
+
+Deterministic repair tasks executed by `npm run fix`.

--- a/docs/scripts/modules.md
+++ b/docs/scripts/modules.md
@@ -1,0 +1,25 @@
+[**agentic-workflow**](README.md)
+
+***
+
+# agentic-workflow
+
+## Modules
+
+- [check-adr-index](check-adr-index/README.md)
+- [check-command-docs](check-command-docs/README.md)
+- [check-frontmatter](check-frontmatter/README.md)
+- [check-markdown-links](check-markdown-links/README.md)
+- [check-script-docs](check-script-docs/README.md)
+- [check-spec-state](check-spec-state/README.md)
+- [check-traceability](check-traceability/README.md)
+- [fix-adr-index](fix-adr-index/README.md)
+- [fix-command-docs](fix-command-docs/README.md)
+- [fix-generated](fix-generated/README.md)
+- [fix-script-docs](fix-script-docs/README.md)
+- [lib/adr](lib/adr/README.md)
+- [lib/commands](lib/commands/README.md)
+- [lib/repo](lib/repo/README.md)
+- [lib/runner](lib/runner/README.md)
+- [lib/tasks](lib/tasks/README.md)
+- [verify](verify/README.md)

--- a/docs/scripts/verify/README.md
+++ b/docs/scripts/verify/README.md
@@ -1,0 +1,7 @@
+[**agentic-workflow**](../README.md)
+
+***
+
+[agentic-workflow](../modules.md) / verify
+
+# verify

--- a/docs/verify-gate.md
+++ b/docs/verify-gate.md
@@ -37,7 +37,7 @@ npm install
 npm run verify
 ```
 
-The check scripts are read-only and live in `scripts/`. `npm run verify` uses a small Node runner that stops on the first failing check and prints the exact `npm run check:*` command to rerun while iterating. The template repo currently checks Markdown links, ADR index drift, command inventory drift, frontmatter conventions, lifecycle workflow-state consistency, and traceability ID references. Local repair helpers are intentionally separate: `npm run fix` runs all generated-block repairs, `npm run fix:adr-index` regenerates the ADR index, and `npm run fix:commands` regenerates command inventories.
+The check scripts are read-only and live in `scripts/`. `npm run verify` uses a small Node runner that stops on the first failing check and prints the exact `npm run check:*` command to rerun while iterating. The template repo currently checks Markdown links, ADR index drift, command inventory drift, TypeDoc-generated script documentation drift, frontmatter conventions, lifecycle workflow-state consistency, and traceability ID references. Local repair helpers are intentionally separate: `npm run fix` runs all generated-block repairs, `npm run fix:adr-index` regenerates the ADR index, `npm run fix:commands` regenerates command inventories, and `npm run fix:script-docs` regenerates `docs/scripts/` from JSDoc blocks.
 
 ## Reporting
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,296 @@
     "": {
       "name": "agentic-workflow",
       "version": "0.2.0",
+      "devDependencies": {
+        "@types/node": "^20.19.39",
+        "typedoc": "^0.28.19",
+        "typedoc-plugin-markdown": "^4.11.0"
+      },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@gerrit0/mini-shiki": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.23.0.tgz",
+      "integrity": "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-oniguruma": "^3.23.0",
+        "@shikijs/langs": "^3.23.0",
+        "@shikijs/themes": "^3.23.0",
+        "@shikijs/types": "^3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/typedoc": {
+      "version": "0.28.19",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.19.tgz",
+      "integrity": "sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@gerrit0/mini-shiki": "^3.23.0",
+        "lunr": "^2.3.9",
+        "markdown-it": "^14.1.1",
+        "minimatch": "^10.2.5",
+        "yaml": "^2.8.3"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 18",
+        "pnpm": ">= 10"
+      },
+      "peerDependencies": {
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x"
+      }
+    },
+    "node_modules/typedoc-plugin-markdown": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.11.0.tgz",
+      "integrity": "sha512-2iunh2ALyfyh204OF7h2u0kuQ84xB3jFZtFyUr01nThJkLvR8oGGSSDlyt2gyO4kXhvUxDcVbO0y43+qX+wFbw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "typedoc": "0.28.x"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -8,14 +8,22 @@
     "check:links": "node scripts/check-markdown-links.js",
     "check:adr-index": "node scripts/check-adr-index.js",
     "check:commands": "node scripts/check-command-docs.js",
+    "check:script-docs": "node scripts/check-script-docs.js",
     "check:frontmatter": "node scripts/check-frontmatter.js",
     "check:specs": "node scripts/check-spec-state.js",
     "check:traceability": "node scripts/check-traceability.js",
+    "docs:scripts": "typedoc --options typedoc.json",
     "fix": "node scripts/fix-generated.js",
     "fix:adr-index": "node scripts/fix-adr-index.js",
-    "fix:commands": "node scripts/fix-command-docs.js"
+    "fix:commands": "node scripts/fix-command-docs.js",
+    "fix:script-docs": "node scripts/fix-script-docs.js"
   },
   "engines": {
     "node": ">=20"
+  },
+  "devDependencies": {
+    "@types/node": "^20.19.39",
+    "typedoc": "^0.28.19",
+    "typedoc-plugin-markdown": "^4.11.0"
   }
 }

--- a/scripts/check-script-docs.js
+++ b/scripts/check-script-docs.js
@@ -1,0 +1,87 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { failIfErrors, readText, repoRoot, toPosix } from "./lib/repo.js";
+
+const outputDir = path.join(repoRoot, "docs/scripts");
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentic-workflow-script-docs-"));
+const generatedDir = path.join(tempDir, "scripts");
+const errors = [];
+
+try {
+  const result = spawnNpm(["run", "docs:scripts", "--", "--out", generatedDir], {
+    cwd: repoRoot,
+    stdio: "inherit",
+    windowsHide: true,
+  });
+
+  if (result.error) {
+    console.error(result.error.message);
+    process.exit(1);
+  }
+
+  if (result.status !== 0) {
+    process.exit(result.status || 1);
+  }
+
+  compareGeneratedDocs();
+  failIfErrors(errors, "check:script-docs");
+} finally {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+}
+
+function compareGeneratedDocs() {
+  const expected = new Map(markdownRecords(outputDir).map((record) => [record.rel, record]));
+  const actual = new Map(markdownRecords(generatedDir).map((record) => [record.rel, record]));
+  const paths = [...new Set([...expected.keys(), ...actual.keys()])].sort();
+
+  for (const rel of paths) {
+    const expectedRecord = expected.get(rel);
+    const actualRecord = actual.get(rel);
+    if (!expectedRecord) {
+      errors.push(`docs/scripts missing generated file: ${rel}`);
+      continue;
+    }
+    if (!actualRecord) {
+      errors.push(`docs/scripts contains stale file: ${rel}`);
+      continue;
+    }
+    if (readText(expectedRecord.filePath) !== readText(actualRecord.filePath)) {
+      errors.push(`docs/scripts/${rel} is out of date; run npm run fix:script-docs`);
+    }
+  }
+}
+
+function markdownRecords(root) {
+  if (!fs.existsSync(root)) return [];
+  return walkMarkdownFiles(root).map((filePath) => ({
+    filePath,
+    rel: toPosix(path.relative(root, filePath)),
+  }));
+}
+
+function walkMarkdownFiles(root) {
+  const results = [];
+
+  function walk(current) {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const filePath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        walk(filePath);
+        continue;
+      }
+      if (entry.isFile() && entry.name.endsWith(".md")) results.push(filePath);
+    }
+  }
+
+  walk(root);
+  return results.sort((a, b) => toPosix(path.relative(root, a)).localeCompare(toPosix(path.relative(root, b))));
+}
+
+function spawnNpm(args, options) {
+  if (process.env.npm_execpath) {
+    return spawnSync(process.execPath, [process.env.npm_execpath, ...args], options);
+  }
+  return spawnSync(process.platform === "win32" ? "npm.cmd" : "npm", args, options);
+}

--- a/scripts/fix-script-docs.js
+++ b/scripts/fix-script-docs.js
@@ -1,0 +1,20 @@
+import { spawnSync } from "node:child_process";
+
+const result = spawnNpm(["run", "docs:scripts"], {
+  stdio: "inherit",
+  windowsHide: true,
+});
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+process.exit(result.status || 0);
+
+function spawnNpm(args, options) {
+  if (process.env.npm_execpath) {
+    return spawnSync(process.execPath, [process.env.npm_execpath, ...args], options);
+  }
+  return spawnSync(process.platform === "win32" ? "npm.cmd" : "npm", args, options);
+}

--- a/scripts/lib/adr.js
+++ b/scripts/lib/adr.js
@@ -2,6 +2,21 @@ import fs from "node:fs";
 import path from "node:path";
 import { extractFrontmatter, parseSimpleYaml, readText, repoRoot } from "./repo.js";
 
+/**
+ * ADR metadata used by generated index checks.
+ *
+ * @typedef {object} AdrRecord
+ * @property {string} number - Four-digit ADR number from the filename.
+ * @property {string} fileName - Markdown filename below `docs/adr`.
+ * @property {unknown} title - Title from frontmatter, heading text, or filename fallback.
+ * @property {unknown} status - Normalized status from frontmatter, body text, or fallback.
+ */
+
+/**
+ * Read ADR metadata from `docs/adr`.
+ *
+ * @returns {AdrRecord[]} ADR records sorted by filename.
+ */
 export function getAdrs() {
   const dir = path.join(repoRoot, "docs/adr");
   return fs
@@ -20,6 +35,11 @@ export function getAdrs() {
     });
 }
 
+/**
+ * Render the generated ADR index table used by `docs/adr/README.md`.
+ *
+ * @returns {string} Markdown table containing ADR number, title, and status.
+ */
 export function renderAdrIndex() {
   const rows = [
     "| # | Title | Status |",
@@ -43,6 +63,12 @@ function statusFromBody(text) {
   return firstLine || null;
 }
 
+/**
+ * Convert an ADR status string to title case for stable generated output.
+ *
+ * @param {unknown} value - Raw status value from frontmatter or body text.
+ * @returns {unknown} Title-cased status string, or the original falsy value.
+ */
 export function normalizeStatus(value) {
   if (!value) return value;
   return String(value)

--- a/scripts/lib/commands.js
+++ b/scripts/lib/commands.js
@@ -11,6 +11,20 @@ const labels = new Map([
   ["stock-taking", "Stock-taking Track"],
 ]);
 
+/**
+ * Slash-command metadata discovered from `.claude/commands`.
+ *
+ * @typedef {object} CommandRecord
+ * @property {string} namespace - Command namespace, such as `spec` or `adr`.
+ * @property {string} name - Command name without the `.md` extension.
+ * @property {string} command - Slash-command invocation, such as `/spec:idea`.
+ */
+
+/**
+ * Discover slash-command Markdown files under `.claude/commands`.
+ *
+ * @returns {CommandRecord[]} Command records sorted by slash-command name.
+ */
 export function getCommands() {
   return walkFiles(".claude/commands", (file) => file.endsWith(".md"))
     .filter((file) => path.basename(file) !== "README.md")
@@ -28,6 +42,13 @@ export function getCommands() {
     .sort((a, b) => a.command.localeCompare(b.command));
 }
 
+/**
+ * Render the slash-command inventory block used in generated documentation.
+ *
+ * @param {{ fenced?: boolean }} [options] - Rendering options.
+ * @param {boolean} [options.fenced=false] - Wrap the inventory in a Markdown code fence.
+ * @returns {string} Markdown inventory grouped by command namespace.
+ */
 export function renderCommandInventory({ fenced = false } = {}) {
   const groups = new Map();
   for (const command of getCommands()) {

--- a/scripts/lib/repo.js
+++ b/scripts/lib/repo.js
@@ -2,6 +2,12 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+/**
+ * Absolute filesystem path to the repository root.
+ *
+ * Script helpers resolve all checked and generated paths from this directory so
+ * commands behave the same regardless of the caller's current working directory.
+ */
 export const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 
 const ignoredDirs = new Set([
@@ -14,22 +20,62 @@ const ignoredDirs = new Set([
   "coverage",
 ]);
 
+/**
+ * Parsed frontmatter from a Markdown document.
+ *
+ * @typedef {object} FrontmatterBlock
+ * @property {string} raw - YAML text between delimiter lines.
+ * @property {string} body - Markdown content after the frontmatter block.
+ */
+
+/**
+ * Convert a platform-specific path to a slash-delimited path for Markdown output.
+ *
+ * @param {string} filePath - Path using the current operating system separator.
+ * @returns {string} The same path using `/` separators.
+ */
 export function toPosix(filePath) {
   return filePath.split(path.sep).join("/");
 }
 
+/**
+ * Format an absolute repository path as a stable path relative to the repo root.
+ *
+ * @param {string} filePath - Absolute or repository-root-relative path.
+ * @returns {string} POSIX-style path relative to {@link repoRoot}.
+ */
 export function relativeToRoot(filePath) {
   return toPosix(path.relative(repoRoot, filePath));
 }
 
+/**
+ * Read a UTF-8 text file.
+ *
+ * @param {string} filePath - File path to read.
+ * @returns {string} File contents.
+ */
 export function readText(filePath) {
   return fs.readFileSync(filePath, "utf8");
 }
 
+/**
+ * Write a UTF-8 text file.
+ *
+ * @param {string} filePath - File path to write.
+ * @param {string} text - Complete replacement contents.
+ */
 export function writeText(filePath, text) {
   fs.writeFileSync(filePath, text, "utf8");
 }
 
+/**
+ * Recursively list files below a repository directory while skipping generated
+ * and dependency folders.
+ *
+ * @param {string} startDir - Directory to walk, relative to {@link repoRoot}.
+ * @param {(filePath: string) => boolean} [predicate] - Optional file filter.
+ * @returns {string[]} Absolute file paths sorted by repository-relative path.
+ */
 export function walkFiles(startDir, predicate = () => true) {
   const results = [];
   const root = path.join(repoRoot, startDir);
@@ -50,10 +96,21 @@ export function walkFiles(startDir, predicate = () => true) {
   return results.sort((a, b) => relativeToRoot(a).localeCompare(relativeToRoot(b)));
 }
 
+/**
+ * List all Markdown files tracked by repository checks.
+ *
+ * @returns {string[]} Absolute paths to Markdown files.
+ */
 export function markdownFiles() {
   return walkFiles(".", (file) => file.endsWith(".md"));
 }
 
+/**
+ * Print accumulated validation errors and terminate the current Node process.
+ *
+ * @param {string[]} errors - Human-readable validation errors.
+ * @param {string} heading - Check name shown before the result.
+ */
 export function failIfErrors(errors, heading) {
   if (errors.length === 0) {
     console.log(`${heading}: ok`);
@@ -65,6 +122,12 @@ export function failIfErrors(errors, heading) {
   process.exit(1);
 }
 
+/**
+ * Extract YAML frontmatter from a Markdown document.
+ *
+ * @param {string} text - Markdown document contents.
+ * @returns {FrontmatterBlock | null} Frontmatter and body, or null when no frontmatter block exists.
+ */
 export function extractFrontmatter(text) {
   if (!text.startsWith("---\n") && !text.startsWith("---\r\n")) return null;
   const normalized = text.replace(/\r\n/g, "\n");
@@ -76,6 +139,16 @@ export function extractFrontmatter(text) {
   };
 }
 
+/**
+ * Parse the small YAML subset used by repository state files.
+ *
+ * This parser intentionally supports only the structures needed by local
+ * checks: scalar keys, one-level nested maps, inline arrays, quoted strings,
+ * integers, and null markers.
+ *
+ * @param {string} raw - Raw frontmatter without delimiter lines.
+ * @returns {Record<string, unknown>} Parsed YAML data.
+ */
 export function parseSimpleYaml(raw) {
   const data = {};
   const lines = raw.split("\n");
@@ -132,6 +205,15 @@ function parseYamlScalar(value) {
   return value.replace(/^["']|["']$/g, "");
 }
 
+/**
+ * Replace a named generated Markdown block.
+ *
+ * @param {string} text - Source document containing generated block markers.
+ * @param {string} name - Marker name from `BEGIN GENERATED: <name>`.
+ * @param {string} content - Generated content to place between markers.
+ * @returns {string} Updated document contents.
+ * @throws {Error} When the named block markers are missing.
+ */
 export function replaceGeneratedBlock(text, name, content) {
   const begin = `<!-- BEGIN GENERATED: ${name} -->`;
   const end = `<!-- END GENERATED: ${name} -->`;

--- a/scripts/lib/runner.js
+++ b/scripts/lib/runner.js
@@ -1,5 +1,17 @@
 import { spawnSync } from "node:child_process";
 
+/**
+ * Run a list of Node-backed repository tasks in sequence.
+ *
+ * Each task is executed with the current Node binary. The runner prints a
+ * concise reproduce command when a task fails, which keeps `npm run verify`
+ * output actionable.
+ *
+ * @param {{ name: string, label: string, script: string }[]} tasks - Tasks to execute.
+ * @param {{ heading?: string, stopOnFailure?: boolean }} [options] - Runner behavior.
+ * @param {string} [options.heading="runner"] - Prefix for progress messages.
+ * @param {boolean} [options.stopOnFailure=true] - Exit immediately when a task fails.
+ */
 export function runNodeTasks(tasks, options = {}) {
   const { heading = "runner", stopOnFailure = true } = options;
   const startedAt = Date.now();

--- a/scripts/lib/tasks.js
+++ b/scripts/lib/tasks.js
@@ -1,3 +1,20 @@
+/**
+ * Script task consumed by the shared Node task runner.
+ *
+ * @typedef {object} NodeTask
+ * @property {string} name - npm script name used in reproduce output.
+ * @property {string} label - Human-readable task label.
+ * @property {string} script - Repository-relative Node script path.
+ */
+
+/**
+ * Read-only checks executed by `npm run verify`.
+ *
+ * Keep this list in the order checks should fail during local iteration: cheap
+ * generated-output checks first, broader consistency checks last.
+ *
+ * @type {NodeTask[]}
+ */
 export const checkTasks = [
   {
     name: "check:links",
@@ -13,6 +30,11 @@ export const checkTasks = [
     name: "check:commands",
     label: "Command inventories",
     script: "scripts/check-command-docs.js",
+  },
+  {
+    name: "check:script-docs",
+    label: "Generated script docs",
+    script: "scripts/check-script-docs.js",
   },
   {
     name: "check:frontmatter",
@@ -31,6 +53,11 @@ export const checkTasks = [
   },
 ];
 
+/**
+ * Deterministic repair tasks executed by `npm run fix`.
+ *
+ * @type {NodeTask[]}
+ */
 export const fixTasks = [
   {
     name: "fix:adr-index",
@@ -41,5 +68,10 @@ export const fixTasks = [
     name: "fix:commands",
     label: "Command inventories",
     script: "scripts/fix-command-docs.js",
+  },
+  {
+    name: "fix:script-docs",
+    label: "Generated script docs",
+    script: "scripts/fix-script-docs.js",
   },
 ];

--- a/tsconfig.typedoc.json
+++ b/tsconfig.typedoc.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": false,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["scripts/**/*.js"]
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,13 @@
+{
+  "entryPoints": ["scripts/**/*.js"],
+  "entryPointStrategy": "expand",
+  "exclude": ["scripts/README.md"],
+  "out": "docs/scripts",
+  "plugin": ["typedoc-plugin-markdown"],
+  "tsconfig": "tsconfig.typedoc.json",
+  "readme": "scripts/README.md",
+  "hideGenerator": true,
+  "disableSources": true,
+  "excludePrivate": true,
+  "excludeInternal": true
+}


### PR DESCRIPTION
## Summary
- Add TypeDoc plus the Markdown plugin to generate `docs/scripts/` from JSDoc blocks in `scripts/**/*.js`.
- Add `npm run docs:scripts`, `npm run check:script-docs`, and `npm run fix:script-docs`, with the docs drift check included in `npm run verify`.
- Document the JSDoc convention for script helpers and add JSDoc blocks to the shared script helper modules.

## Dependency justification
- `typedoc` and `typedoc-plugin-markdown` generate Markdown API docs directly from JavaScript JSDoc comments.
- `@types/node` is scoped to the TypeDoc config so TypeDoc can resolve Node built-in modules while reading plain ESM scripts.

## Verification
- `npm run verify`

## Known limitations
- The generated docs cover exported helpers and module surfaces. Top-level CLI scripts should remain thin and delegate reusable behavior to documented helpers.