### PR TITLE
docs(tutorial): desk-validate first-feature against current main

### DIFF
--- a/docs/tutorials/first-feature.md
+++ b/docs/tutorials/first-feature.md
@@ -98,7 +98,7 @@ The first argument is the feature slug; the optional second is the area code tha
 
 **What happens:** the `pm` agent writes a PRD at `requirements.md` from `templates/prd-template.md`. The document's own ID is `PRD-DOCS-001`; functional requirements inside it use **EARS notation** with stable IDs `REQ-DOCS-NNN`. For this feature you should expect one or two requirements — e.g. *"Where the `docs/glossary/` directory is read, the system shall include a `tracer-bullet.md` entry with a one-sentence canonical definition."*
 
-**If you see this, you are on track:** `requirements.md` has frontmatter `id: PRD-DOCS-001`. Body has `## Goals`, `## Non-goals`, `## Personas / stakeholders`, `## Jobs to be done`, and a `## Requirements` section listing at least one `REQ-DOCS-NNN` line that uses one of the EARS keywords (`Where`, `When`, `If`, `While`, `Where`/`shall`). For the EARS reference, see [`docs/ears-notation.md`](../ears-notation.md).
+**If you see this, you are on track:** `requirements.md` has frontmatter `id: PRD-DOCS-001`. Body has `## Summary`, `## Goals`, `## Non-goals`, `## Personas / stakeholders`, `## Jobs to be done`, and a `## Functional requirements (EARS)` section listing at least one `REQ-DOCS-NNN` line that uses one of the EARS keywords (`When`, `Where`, `While`, `If`, the optional-feature pattern, or the ubiquitous `the system shall` form). Further sections — `## Non-functional requirements`, `## Success metrics`, `## Release criteria`, `## Open questions / clarifications`, `## Out of scope`, `## Quality gate` — round out the PRD shape. For the EARS reference, see [`docs/ears-notation.md`](../ears-notation.md).
 
 ---
 

--- a/docs/tutorials/first-feature.md
+++ b/docs/tutorials/first-feature.md
@@ -1,16 +1,18 @@
 # Tutorial — drive your first feature end-to-end
 
-> **Status:** Draft — pending live validation. Every step below is derived from the workflow definition in [`docs/specorator.md`](../specorator.md). It has not yet been re-run from a clean clone of `main` against the live `/spec:*` commands; once it has, the *Status* line will change to *"Validated YYYY-MM-DD on commit `<sha>`"* and any drift between expected and actual output will be patched.
+> **Status:** Desk-validated 2026-04-28 against commit `bbe92492ac`. Every step below was cross-checked against the live `/spec:*` command files in `.claude/commands/spec/`, the agent definitions in `.claude/agents/`, and the artifact templates in `templates/`. **No live run yet** — a 60–90 minute end-to-end re-run from a clean clone is still planned, and any discrepancies it surfaces will be patched in a follow-up. Until then, treat the time budget and conversational specifics as estimates.
 
 ## What you will do
 
-You will drive **one tiny feature** — adding a single term to the plain-English glossary in the top-level `README.md` — through every stage of the Specorator workflow. By the end you will have:
+You will drive **one tiny feature** — adding the term *Tracer Bullet* to the project glossary at `docs/glossary/` — through every stage of the Specorator workflow. By the end you will have:
 
-- An `specs/glossary-term/` directory with one artifact per stage.
-- A new entry in the glossary table in `README.md`.
+- A `specs/glossary-term/` directory with one artifact per stage.
+- A new file at `docs/glossary/tracer-bullet.md`, scaffolded from `templates/glossary-entry-template.md`.
 - A real retrospective documenting what you learned.
 
 The feature is deliberately small. The point is not the change; the point is *the lifecycle*.
+
+> **Why this subject?** The repo's glossary is sharded one-file-per-term per [ADR-0010](../adr/0010-shard-glossary-into-one-file-per-term.md), so adding a term is a markdown-only change with no language-stack assumption. It works the same on Windows, macOS, and Linux. *In real day-to-day work* you would normally run `/glossary:new "Tracer Bullet"` directly — the lifecycle would be overkill. The tutorial uses the lifecycle deliberately so you experience every stage on a small surface.
 
 ## Who this is for
 
@@ -32,7 +34,7 @@ Specorator's value proposition is that **every** feature follows the same discip
 2. Cut a scratch branch: `git checkout -b tutorial/first-feature`.
 3. Open Claude Code: `claude`.
 
