### PR TITLE
docs(how-to): fill 9 planned stubs to MVP quality

### DIFF
--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -8,29 +8,33 @@ For the full doc map by Diátaxis quadrant — Tutorials / How-to / Reference / 
 
 ## Available recipes
 
-These five are the MVP set. Each is short, runnable, and links out for the *why*.
+All recipes below are runnable and link out for the *why*. The first five are the original MVP set; the next nine were promoted from stubs as the workflow surface stabilised.
+
+**Onboarding and configuration**
 
 - [How to fork and personalize the template](./fork-and-personalize.md) — turn a fresh clone into your own project.
+- [How to adapt steering for your own stack](./adapt-steering.md) — rewrite `docs/steering/*.md` so agents read your real context.
+- [How to customize agent permissions](./customize-agent-permissions.md) — change a tool list at the per-agent or project level.
+- [How to migrate an existing project to Specorator](./migrate-to-specorator.md) — overlay the workflow on a brownfield codebase.
+
+**Day-to-day workflow tasks**
+
 - [How to resume a paused feature](./resume-paused-feature.md) — pick up an in-progress feature at the right stage.
-- [How to file a new Architecture Decision Record](./add-adr.md) — capture an irreversible decision in `docs/adr/`.
+- [How to skip the Discovery Track on a simple feature](./skip-discovery.md) — go straight to `/spec:idea` and document the skip.
 - [How to write a requirement in EARS notation](./write-ears-requirement.md) — produce one functional requirement, ready for testing.
-- [How to run the verify gate](./run-verify-gate.md) — green formatter / linter / types / tests / build before pushing.
+- [How to file a new Architecture Decision Record](./add-adr.md) — capture an irreversible decision in `docs/adr/`.
+- [How to run the verify gate](./run-verify-gate.md) — `npm run verify` green before pushing.
 
-## Planned recipes
+**Quality and release**
 
-These are scaffolds with the goal, when-to-use, and links written, but no steps yet. Each is a one-PR job — copy [`_template.md`](./_template.md), fill it in, replace the stub.
+- [How to trace a failing test back to a requirement](./trace-failing-test.md) — walk the chain to find which layer the defect lives in.
+- [How to run a retrospective](./run-retrospective.md) — Stage 11, mandatory before marking a feature complete.
+- [How to authorize a destructive release action](./authorize-destructive-release.md) — scope, approve, log, execute.
 
-- [How to skip the Discovery Track on a simple feature](./skip-discovery.md) — 🚧 planned.
-- [How to customize agent permissions](./customize-agent-permissions.md) — 🚧 planned.
-- [How to adapt steering for your own stack](./adapt-steering.md) — 🚧 planned.
-- [How to trace a failing test back to a requirement](./trace-failing-test.md) — 🚧 planned.
-- [How to switch from Claude Code to Codex / Cursor / Aider](./switch-ai-tool.md) — 🚧 planned.
-- [How to run a retrospective](./run-retrospective.md) — 🚧 planned.
-- [How to authorize a destructive release action](./authorize-destructive-release.md) — 🚧 planned.
-- [How to bootstrap a new operational bot](./bootstrap-operational-bot.md) — 🚧 planned.
-- [How to migrate an existing project to Specorator](./migrate-to-specorator.md) — 🚧 planned.
+**Tooling and extensibility**
 
-Stubs older than 90 days without traction get promoted to GitHub issues; if the planned list still exceeds five at the next docs review, unfilled stubs are dropped.
+- [How to switch from Claude Code to Codex / Cursor / Aider](./switch-ai-tool.md) — continue a feature in a different AI tool.
+- [How to bootstrap a new operational bot](./bootstrap-operational-bot.md) — scheduled bot under `agents/operational/`.
 
 ## Operational runbooks
 

--- a/docs/how-to/adapt-steering.md
+++ b/docs/how-to/adapt-steering.md
@@ -1,27 +1,31 @@
 # How to adapt steering for your own stack
 
-> 🚧 **Planned recipe — not written yet.** This stub is a placeholder so the entry in [`docs/how-to/README.md`](./README.md) resolves; the steps below will be filled in.
+**Goal:** rewrite `docs/steering/*.md` so every stage agent reads accurate context about your product, stack, UX, quality bar, and operational constraints.
 
