### PR TITLE
chore(scripts): structure markdown link diagnostics

### DIFF
--- a/docs/scripts/README.md
+++ b/docs/scripts/README.md
@@ -52,7 +52,7 @@ Check scripts use the same human output by default. Pass `--json` to any check s
 npm run check:links -- --json
 ```
 
-JSON output includes the check name, pass/fail status, and normalized diagnostics with `path`, `line`, `code`, and `message` fields when available.
+JSON output includes the check name, pass/fail status, and normalized diagnostics with `path`, `line`, `code`, and `message` fields when available. Markdown link diagnostics use stable codes such as `LINK_URI`, `LINK_FILE`, and `LINK_ANCHOR`.
 
 ## Checks
 

--- a/docs/scripts/lib/markdown-links/README.md
+++ b/docs/scripts/lib/markdown-links/README.md
@@ -6,10 +6,15 @@
 
 # lib/markdown-links
 
+## Type Aliases
+
+- [LinkDiagnosticCode](type-aliases/LinkDiagnosticCode.md)
+
 ## Functions
 
 - [collectAnchors](functions/collectAnchors.md)
 - [githubSlug](functions/githubSlug.md)
+- [linkDiagnostic](functions/linkDiagnostic.md)
 - [safeDecode](functions/safeDecode.md)
 - [shouldIgnoreTarget](functions/shouldIgnoreTarget.md)
 - [slugVariants](functions/slugVariants.md)

--- a/docs/scripts/lib/markdown-links/functions/linkDiagnostic.md
+++ b/docs/scripts/lib/markdown-links/functions/linkDiagnostic.md
@@ -1,0 +1,43 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/markdown-links](../README.md) / linkDiagnostic
+
+# Function: linkDiagnostic()
+
+> **linkDiagnostic**(`code`, `filePath`, `line`, `target`): [`Diagnostic`](../../diagnostics/type-aliases/Diagnostic.md)
+
+Build a structured Markdown link diagnostic.
+
+## Parameters
+
+### code
+
+[`LinkDiagnosticCode`](../type-aliases/LinkDiagnosticCode.md)
+
+Stable diagnostic code for the link failure.
+
+### filePath
+
+`string`
+
+Repository-relative Markdown file path.
+
+### line
+
+`number`
+
+One-based line number.
+
+### target
+
+`string`
+
+Link target that failed validation.
+
+## Returns
+
+[`Diagnostic`](../../diagnostics/type-aliases/Diagnostic.md)
+
+Structured diagnostic for check output.

--- a/docs/scripts/lib/markdown-links/type-aliases/LinkDiagnosticCode.md
+++ b/docs/scripts/lib/markdown-links/type-aliases/LinkDiagnosticCode.md
@@ -1,0 +1,9 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/markdown-links](../README.md) / LinkDiagnosticCode
+
+# Type Alias: LinkDiagnosticCode
+
+> **LinkDiagnosticCode** = `"LINK_URI"` \| `"LINK_FILE"` \| `"LINK_ANCHOR"`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -48,7 +48,7 @@ Check scripts use the same human output by default. Pass `--json` to any check s
 npm run check:links -- --json
 ```
 
-JSON output includes the check name, pass/fail status, and normalized diagnostics with `path`, `line`, `code`, and `message` fields when available.
+JSON output includes the check name, pass/fail status, and normalized diagnostics with `path`, `line`, `code`, and `message` fields when available. Markdown link diagnostics use stable codes such as `LINK_URI`, `LINK_FILE`, and `LINK_ANCHOR`.
 
 ## Checks
 