-If you reach the end of the tutorial and want to throw the work away, run `git checkout main && git branch -D tutorial/first-feature && rm -rf specs/glossary-term`.
+If you reach the end of the tutorial and want to throw the work away, see the cleanup snippet at the bottom of this page.
 
 ## The lifecycle
 
@@ -54,27 +56,29 @@ flowchart LR
     s0 --> s1 --> s2 --> s3 --> s4 --> s5 --> s6 --> s7 --> s8 --> s9 --> s10 --> s11
 ```
 
-Each stage has a slash command, produces one Markdown artifact, and updates `specs/glossary-term/workflow-state.md`.
+Each stage has a slash command, produces one (or two) Markdown artifacts under `specs/glossary-term/`, and updates `specs/glossary-term/workflow-state.md`. The IDs you will see — `IDEA-DOCS-NNN`, `PRD-DOCS-NNN`, `REQ-DOCS-NNN`, `T-DOCS-NNN`, `TEST-DOCS-NNN` — all use the area code `DOCS`.
 
 ---
 
 ### Stage 0 — Scaffold the feature directory
 
-**Command:** `/spec:start glossary-term`.
+**Command:** `/spec:start glossary-term DOCS`.
 
-**What happens:** Claude Code creates `specs/glossary-term/` with a `workflow-state.md` file initialised to `Active stage: Stage 1 — Idea`.
+The first argument is the feature slug; the optional second is the area code that prefixes IDs. If you omit it, `/spec:start` proposes one derived from the slug — confirm `DOCS` when prompted.
 
-**If you see this, you are on track:** `ls specs/glossary-term/` shows `workflow-state.md`. Open it — `Active stage` reads `Stage 1 — Idea`. No other artifacts yet.
+**What happens:** Claude Code creates `specs/glossary-term/` and copies `templates/workflow-state-template.md` into it as `workflow-state.md`, filling `feature: glossary-term` and `area: DOCS` in the frontmatter.
+
+**If you see this, you are on track:** `ls specs/glossary-term/` shows exactly one file — `workflow-state.md`. Open it. Frontmatter has `current_stage: idea`, `status: active`, and an `artifacts:` map listing every future artifact as `pending`. Below the frontmatter is a `## Stage progress` table showing each stage with its expected artifact and status `pending`.
 
 ---
 
 ### Stage 1 — Idea (analyst)
 
-**Command:** `/spec:idea`. Or in plain language: *"I want to add a new term to the glossary in `README.md` — specifically the term **Tracer Bullet**."*
+**Command:** `/spec:idea`. Or in plain language: *"I want to add a glossary entry for **Tracer Bullet**, the term defined by Hunt and Thomas in *The Pragmatic Programmer*."*
 
-**What happens:** the `analyst` agent asks you a few clarifying questions, then writes `specs/glossary-term/idea.md` — the framing of the problem and the success signal.
+**What happens:** the `analyst` agent asks a few clarifying questions about the brief, then writes `specs/glossary-term/idea.md` from `templates/idea-template.md`.
 
-**If you see this, you are on track:** `idea.md` exists; it has a clear `Problem`, `Goal`, and `Success signal` section. The `Active stage` in `workflow-state.md` has advanced to `Stage 2 — Research`.
+**If you see this, you are on track:** `idea.md` exists with frontmatter `id: IDEA-DOCS-001`, `stage: idea`, `status: draft`. Body has these sections: `## Problem statement`, `## Target users`, `## Desired outcome`, `## Constraints`, `## Open questions`. The Open questions section becomes the research agenda for Stage 2. `workflow-state.md`'s frontmatter has advanced to `current_stage: research` and the Stage 1 row in the progress table is now `complete`.
 
 ---
 
@@ -82,9 +86,9 @@ Each stage has a slash command, produces one Markdown artifact, and updates `spe
 
 **Command:** `/spec:research`.
 
-**What happens:** the analyst surfaces alternatives and prior art — for our subject, the agent compares phrasings of *Tracer Bullet*, looks at the existing glossary entries for tone, and lists risks. The output is `research.md`.
+**What happens:** the analyst answers the Open questions from `idea.md`. For our subject, the agent compares phrasings of *Tracer Bullet* (Hunt & Thomas's original definition vs. how the term is used elsewhere in this repo's docs), surveys existing glossary entries for tone, and lists risks (e.g. confusing it with *Spike*).
 
-**If you see this, you are on track:** `research.md` lists at least two phrasing alternatives plus a recommendation. `Active stage` is now `Stage 3 — Requirements`.
+**If you see this, you are on track:** `research.md` exists with `id: RESEARCH-DOCS-001`. Body has `## Research questions` (a table answering each Open question from idea.md), `## Market / ecosystem`, `## User needs`, and a recommendation. `current_stage: requirements`.
 
 ---
 