-**Goal:** rewrite `docs/steering/*.md` so every agent in your project has accurate context about your product, tech stack, UX expectations, quality bar, and operational constraints.
-
-**When to use:** you have just forked the template **or** your stack has changed materially since the steering files were last written.
+**When to use:** you just forked the template, **or** your stack / product / quality bar shifted enough that the existing steering files would mislead an agent.
 
 **Prerequisites:**
 
-- _TBD_
+- Cloned repo on disk.
+- A clear picture of the product, stack, and operational reality.
+- Working tree on a topic branch.
 
 ## Steps
 
-1. _TBD_
+1. List the steering files — `ls docs/steering/`. Open [`docs/steering/README.md`](../steering/README.md) to see what each file is for.
+2. Open `docs/steering/product.md`. Replace placeholder content with one paragraph on what the product does and who it serves.
+3. Open `docs/steering/tech.md`. List language, framework, datastore, build system, deploy target, and any non-obvious tooling. Note anything that would surprise a new contributor.
+4. Open `docs/steering/ux.md`. Describe the design system, accessibility floor, and target devices. Skip if you have no UI.
+5. Open `docs/steering/quality.md`. Capture test expectations, lint rules, code-coverage floor, and review expectations.
+6. Open `docs/steering/operations.md` (or the project's equivalent). Note observability stack, on-call expectations, deploy cadence, and post-incident review rules.
+7. Commit each file with a focused message — `docs(steering): adapt tech.md to <stack>`.
 
 ## Verify
 
-_TBD_
+`git log --oneline docs/steering/` shows your edit commits, and an agent run on a tiny feature (e.g. `/spec:requirements`) cites your stack instead of the placeholder text.
 
 ## Related
 
-- Reference — [`docs/steering/`](../steering/) — the steering files an agent reads.
+- Reference — [`docs/steering/`](../steering/) — the files an agent reads.
 - How-to — [`fork-and-personalize.md`](./fork-and-personalize.md) — first-time personalization.
 - Explanation — [`docs/specorator.md`](../specorator.md) — how steering plugs into stage agents.
-
-> Want this written sooner? Open a PR — copy [`_template.md`](./_template.md) and fill it in.

--- a/docs/how-to/authorize-destructive-release.md
+++ b/docs/how-to/authorize-destructive-release.md
@@ -1,27 +1,32 @@
 # How to authorize a destructive release action
 
-> 🚧 **Planned recipe — not written yet.** This stub is a placeholder so the entry in [`docs/how-to/README.md`](./README.md) resolves; the steps below will be filled in.
+**Goal:** scope, approve, log, and execute an irreversible release action — deploy, force-push to a release branch, prod data migration — so the agent runs it once with explicit human authorization and a paper trail.
 
-**Goal:** scope, approve, and log an irreversible release action (deploy, force-push to a release branch, prod data migration) so the agent can execute it once and only once, with a paper trail.
-
-**When to use:** Stage 10 (`/spec:release`) has produced a release plan that includes an irreversible step requiring explicit human authorization per Article IX.
+**When to use:** Stage 10 (`/spec:release`) has produced a release plan that includes a step the agent cannot run autonomously per [Article IX](../../memory/constitution.md).
 
 **Prerequisites:**
 
-- _TBD_
+- `specs/<slug>/release-notes.md` and the release plan exist.
+- A named human Decider available to authorize the action.
+- Both the destructive command AND its rollback procedure written down before you ask.
 
 ## Steps
 
-1. _TBD_
+1. Open `specs/<slug>/release-notes.md` and find the section labelled `Authorization required:`. Each item there is a destructive action.
+2. For each item, write a one-line **scope statement** — exactly which command, against which environment, on which artifact. No vague verbs (no "deploy"; instead, "run `kubectl apply -f manifests/prod/api.yaml` against cluster `prod-eu`").
+3. Write a one-line **rollback statement** — what the human will run if the action goes wrong, within how many minutes. If there is no rollback, say so explicitly.
+4. Send the scope + rollback to the named Decider. Wait for an explicit *"approved"* response. Capture the approval (Slack permalink, email, signed PR comment) in `release-notes.md` under `Authorization log:` with a UTC timestamp.
+5. Run the command exactly as scoped. Do not generalise the scope; do not retry without re-asking the Decider.
+6. Capture the actual outcome — exit code, full output — in `release-notes.md` under `Execution log:`. Time-stamp it.
+7. If the action failed, run the rollback. Authorization to rollback is implied by the prior approval; authorization to **retry** is not — re-ask the Decider.
+8. Commit the updated `release-notes.md` with message `docs(release): authorize <slug> step <N>`.
 
 ## Verify
 
-_TBD_
+`release-notes.md` has both `Authorization log:` and `Execution log:` filled with UTC timestamps and the Decider's identity, and the production environment is in the expected post-release state.
 
 ## Related
 
 - Reference — [`docs/specorator.md`](../specorator.md) — Stage 10 definition.
 - Reference — [`.claude/agents/release-manager.md`](../../.claude/agents/release-manager.md) — agent scope.
 - Explanation — [`memory/constitution.md`](../../memory/constitution.md) — Article IX on reversibility.
-
-> Want this written sooner? Open a PR — copy [`_template.md`](./_template.md) and fill it in.

--- a/docs/how-to/bootstrap-operational-bot.md
+++ b/docs/how-to/bootstrap-operational-bot.md
@@ -1,27 +1,32 @@
 # How to bootstrap a new operational bot
 
-> 🚧 **Planned recipe — not written yet.** This stub is a placeholder so the entry in [`docs/how-to/README.md`](./README.md) resolves; the steps below will be filled in.
+**Goal:** add a new bot under `agents/operational/<name>/` with the eight-section common shape, wired to the project's scheduling harness.
 
-**Goal:** add a new scheduled bot under `agents/operational/<name>/` that follows the eight-section common shape and integrates with the project's scheduling harness.
-
-**When to use:** you have a recurring repo task — drift detection, dep triage, plan reconciliation — that should run on a cron, not on demand.
+**When to use:** you have a recurring repo task — drift detection, dep triage, plan reconciliation, alert triage — that should run on a cron, not on demand.
 
 **Prerequisites:**
 
-- _TBD_
+- A clear answer to: what input the bot reads, what output it produces, on what cadence, and what severity scale it uses.
+- An existing bot you can mirror (e.g. [`agents/operational/docs-review-bot/`](../../agents/operational/docs-review-bot/)).
+- Working tree on a topic branch.
 
 ## Steps
 
-1. _TBD_
+1. Pick a slug. Convention — `<area>-<verb>-bot` (e.g. `pr-triage-bot`, `dep-bump-bot`).
+2. Create `agents/operational/<slug>/` with two files: `PROMPT.md` (the source of truth the scheduled run loads) and `README.md` (the contributor-facing docs).
+3. Open [`agents/operational/README.md`](../../agents/operational/README.md) and read the eight-section common shape. The required sections in `PROMPT.md` are — Role, Scope this run, Severity, What to flag, Process, Hard rules, Output, Idempotency, Failure handling, Dry-run mode, Do not.
+4. Fill each section. Use the canonical four-tier severity scale (`[BLOCKER]` / `[MAJOR]` / `[MINOR]` / `[NIT]`) unless you have a documented reason to specialise it.
+5. Wire the cron. Add a workflow under `.github/workflows/` modelled on the existing bots' workflows. The schedule is part of the workflow file, not the prompt.
+6. Run a dry-run by setting the env var the bot uses (commonly `DRY_RUN=1`). Confirm output goes to stdout, not the live sink (issue, Slack, etc.).
+7. Add the new bot to the index list in `agents/operational/README.md` — same row shape as the existing entries.
+8. Commit; open a PR.
 
 ## Verify
 
-_TBD_
+`ls agents/operational/<slug>/` shows both `PROMPT.md` and `README.md`; the dry-run produces a non-empty plausible output; the new workflow file appears under `.github/workflows/`; the index in `agents/operational/README.md` lists the bot.
 
 ## Related
 
-- Reference — [`agents/operational/README.md`](../../agents/operational/README.md) — the eight-section shape.
+- Reference — [`agents/operational/README.md`](../../agents/operational/README.md) — the eight-section shape and severity scale.
 - Reference — [`agents/operational/`](../../agents/operational/) — existing bots as examples.
 - Explanation — [`docs/specorator.md`](../specorator.md) — where operational agents fit relative to lifecycle agents.
-
-> Want this written sooner? Open a PR — copy [`_template.md`](./_template.md) and fill it in.

--- a/docs/how-to/bootstrap-operational-bot.md
+++ b/docs/how-to/bootstrap-operational-bot.md
@@ -14,8 +14,8 @@
 
 1. Pick a slug. Convention — `<area>-<verb>-bot` (e.g. `pr-triage-bot`, `dep-bump-bot`).
 2. Create `agents/operational/<slug>/` with two files: `PROMPT.md` (the source of truth the scheduled run loads) and `README.md` (the contributor-facing docs).
-3. Open [`agents/operational/README.md`](../../agents/operational/README.md) and read the eight-section common shape. The required sections in `PROMPT.md` are — Role, Scope this run, Severity, What to flag, Process, Hard rules, Output, Idempotency, Failure handling, Dry-run mode, Do not.
-4. Fill each section. Use the canonical four-tier severity scale (`[BLOCKER]` / `[MAJOR]` / `[MINOR]` / `[NIT]`) unless you have a documented reason to specialise it.
+3. Open [`agents/operational/README.md`](../../agents/operational/README.md) and read the eight-section common shape. The exact required headings, in order, are — `## Role`, `## Scope this run`, `## Process`, `## Hard rules`, `## Output`, `## Idempotency`, `## Failure handling`, `## Dry-run mode`. Do not rename them. Bots may add their own sections (e.g. `## Severity`, `## What to flag`, `## Do not`) underneath or alongside, but the eight above are the contract.
+4. Fill each section. Use the canonical four-tier severity scale (`[BLOCKER]` / `[MAJOR]` / `[MINOR]` / `[NIT]`) from the parent README unless you have a documented reason to specialise it.
 5. Wire the cron. Add a workflow under `.github/workflows/` modelled on the existing bots' workflows. The schedule is part of the workflow file, not the prompt.
 6. Run a dry-run by setting the env var the bot uses (commonly `DRY_RUN=1`). Confirm output goes to stdout, not the live sink (issue, Slack, etc.).
 7. Add the new bot to the index list in `agents/operational/README.md` — same row shape as the existing entries.

--- a/docs/how-to/customize-agent-permissions.md
+++ b/docs/how-to/customize-agent-permissions.md
@@ -1,27 +1,32 @@
 # How to customize agent permissions
 
-> 🚧 **Planned recipe — not written yet.** This stub is a placeholder so the entry in [`docs/how-to/README.md`](./README.md) resolves; the steps below will be filled in.
+**Goal:** add or remove a tool, Bash command, or path permission for a specific agent — at the per-agent level (`.claude/agents/<name>.md` frontmatter) or at the project level (`.claude/settings.json`).
 
-**Goal:** loosen or tighten the tool list and `Bash` rules an agent uses, in `.claude/settings.json` or a per-agent frontmatter, without breaking the workflow's safety story.
-
-**When to use:** an agent cannot do its job because of a missing permission, **or** an agent has a tool it should not need and you want to remove it.
+**When to use:** an agent fails because a tool it needs is denied, **or** an agent has a tool it should not have.
 
 **Prerequisites:**
 
-- _TBD_
+- Working tree on a topic branch.
+- You know which agent (e.g. `dev`, `qa`, `release-manager`) and which permission is involved.
+- For loosening (removing a deny rule): a clear rationale ready for an ADR.
 
 ## Steps
 
-1. _TBD_
+1. Open the agent file at `.claude/agents/<name>.md` and read the `tools:` line in its frontmatter. The tools listed are the only ones it can call.
+2. Read [`.claude/settings.json`](../../.claude/settings.json) for project-wide permission rules — `permissions.allow`, `permissions.deny`, and any hooks.
+3. Decide scope. **Per-agent** change → edit the frontmatter `tools:` list. **Project-wide** → edit `.claude/settings.json`.
+4. Make the edit. Keep tool lists minimal — add only what the failure traces to.
+5. If you are loosening a deny rule, file an ADR with `/adr:new "<title>"`. Tightening (removing an allow rule) does not need an ADR.
+6. Re-run the failing scenario; confirm the previously-blocked operation now succeeds (or, for tightening, that it now fails as intended).
+7. Run `npm run verify` to confirm no other check broke.
 
 ## Verify
 
-_TBD_
+The previously-failing operation now succeeds in the agent's session, AND `npm run verify` is green.
 
 ## Related
 
 - Reference — [`.claude/settings.json`](../../.claude/settings.json) — permission baseline.
 - Reference — [`.claude/agents/`](../../.claude/agents/) — per-agent tool lists.
 - Explanation — [`AGENTS.md`](../../AGENTS.md) — why tool restrictions are deliberate.
-
-> Want this written sooner? Open a PR — copy [`_template.md`](./_template.md) and fill it in.
+- How-to — [`add-adr.md`](./add-adr.md) — file the ADR when loosening.

--- a/docs/how-to/migrate-to-specorator.md
+++ b/docs/how-to/migrate-to-specorator.md
@@ -1,27 +1,32 @@
 # How to migrate an existing project to Specorator
 
-> 🚧 **Planned recipe — not written yet.** This stub is a placeholder so the entry in [`docs/how-to/README.md`](./README.md) resolves; the steps below will be filled in.
+**Goal:** overlay the Specorator workflow on a brownfield project that is already shipping code, without disrupting in-flight work.
 
-**Goal:** take a project that already has code, history, and contributors, and overlay the Specorator workflow on it without breaking ongoing work.
-
-**When to use:** you want the spec-driven workflow on a brownfield codebase that is already shipping — typically after running the Stock-taking Track to inventory what's there.
+**When to use:** you want spec-driven discipline on a codebase that has history, contributors, and existing process.
 
 **Prerequisites:**
 
-- _TBD_
+- Repo cloned with write access.
+- Time and budget to run a Stock-taking Track first — typically 1–3 days.
+- Buy-in from at least one team lead.
 
 ## Steps
 
-1. _TBD_
+1. Run the Stock-taking Track first — `/stock:start <slug>` → `/stock:scope` → `/stock:audit` → `/stock:synthesize` → `/stock:handoff`. The output `stock-taking-inventory.md` becomes the input for the next steps. See [`docs/stock-taking-track.md`](../stock-taking-track.md).
+2. Add Specorator scaffolding to the repo — copy `memory/`, `templates/`, `docs/specorator.md`, `docs/steering/`, `docs/quality-framework.md`, `.claude/agents/`, `.claude/skills/`, `.claude/commands/`, and `AGENTS.md` from the template repo. Do not overwrite existing files; merge where there is a name clash.
+3. Adapt steering — follow [`adapt-steering.md`](./adapt-steering.md) so `docs/steering/*.md` reflects your real stack.
+4. Adapt the constitution — copy `memory/constitution.md` from the template, then edit any article that conflicts with the team's existing principles.
+5. File an ADR — `/adr:new "Adopt Specorator workflow"` — recording the date, the migrate-from state, the chosen subset of stages (you may opt-out of, e.g., the Discovery Track for now), and any modifications. See [`add-adr.md`](./add-adr.md).
+6. Run `/spec:start <feature-slug>` for the next feature you ship; treat it as the first dogfood. Adjust the scaffolding based on what hurts.
+7. After 2–3 features, run a retrospective focused on the migration itself; promote learnings into `feedback_*.md` files under `.claude/memory/`.
 
 ## Verify
 
-_TBD_
+`ls memory/ docs/specorator.md docs/steering/ .claude/agents/ AGENTS.md` all return successfully; the next feature uses the `/spec:*` flow end-to-end; an ADR documents the migration decision.
 
 ## Related
 
-- Reference — [`docs/stock-taking-track.md`](../stock-taking-track.md) — the inventory step that should run first.
+- Reference — [`docs/stock-taking-track.md`](../stock-taking-track.md) — the inventory step that runs first.
 - Reference — [`docs/specorator.md`](../specorator.md) — the workflow being adopted.
 - Explanation — [ADR-0007](../adr/0007-add-stock-taking-track-for-legacy-projects.md) — why brownfield gets its own track.
-
-> Want this written sooner? Open a PR — copy [`_template.md`](./_template.md) and fill it in.
+- How-to — [`fork-and-personalize.md`](./fork-and-personalize.md), [`adapt-steering.md`](./adapt-steering.md), [`add-adr.md`](./add-adr.md).

--- a/docs/how-to/run-retrospective.md
+++ b/docs/how-to/run-retrospective.md
@@ -1,27 +1,32 @@
 # How to run a retrospective
 
-> 🚧 **Planned recipe — not written yet.** This stub is a placeholder so the entry in [`docs/how-to/README.md`](./README.md) resolves; the steps below will be filled in.
-
 **Goal:** run Stage 11 (`/spec:retro`) on a feature, capture what worked / didn't / what to change, and propose concrete amendments to templates, agents, or the constitution.
 
-**When to use:** the feature has shipped (or been killed) and you are about to mark it complete; the retrospective is mandatory.
+**When to use:** the feature has shipped or been killed; the retrospective is mandatory before marking the feature complete (Article X).
 
 **Prerequisites:**
 
-- _TBD_
+- Feature has reached Stage 9 (Review) with a verdict; Stage 10 (Release) is either done or explicitly skipped.
+- `specs/<slug>/workflow-state.md` says `Active stage: Stage 11 — Retrospective`.
+- Open Claude Code session, OR willingness to run the retrospective agent manually in another tool.
 
 ## Steps
 
-1. _TBD_
+1. Open Claude Code — `claude`.
+2. Run `/spec:retro`. The retrospective agent reads every prior artifact in `specs/<slug>/` and walks you through the questions.
+3. Answer each prompt. The agent captures three sections — **What worked**, **What didn't**, **Actions** (with owner and target date for each).
+4. The agent writes `specs/<slug>/retrospective.md` and proposes amendments to templates, agents, or [`memory/constitution.md`](../../memory/constitution.md). Each amendment is a separate suggestion you accept or reject.
+5. File accepted amendments as their own follow-up work — typically a `chore(memory): …` PR for `feedback_*.md`, or an ADR for constitution changes. See [`add-adr.md`](./add-adr.md).
+6. Update `workflow-state.md` to `Active stage: Complete`.
+7. Commit `retrospective.md` and any accepted amendments.
 
 ## Verify
 
-_TBD_
+`cat specs/<slug>/retrospective.md` shows the three sections filled, with at least one Action item (even *"none — feature shipped clean"* counts).
 
 ## Related
 
 - Reference — [`docs/specorator.md`](../specorator.md) — Stage 11 definition.
 - Reference — [`.claude/agents/retrospective.md`](../../.claude/agents/retrospective.md) — agent scope.
 - Explanation — [`memory/constitution.md`](../../memory/constitution.md) — Article X on iteration.
-
-> Want this written sooner? Open a PR — copy [`_template.md`](./_template.md) and fill it in.
+- How-to — [`add-adr.md`](./add-adr.md) — for constitution-level amendments.

--- a/docs/how-to/skip-discovery.md
+++ b/docs/how-to/skip-discovery.md
@@ -1,27 +1,30 @@
 # How to skip the Discovery Track on a simple feature
 
-> 🚧 **Planned recipe — not written yet.** This stub is a placeholder so the entry in [`docs/how-to/README.md`](./README.md) resolves; the steps below will be filled in.
+**Goal:** start a feature directly with `/spec:idea` and capture the skip-decision so reviewers can audit it later.
 
-**Goal:** decide when a feature is small or well-scoped enough to go straight to `/spec:idea` without running Frame → Diverge → … → Handoff first, and document the decision so reviewers understand why discovery was skipped.
-
-**When to use:** you have a clear, single-option brief and the team agrees discovery would not change the outcome.
+**When to use:** the brief is single-option and well-scoped, the problem is a known recurring pattern, and the team agrees discovery would not change the outcome.
 
 **Prerequisites:**
 
-- _TBD_
+- A written brief or one-liner ready.
+- No competing concept candidates worth exploring.
+- A reviewer or Decider available to challenge the skip if needed.
 
 ## Steps
 
-1. _TBD_
+1. Write a one-paragraph rationale: brief, why discovery is unnecessary, who agreed. Paste it into the conversation when you run `/spec:idea`.
+2. Run `/spec:start <slug>` to scaffold the feature directory.
+3. Run `/spec:idea`. The analyst will offer to invoke discovery if the brief looks blank — answer *"no, skipping discovery"* and paste your rationale.
+4. The analyst captures the rationale in `idea.md` under a `## Discovery skipped because…` section.
+5. Continue to `/spec:research` and onward as normal.
 
 ## Verify
 
-_TBD_
+`grep -i "discovery skipped" specs/<slug>/idea.md` returns a match containing your rationale.
 
 ## Related
 
-- Reference — [`docs/discovery-track.md`](../discovery-track.md)
-- Reference — [`docs/specorator.md`](../specorator.md)
+- Reference — [`docs/discovery-track.md`](../discovery-track.md) — when discovery DOES help.
+- Reference — [`docs/specorator.md`](../specorator.md) — Stage 1 (Idea) definition.
 - Explanation — [ADR-0005](../adr/0005-add-discovery-track-before-stage-1.md) — why Discovery exists in the first place.
-
-> Want this written sooner? Open a PR — copy [`_template.md`](./_template.md) and fill it in.
+- How-to — [`add-adr.md`](./add-adr.md) — file an ADR if the skip is policy-level.

--- a/docs/how-to/switch-ai-tool.md
+++ b/docs/how-to/switch-ai-tool.md
@@ -1,27 +1,31 @@
 # How to switch from Claude Code to Codex / Cursor / Aider
 
-> 🚧 **Planned recipe — not written yet.** This stub is a placeholder so the entry in [`docs/how-to/README.md`](./README.md) resolves; the steps below will be filled in.
+**Goal:** continue an in-progress feature in a different AI coding tool without losing stage state, traceability, or the workflow contract.
 
-**Goal:** continue an in-progress feature using a different AI coding tool, without losing stage state, traceability, or the workflow contract.
-
-**When to use:** your team is moving (or experimenting with moving) from Claude Code to another agent-capable editor and the artifact format must stay tool-agnostic.
+**When to use:** your team is moving (or experimenting with moving) to a non-Claude-Code tool, **or** a teammate on a different tool needs to pick up your work.
 
 **Prerequisites:**
 
-- _TBD_
+- Feature directory `specs/<slug>/` exists and is up to date in git.
+- The destination tool installed and configured.
+- Working tree on a topic branch.
 
 ## Steps
 
-1. _TBD_
+1. Confirm the destination tool reads [`AGENTS.md`](../../AGENTS.md) as its root context. All Specorator-supported tools do (Codex, Cursor, Aider, Copilot, Gemini). If your tool has a tool-specific config, point it at `AGENTS.md` via `@import` or the tool's equivalent.
+2. Commit and push any in-flight work in your current tool. The destination picks up from the *committed* state in `specs/<slug>/`.
+3. Open the destination tool in the repo root. Confirm it has loaded `AGENTS.md` and [`memory/constitution.md`](../../memory/constitution.md).
+4. Read `specs/<slug>/workflow-state.md`. Identify the active stage.
+5. Drive the matching stage manually — slash commands won't auto-run on most non-Claude-Code tools, so invoke the equivalent stage workflow by reading the relevant template under `templates/` and the agent definition under `.claude/agents/<role>.md`.
+6. Update `specs/<slug>/workflow-state.md` after you advance a stage, exactly as the slash commands would.
+7. Run `npm run verify` before pushing — it works regardless of tool.
 
 ## Verify
 
-_TBD_
+The destination tool successfully advances one stage and updates `workflow-state.md`; `npm run verify` is green; `git log --author=...` shows your commit on the destination tool.
 
 ## Related
 
 - Reference — [`AGENTS.md`](../../AGENTS.md) — cross-tool root context every supported tool reads.
 - Reference — [`.codex/`](../../.codex/) — Codex-specific instructions.
 - Explanation — [`docs/specorator.md`](../specorator.md) — why the workflow is tool-agnostic.
-
-> Want this written sooner? Open a PR — copy [`_template.md`](./_template.md) and fill it in.

--- a/docs/how-to/trace-failing-test.md
+++ b/docs/how-to/trace-failing-test.md
@@ -1,27 +1,30 @@
 # How to trace a failing test back to a requirement
 
-> 🚧 **Planned recipe — not written yet.** This stub is a placeholder so the entry in [`docs/how-to/README.md`](./README.md) resolves; the steps below will be filled in.
+**Goal:** start from a failing `TEST-<AREA>-NNN`, walk the chain back through code, task, spec, and requirement, and identify which layer the defect lives in before fixing it.
 
-**Goal:** start from a failing `TEST-<AREA>-NNN` and walk the chain back through code, task, spec, and requirement to identify where the defect actually lives, before you fix it.
-
-**When to use:** a test in `specs/<slug>/test-report.md` is red and you do not know whether the defect is in the test, the code, or the spec upstream.
+**When to use:** a test in `specs/<slug>/test-report.md` is red and you do not yet know whether the bug is in the test, the code, or the requirement upstream.
 
 **Prerequisites:**
 
-- _TBD_
+- A reproducible failing test with a `TEST-<AREA>-NNN` ID.
+- The feature's `specs/<slug>/` directory accessible.
+- The traceability matrix at `specs/<slug>/traceability.md` is up to date.
 
 ## Steps
 
-1. _TBD_
+1. Open `specs/<slug>/test-report.md`. Copy the failing `TEST-<AREA>-NNN` ID and its assertion text.
+2. Open `specs/<slug>/traceability.md`. Find the row whose Test column contains your ID. Note the linked `T-<AREA>-NNN` (task) and `REQ-<AREA>-NNN` (requirement).
+3. Open the test source. Re-read the assertion. Ask: does it actually verify the requirement, or does it test something close-but-different? If close-but-different, the defect is in the **test** — fix the test.
+4. Open the code under test. Step through the assertion mentally. Does the code do what the test expects? If no, the defect is in the **code** — fix the code, leave the test.
+5. Open the originating `REQ-<AREA>-NNN` in `requirements.md`. Does the requirement actually say what the test is checking? If no, the defect is in the **requirement** — escalate per [Article IV](../../memory/constitution.md): update `requirements.md` first, then re-spec, re-task, re-implement, re-test.
+6. Document your finding in the test report's `Notes:` field for the failure, with a one-liner naming the layer.
 
 ## Verify
 
-_TBD_
+`grep "<TEST-ID>" specs/<slug>/test-report.md` shows your finding line, and `git diff` shows the fix at exactly one layer (test, code, or requirement chain) — not all three.
 
 ## Related
 
 - Reference — [`docs/traceability.md`](../traceability.md) — the chain of IDs.
 - Reference — [`docs/quality-framework.md`](../quality-framework.md) — gates per stage.
 - Explanation — [`memory/constitution.md`](../../memory/constitution.md) — Article IV on resolving defects at the earliest stage.
-
-> Want this written sooner? Open a PR — copy [`_template.md`](./_template.md) and fill it in.


### PR DESCRIPTION
## Summary

Every 🚧 planned stub introduced in #35 is now a full, runnable recipe. The 14-recipe how-to surface is complete for v0.2.

Filled (each follows the standard recipe shape — Goal / When to use / Prerequisites / Steps / Verify / Related):

| Recipe | What it covers |
|--------|----------------|
| [skip-discovery](docs/how-to/skip-discovery.md) | go straight to `/spec:idea` and document the skip |
| [customize-agent-permissions](docs/how-to/customize-agent-permissions.md) | per-agent frontmatter vs project-wide `settings.json` |
| [adapt-steering](docs/how-to/adapt-steering.md) | walk every steering file, replace placeholders |
| [trace-failing-test](docs/how-to/trace-failing-test.md) | TEST → T → REQ chain walk to find the defect layer |
| [switch-ai-tool](docs/how-to/switch-ai-tool.md) | continue a feature in Codex / Cursor / Aider |
| [run-retrospective](docs/how-to/run-retrospective.md) | `/spec:retro` flow + accepted-amendment follow-ups |
| [authorize-destructive-release](docs/how-to/authorize-destructive-release.md) | scope, approve, log, execute under Article IX |
| [bootstrap-operational-bot](docs/how-to/bootstrap-operational-bot.md) | eight-section shape + dry-run + cron |
| [migrate-to-specorator](docs/how-to/migrate-to-specorator.md) | Stock-taking first, then scaffold + dogfood + retro |

[`docs/how-to/README.md`](docs/how-to/README.md) is re-organised — the 14 recipes are now grouped by intent (onboarding/configuration, day-to-day workflow, quality and release, tooling/extensibility) rather than by MVP-vs-planned status. The "Stubs older than 90 days…" promotion-cadence note is dropped because there are no stubs left to age out.

## Test plan

- [x] `npm run verify` green locally — links, ADR index, command inventories, script docs, frontmatter, spec state, traceability all pass.
- [x] Every filled recipe contains all required headings (Goal, When to use, Prerequisites, Steps, Verify, Related).
- [x] No section other than `## Steps` exceeds two sentences in any filled recipe.
- [x] No theory or rationale in recipe bodies; *why*-content is linked, not duplicated.
- [x] No new files added under `docs/` — this PR only edits existing files, so the hub-drift trigger does not fire (per the PROMPT.md rule clarified in #35).

## Out of scope

- Live tutorial validation (deferred to a separate branch as agreed).
- Recipes beyond the original 9 stubs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)