--- a/scripts/check-markdown-links.ts
+++ b/scripts/check-markdown-links.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { failIfErrors, markdownFiles, readText, relativeToRoot, repoRoot } from "./lib/repo.js";
-import { collectAnchors, safeDecode, shouldIgnoreTarget } from "./lib/markdown-links.js";
+import { collectAnchors, linkDiagnostic, safeDecode, shouldIgnoreTarget } from "./lib/markdown-links.js";
 
 const errors = [];
 const linkPattern = /!?\[[^\]]*?\]\(([^)\s]+(?:\s+"[^"]*")?)\)/g;
@@ -21,7 +21,7 @@ for (const filePath of markdownFiles()) {
       const decodedAnchor = safeDecode(rawAnchor);
 
       if (!decodedPath.ok || !decodedAnchor.ok) {
-        errors.push(`${relativeToRoot(filePath)}:${lineIndex + 1} has invalid URI escape in link ${target}`);
+        errors.push(linkDiagnostic("LINK_URI", relativeToRoot(filePath), lineIndex + 1, target));
         continue;
       }
 
@@ -30,7 +30,7 @@ for (const filePath of markdownFiles()) {
         : filePath;
 
       if (targetPath && !fs.existsSync(resolvedPath)) {
-        errors.push(`${relativeToRoot(filePath)}:${lineIndex + 1} links to missing file ${target}`);
+        errors.push(linkDiagnostic("LINK_FILE", relativeToRoot(filePath), lineIndex + 1, target));
         continue;
       }
 
@@ -38,7 +38,7 @@ for (const filePath of markdownFiles()) {
         const anchors = collectAnchors(readText(resolvedPath));
         const anchor = decodedAnchor.value.toLowerCase();
         if (!anchors.has(anchor)) {
-          errors.push(`${relativeToRoot(filePath)}:${lineIndex + 1} links to missing anchor ${target}`);
+          errors.push(linkDiagnostic("LINK_ANCHOR", relativeToRoot(filePath), lineIndex + 1, target));
         }
       }
     }

--- a/scripts/lib/markdown-links.ts
+++ b/scripts/lib/markdown-links.ts
@@ -1,3 +1,30 @@
+import type { Diagnostic } from "./diagnostics.js";
+
+export type LinkDiagnosticCode = "LINK_URI" | "LINK_FILE" | "LINK_ANCHOR";
+
+/**
+ * Build a structured Markdown link diagnostic.
+ *
+ * @param {LinkDiagnosticCode} code - Stable diagnostic code for the link failure.
+ * @param {string} filePath - Repository-relative Markdown file path.
+ * @param {number} line - One-based line number.
+ * @param {string} target - Link target that failed validation.
+ * @returns {Diagnostic} Structured diagnostic for check output.
+ */
+export function linkDiagnostic(
+  code: LinkDiagnosticCode,
+  filePath: string,
+  line: number,
+  target: string,
+): Diagnostic {
+  return {
+    code,
+    path: filePath,
+    line,
+    message: linkDiagnosticMessage(code, target),
+  };
+}
+
 export function safeDecode(value: string | undefined): { ok: boolean; value: string } {
   if (value === undefined) return { ok: true, value: "" };
   try {
@@ -5,6 +32,12 @@ export function safeDecode(value: string | undefined): { ok: boolean; value: str
   } catch {
     return { ok: false, value };
   }
+}
+
+function linkDiagnosticMessage(code: LinkDiagnosticCode, target: string): string {
+  if (code === "LINK_URI") return `has invalid URI escape in link ${target}`;
+  if (code === "LINK_FILE") return `links to missing file ${target}`;
+  return `links to missing anchor ${target}`;
 }
 
 export function shouldIgnoreTarget(target: string): boolean {

--- a/tests/scripts/markdown-links.test.ts
+++ b/tests/scripts/markdown-links.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   collectAnchors,
   githubSlug,
+  linkDiagnostic,
   safeDecode,
   shouldIgnoreTarget,
   slugVariants,
@@ -13,6 +14,15 @@ test("collectAnchors follows GitHub-style duplicate heading suffixes", () => {
   assert.equal(anchors.has("title"), true);
   assert.equal(anchors.has("a-code-heading"), true);
   assert.equal(anchors.has("a-code-heading-1"), true);
+});
+
+test("linkDiagnostic returns structured link failure details", () => {
+  assert.deepEqual(linkDiagnostic("LINK_ANCHOR", "docs/example.md", 12, "./target.md#missing"), {
+    code: "LINK_ANCHOR",
+    path: "docs/example.md",
+    line: 12,
+    message: "links to missing anchor ./target.md#missing",
+  });
 });
 
 test("slugVariants covers Unicode dash variants used in existing docs", () => {


### PR DESCRIPTION
## Summary
- Adds stable structured diagnostic codes for Markdown link failures: `LINK_URI`, `LINK_FILE`, and `LINK_ANCHOR`.
- Wires `check:links` to emit structured diagnostics through the existing `failIfErrors` JSON path while preserving human output.
- Adds unit coverage for Markdown link diagnostic construction and regenerates script API docs.

## Verification
- `npm run check:links -- --json`
- `npm run verify`
- `npm run doctor`

## Notes
- `npm run doctor` passed with the expected dirty-worktree warning before commit because branch changes were uncommitted at that moment.