@@ -92,21 +96,21 @@ Each stage has a slash command, produces one Markdown artifact, and updates `spe
 
 **Command:** `/spec:requirements`.
 
-**What happens:** the `pm` agent writes `requirements.md` with **EARS-formatted** functional requirements. For this feature you should expect one or two — e.g. `REQ-DOCS-001. Where the README glossary table is rendered, the system shall include an entry for "Tracer Bullet" with a one-sentence plain-English definition.`
+**What happens:** the `pm` agent writes a PRD at `requirements.md` from `templates/prd-template.md`. The document's own ID is `PRD-DOCS-001`; functional requirements inside it use **EARS notation** with stable IDs `REQ-DOCS-NNN`. For this feature you should expect one or two requirements — e.g. *"Where the `docs/glossary/` directory is read, the system shall include a `tracer-bullet.md` entry with a one-sentence canonical definition."*
 
-**If you see this, you are on track:** `requirements.md` has at least one `REQ-DOCS-NNN` line; each requirement uses one of the EARS keywords (`Where`, `When`, `If`, `While`, or `shall`). For the EARS reference, see [`docs/ears-notation.md`](../ears-notation.md).
+**If you see this, you are on track:** `requirements.md` has frontmatter `id: PRD-DOCS-001`. Body has `## Goals`, `## Non-goals`, `## Personas / stakeholders`, `## Jobs to be done`, and a `## Requirements` section listing at least one `REQ-DOCS-NNN` line that uses one of the EARS keywords (`Where`, `When`, `If`, `While`, `Where`/`shall`). For the EARS reference, see [`docs/ears-notation.md`](../ears-notation.md).
 
 ---
 
 ### Stage 4 — Design (ux + ui + architect)
 
-**Command:** `/spec:design`.
+**Command:** `/spec:design`. The orchestrator sequences three collaborators on the same `design.md` file: ux-designer (Part A), ui-designer (Part B), architect (Part C).
 
-**What happens:** three agents contribute. For a markdown-only change the design is intentionally thin — UX confirms the glossary table is the right place; UI confirms no visual treatment changes; the architect documents which file gets edited and that no code path is touched. Output: `design.md`.
+**What happens:** for a markdown-only change the design is intentionally thin — UX confirms `docs/glossary/<slug>.md` is the right home; UI confirms no visual treatment changes; the architect documents the file path, the template (`templates/glossary-entry-template.md`), and that no code path is touched. The architect closes Part C and the cross-cutting requirements-coverage table.
 
-**Accept the defaults.** This is one of the stages where the agents will offer options; for a tutorial subject this small, the recommended option is correct.
+**Accept the defaults.** For a tutorial subject this small, the recommended option at each gate is correct.
 
-**If you see this, you are on track:** `design.md` exists with three short sections (UX, UI, Architecture) and identifies `README.md` as the only file to edit.
+**If you see this, you are on track:** `design.md` exists with frontmatter `id: DESIGN-DOCS-001`, `owner: architect`, and `collaborators: [ux-designer, ui-designer, architect]`. Body shows three short Parts (A — UX, B — UI, C — Architecture) and a final cross-cutting table mapping `REQ-DOCS-NNN` → which Part covers it.
 
 ---
 
@@ -114,9 +118,9 @@ Each stage has a slash command, produces one Markdown artifact, and updates `spe
 
 **Command:** `/spec:specify`.
 
-**What happens:** the architect produces `spec.md` — implementation-ready detail. For our feature this means: the exact row to add, the column order matching the existing table, and the placement (alphabetical position).
+**What happens:** the architect produces `spec.md` — implementation-ready detail. For our feature the spec captures: the exact path (`docs/glossary/tracer-bullet.md`), the source template (`templates/glossary-entry-template.md`), the values for the frontmatter fields (`term`, `slug`, `last-updated`, `related`, `tags`), and the body content for each section the template requires (`## Definition`, `## Why it matters`, `## Examples`, `## Avoid`, `## See also`).
 
-**If you see this, you are on track:** `spec.md` shows the literal Markdown line that will be added to `README.md`, and the line number or anchor it goes after.
+**If you see this, you are on track:** `spec.md` has `id: SPECDOC-DOCS-001`, body section `## Interfaces` with at least one `SPEC-DOCS-NNN` heading describing the file to be created. Each `SPEC-DOCS-NNN` lists pre-conditions, the exact content, and links back to its `REQ-DOCS-NNN`.
 
 ---
 
@@ -124,19 +128,24 @@ Each stage has a slash command, produces one Markdown artifact, and updates `spe
 
 **Command:** `/spec:tasks`.
 
-**What happens:** the `planner` decomposes the spec into a tasks list with stable IDs (`T-DOCS-NNN`). Output: `tasks.md`. Expect one or two tasks — *"Add Tracer Bullet row to glossary"* and *"Verify alphabetical order preserved"*.
+**What happens:** the `planner` decomposes the spec into a tasks list at `tasks.md` from `templates/tasks-template.md`. Each task carries a `T-DOCS-NNN` ID, an emoji marker (🧪 test, 🔨 implementation, 📐 design/scaffolding, 📚 documentation, 🚀 release/ops), an owner from the closed set `dev | qa | sre | human`, and references at least one `REQ-DOCS-NNN`. **TDD ordering** is enforced — the test task for a requirement comes *before* the implementation task for that requirement.
 
-**If you see this, you are on track:** `tasks.md` lists at least one `T-DOCS-NNN` task with a Definition of Done and a link back to the originating `REQ-DOCS-NNN`.
+**If you see this, you are on track:** `tasks.md` lists at least one 🧪 test task (owner=`qa`) followed by one 🔨 implementation task (owner=`dev`). Each row has `Satisfies: REQ-DOCS-NNN`, a `Definition of done:` checkbox list, and an estimate of S or M.
 
 ---
 
-### Stage 7 — Implementation (dev)
+### Stage 7 — Implementation (dev / qa)
 
-**Command:** `/spec:implement` (the orchestrator dispatches one task at a time).
+**Command:** `/spec:implement`. The command picks the next ready task automatically (the first whose dependencies are done), routes by `owner`, and runs one task per invocation. Run it once per task.
 
-**What happens:** the `dev` agent edits `README.md`, makes the glossary change, and appends to `implementation-log.md`. The change is staged but not pushed.
+**What happens for our feature:**
 
-**If you see this, you are on track:** `git diff README.md` shows the new glossary row in alphabetical position; `implementation-log.md` records the task ID, the file changed, and the result.
+- **First invocation** picks the 🧪 test task (owner=`qa`) — the qa agent writes the failing test. *(This may be as simple as a script that asserts `docs/glossary/tracer-bullet.md` exists and parses, or a check that the term is linked from a related entry.)*
+- **Second invocation** picks the 🔨 implementation task (owner=`dev`) — the dev agent creates `docs/glossary/tracer-bullet.md` from the template, fills it from `spec.md`, and re-runs the test until it passes.
+
+After each invocation, `/spec:implement` proposes a per-task commit with a message of the form `feat(docs): T-DOCS-NNN <short title>` (imperative mood, references the task ID). The commit is local-only and reversible (`git reset --soft HEAD~1` undoes it).
+
+**If you see this, you are on track:** `git log --oneline` shows at least one `feat(docs): T-DOCS-NNN …` commit per task. `implementation-log.md` has structured entries — `### YYYY-MM-DD — T-DOCS-NNN — <title>` with **Files changed**, **Commit**, **Spec reference**, **Outcome**, **Deviation from spec**, **Notes**. The new file `docs/glossary/tracer-bullet.md` exists with the frontmatter and body the spec called for.
 
 ---
 
@@ -144,9 +153,9 @@ Each stage has a slash command, produces one Markdown artifact, and updates `spe
 
 **Command:** `/spec:test`.
 
-**What happens:** because the subject is markdown-only, the `qa` agent runs a small set of checks — does the glossary still parse as a Markdown table? Does the new row sit in alphabetical order? Are there any broken links? Output: `test-plan.md` and `test-report.md`.
+**What happens:** the qa agent confirms entry criteria (spec accepted, implementation complete), runs the full test suite for the change, and writes both `test-plan.md` and `test-report.md`. Because the subject is markdown-only, the suite is small — `npm run check:links` is the load-bearing one.
 
-**If you see this, you are on track:** `test-report.md` shows every assertion as `PASS` and traces each back to its `REQ-DOCS-NNN`.
+**If you see this, you are on track:** `test-report.md` has frontmatter `id: TESTREPORT-DOCS-001`. Body shows a `## Summary` table (Total / Passed / Failed / Skipped / Coverage) followed by a `## Per-requirement results` table — one row per `REQ-DOCS-NNN` with the tests that exercised it and a status of ✅. No `## Failures` rows means the run was clean.
 
 ---
 
@@ -154,9 +163,9 @@ Each stage has a slash command, produces one Markdown artifact, and updates `spe
 
 **Command:** `/spec:review`.
 
-**What happens:** the `reviewer` audits the chain: requirement → spec → task → code → test → finding. It refreshes `traceability.md` so every ID has a downstream link. It writes `review.md` with the verdict.
+**What happens:** the `reviewer` audits the chain: requirement → spec → task → code → test → finding. It refreshes `traceability.md` so every `REQ-DOCS-NNN`, `SPEC-DOCS-NNN`, `T-DOCS-NNN`, and `TEST-DOCS-NNN` is linked end-to-end. It writes `review.md` with the verdict.
 
-**If you see this, you are on track:** `review.md` ends with `Verdict: APPROVED` (or, more interestingly, lists findings to address — fix them and re-run); `traceability.md` shows your `REQ-DOCS-NNN` linked to the tests that exercised it.
+**If you see this, you are on track:** `review.md` has a `## Verdict` section with three checkboxes — *Approved — proceed to release*, *Approved with conditions — see findings*, *Blocked — must address before release*. The first checkbox is ticked. The `## Requirements compliance`, `## Design compliance`, and `## Spec compliance` tables all show your `REQ-DOCS-NNN` as satisfied with evidence rows pointing at the test IDs and the implementation-log entry. `traceability.md` (the RTM) has every cell filled — no empty cells, no orphan tests, no orphan tasks.
 
 ---
 
@@ -174,9 +183,9 @@ What it would do, if you did run it: invoke the `release-manager` agent to write
 
 **Command:** `/spec:retro`.
 
-**What happens:** the `retrospective` agent walks you through what worked, what didn't, and what to change. The output is `retrospective.md`. The retrospective is **mandatory**, not optional, even on a tutorial — running it once now is the easiest way to internalise that.
+**What happens:** the `retrospective` agent reads every artifact in `specs/glossary-term/` and walks you through the questions. The retrospective is **mandatory**, not optional — even on a tutorial — running it once now is the easiest way to internalise that.
 
-**If you see this, you are on track:** `retrospective.md` exists with sections for *What worked*, *What didn't*, and *Actions* — the actions field has at least one item (even *"none — feature shipped clean"* counts).
+**If you see this, you are on track:** `retrospective.md` has frontmatter `id: RETRO-DOCS-001`, `stage: learning`. Body has the sections from `templates/retrospective-template.md` filled in: `## Outcome`, `## What worked`, `## What didn't work`, `## Spec adherence`, `## Process observations`. The agent also surfaces proposed amendments — to templates, agents, or the constitution — for you to accept or reject. Even a one-line *"none — feature shipped clean"* counts as an answer.
 
 ---
 
@@ -185,7 +194,7 @@ What it would do, if you did run it: invoke the `release-manager` agent to write
 You now have:
 
 - A complete `specs/glossary-term/` directory with one artifact per stage.
-- A real change to `README.md`.
+- A new term file at `docs/glossary/tracer-bullet.md`.
 - A real retrospective.
 
 Where to go from here:
@@ -194,13 +203,14 @@ Where to go from here:
 - **Customize the workflow for your stack.** [`how-to/fork-and-personalize.md`](../how-to/fork-and-personalize.md) and [`how-to/adapt-steering.md`](../how-to/adapt-steering.md).
 - **Understand why the workflow looks like this.** [`docs/specorator.md`](../specorator.md) is the canonical definition; the [Explanation](../README.md#explanation) quadrant in the doc hub has the rationale for each track.
 - **Learn the small disciplines.** [`how-to/write-ears-requirement.md`](../how-to/write-ears-requirement.md), [`how-to/add-adr.md`](../how-to/add-adr.md), [`how-to/run-verify-gate.md`](../how-to/run-verify-gate.md).
+- **Drop the lifecycle when it's overkill.** A real glossary entry would normally just be `/glossary:new "<term>"` — see [`how-to/skip-discovery.md`](../how-to/skip-discovery.md) for the same pragmatism applied to the Discovery Track.
 
 If you want to throw away your scratch branch and start fresh:
 
 ```bash
 git checkout main
 git branch -D tutorial/first-feature
-rm -rf specs/glossary-term
+rm -rf specs/glossary-term docs/glossary/tracer-bullet.md
 ```
 
 Welcome to spec-driven development.


### PR DESCRIPTION
## Summary

Path C of the validation plan agreed in chat: desk-validate the first-feature tutorial without running it live. Re-read every `/spec:*` command, every agent definition, and every artifact template against the tutorial; patch all drift; flip the Status banner.

### Subject change

The original tutorial added a row to an inline glossary **table in `README.md`**. That table no longer exists — [ADR-0010](docs/adr/0010-shard-glossary-into-one-file-per-term.md) sharded the glossary into one-file-per-term under `docs/glossary/`. The tutorial subject is now **create `docs/glossary/tracer-bullet.md` from `templates/glossary-entry-template.md`**. A pragmatism note up front tells the reader that a real glossary entry would normally just use `/glossary:new`; the lifecycle is run here for teaching.

### Per-stage drift fixed

Each step was cross-checked against the live template / command / agent file. Concrete drift, with the source of truth in parens:

- **Stage 0** — workflow-state.md frontmatter `current_stage: idea` + Stage progress table (`templates/workflow-state-template.md`). The made-up `Active stage: Stage 1 — Idea` line is gone. Tutorial now uses `/spec:start glossary-term DOCS` to set the AREA explicitly.
- **Stage 1** — idea.md sections are now the real ones — `Problem statement`, `Target users`, `Desired outcome`, `Constraints`, `Open questions` (`templates/idea-template.md`). The made-up `Goal` / `Success signal` is gone.
- **Stage 2** — research.md sections aligned with `templates/research-template.md`.
- **Stage 3** — requirements.md is a PRD (`id: PRD-DOCS-NNN`) with `REQ-DOCS-NNN` inside.
- **Stage 4** — design.md owner=architect, collaborators=[ux-designer, ui-designer, architect], Parts A/B/C (`templates/design-template.md`).
- **Stage 5** — spec.md uses `id: SPECDOC-DOCS-NNN`, with `SPEC-DOCS-NNN` per interface (`templates/spec-template.md`).
- **Stage 6** — tasks.md follows `templates/tasks-template.md` — emoji markers, `Satisfies:` field, owner restricted to `dev|qa|sre|human`, TDD ordering enforced.
- **Stage 7** — `/spec:implement` runs one task per invocation, routes by owner, proposes a per-task commit `feat(<area>): <task-id> <title>`. Tutorial walks qa-then-dev. implementation-log entry shape (Files changed, Commit, Spec reference, Outcome, Deviation) is correct now.
- **Stage 8** — test-report has a Summary table + Per-requirement results table — not "every assertion as PASS".
- **Stage 9** — review verdict is the checkbox triplet (Approved / Approved with conditions / Blocked) per `templates/review-template.md`. Mentions RTM regeneration.
- **Stage 11** — retrospective sections from `templates/retrospective-template.md` (Outcome, What worked, What didn't, Spec adherence, Process observations) — not the made-up What-worked/What-didn't/Actions triple.

### Status banner

```
Status: Desk-validated 2026-04-28 against commit `bbe92492ac`. Every step
was cross-checked against the live `/spec:*` command files, the agent
definitions, and the artifact templates. No live run yet — a 60–90
minute end-to-end re-run from a clean clone is still planned, and any
discrepancies it surfaces will be patched in a follow-up.
```

## Test plan

- [x] `npm run verify` green locally — links, ADR index, command inventories, script docs, frontmatter, spec state, traceability all pass.
- [x] Subject swap is consistent — every reference to "README glossary" replaced with `docs/glossary/<slug>.md`; cleanup snippet at the bottom updated.
- [x] Hub-drift trigger does not fire — only edits to existing files, no add/rename/remove under `docs/`.
- [ ] Live tutorial re-run from a clean clone — explicitly out of scope for this PR; deferred to a follow-up branch as agreed.

## Out of scope

- Live workflow run (Path A from the original three-option list).
- Edits to other docs/ files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)