### PR TITLE
[codex] Add structured frontmatter diagnostics

### DIFF
--- a/docs/scripts/README.md
+++ b/docs/scripts/README.md
@@ -58,7 +58,7 @@ Check scripts use the same human output by default. Pass `--json` to any check s
 npm run check:links -- --json
 ```
 
-JSON output includes the check name, pass/fail status, and normalized diagnostics with `path`, `line`, `code`, and `message` fields when available. Markdown link diagnostics use stable codes such as `LINK_URI`, `LINK_FILE`, and `LINK_ANCHOR`.
+JSON output includes the check name, pass/fail status, and normalized diagnostics with `path`, `line`, `code`, and `message` fields when available. Markdown link diagnostics use stable codes such as `LINK_URI`, `LINK_FILE`, and `LINK_ANCHOR`; frontmatter diagnostics use stable `FM_*` codes such as `FM_MISSING`, `FM_KEY`, and `FM_ARTIFACT_STATUS`.
 
 ## Checks
 

--- a/docs/scripts/lib/frontmatter/README.md
+++ b/docs/scripts/lib/frontmatter/README.md
@@ -1,0 +1,22 @@
+---
+title: "lib/frontmatter"
+folder: "docs/scripts/lib/frontmatter"
+description: "Entry point for generated API reference for the lib/frontmatter script helper module."
+entry_point: true
+---
+[**agentic-workflow**](../../README.md)
+
+***
+
+[agentic-workflow](../../modules.md) / lib/frontmatter
+
+# lib/frontmatter
+
+## Type Aliases
+
+- [FrontmatterDiagnosticCode](type-aliases/FrontmatterDiagnosticCode.md)
+
+## Functions
+
+- [frontmatterDiagnostic](functions/frontmatterDiagnostic.md)
+- [requiredKeyDiagnostics](functions/requiredKeyDiagnostics.md)

--- a/docs/scripts/lib/frontmatter/functions/frontmatterDiagnostic.md
+++ b/docs/scripts/lib/frontmatter/functions/frontmatterDiagnostic.md
@@ -1,0 +1,37 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/frontmatter](../README.md) / frontmatterDiagnostic
+
+# Function: frontmatterDiagnostic()
+
+> **frontmatterDiagnostic**(`code`, `filePath`, `message`): [`Diagnostic`](../../diagnostics/type-aliases/Diagnostic.md)
+
+Build a structured frontmatter diagnostic.
+
+## Parameters
+
+### code
+
+[`FrontmatterDiagnosticCode`](../type-aliases/FrontmatterDiagnosticCode.md)
+
+Stable diagnostic code for the frontmatter failure.
+
+### filePath
+
+`string`
+
+Repository-relative Markdown file path, or a directory for duplicate README failures.
+
+### message
+
+`string`
+
+Human-readable failure message.
+
+## Returns
+
+[`Diagnostic`](../../diagnostics/type-aliases/Diagnostic.md)
+
+Structured diagnostic for check output.

--- a/docs/scripts/lib/frontmatter/functions/requiredKeyDiagnostics.md
+++ b/docs/scripts/lib/frontmatter/functions/requiredKeyDiagnostics.md
@@ -1,0 +1,37 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/frontmatter](../README.md) / requiredKeyDiagnostics
+
+# Function: requiredKeyDiagnostics()
+
+> **requiredKeyDiagnostics**(`filePath`, `data`, `keys`): [`Diagnostic`](../../diagnostics/type-aliases/Diagnostic.md)[]
+
+Build diagnostics for required frontmatter keys.
+
+## Parameters
+
+### filePath
+
+`string`
+
+Repository-relative Markdown file path.
+
+### data
+
+`Record`\<`string`, `unknown`\>
+
+Parsed frontmatter data.
+
+### keys
+
+`string`[]
+
+Required frontmatter keys.
+
+## Returns
+
+[`Diagnostic`](../../diagnostics/type-aliases/Diagnostic.md)[]
+
+Missing-key diagnostics.

--- a/docs/scripts/lib/frontmatter/type-aliases/FrontmatterDiagnosticCode.md
+++ b/docs/scripts/lib/frontmatter/type-aliases/FrontmatterDiagnosticCode.md
@@ -1,0 +1,9 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/frontmatter](../README.md) / FrontmatterDiagnosticCode
+
+# Type Alias: FrontmatterDiagnosticCode
+
+> **FrontmatterDiagnosticCode** = `"FM_README_NAME"` \| `"FM_README_DUPLICATE"` \| `"FM_MISSING"` \| `"FM_KEY"` \| `"FM_README_FOLDER"` \| `"FM_README_ENTRY_POINT"` \| `"FM_ADR_ID"` \| `"FM_ADR_STATUS"` \| `"FM_WORKFLOW_STAGE"` \| `"FM_WORKFLOW_STATUS"` \| `"FM_ARTIFACT_STATUS"` \| `"FM_REVIEW_SHA"` \| `"FM_REVIEW_ISSUE"` \| `"FM_REVIEW_FINDING_COUNT"`

--- a/docs/scripts/modules.md
+++ b/docs/scripts/modules.md
@@ -23,6 +23,7 @@
 - [lib/adr](lib/adr/README.md)
 - [lib/commands](lib/commands/README.md)
 - [lib/diagnostics](lib/diagnostics/README.md)
+- [lib/frontmatter](lib/frontmatter/README.md)
 - [lib/markdown-links](lib/markdown-links/README.md)
 - [lib/repo](lib/repo/README.md)
 - [lib/runner](lib/runner/README.md)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -54,7 +54,7 @@ Check scripts use the same human output by default. Pass `--json` to any check s
 npm run check:links -- --json
 ```
 
-JSON output includes the check name, pass/fail status, and normalized diagnostics with `path`, `line`, `code`, and `message` fields when available. Markdown link diagnostics use stable codes such as `LINK_URI`, `LINK_FILE`, and `LINK_ANCHOR`.
+JSON output includes the check name, pass/fail status, and normalized diagnostics with `path`, `line`, `code`, and `message` fields when available. Markdown link diagnostics use stable codes such as `LINK_URI`, `LINK_FILE`, and `LINK_ANCHOR`; frontmatter diagnostics use stable `FM_*` codes such as `FM_MISSING`, `FM_KEY`, and `FM_ARTIFACT_STATUS`.
 
 ## Checks
 

--- a/scripts/check-frontmatter.ts
+++ b/scripts/check-frontmatter.ts
@@ -1,4 +1,6 @@
 import path from "node:path";
+import type { Diagnostic } from "./lib/diagnostics.js";
+import { frontmatterDiagnostic, requiredKeyDiagnostics } from "./lib/frontmatter.js";
 import {
   FrontmatterBlock,
   extractFrontmatter,
@@ -10,7 +12,7 @@ import {
 } from "./lib/repo.js";
 import { artifactStatuses, workflowStages, workflowStatuses } from "./lib/workflow-schema.js";
 
-const errors: string[] = [];
+const errors: Diagnostic[] = [];
 const readmeDirs = new Map<string, string[]>();
 
 for (const filePath of markdownFiles()) {
@@ -26,7 +28,7 @@ for (const filePath of markdownFiles()) {
     readmeDirs.set(dirname, siblings);
 
     if (basename !== "README.md") {
-      errors.push(`${rel} must be named README.md`);
+      errors.push(frontmatterDiagnostic("FM_README_NAME", rel, "must be named README.md"));
     } else {
       requireFrontmatter(rel, frontmatter);
       if (frontmatter) validateReadme(rel, parseSimpleYaml(frontmatter.raw));
@@ -56,7 +58,9 @@ for (const filePath of markdownFiles()) {
 
 for (const [dirname, readmes] of readmeDirs) {
   if (readmes.length > 1) {
-    errors.push(`${dirname} has multiple README files: ${readmes.join(", ")}`);
+    errors.push(
+      frontmatterDiagnostic("FM_README_DUPLICATE", dirname, `has multiple README files: ${readmes.join(", ")}`),
+    );
   }
 }
 
@@ -67,90 +71,85 @@ function isAdr(rel: string): boolean {
 }
 
 function requireFrontmatter(rel: string, frontmatter: FrontmatterBlock | null): void {
-  if (!frontmatter) errors.push(`${rel} is missing YAML frontmatter`);
+  if (!frontmatter) errors.push(frontmatterDiagnostic("FM_MISSING", rel, "is missing YAML frontmatter"));
 }
 
 function validateReadme(rel: string, data: Record<string, unknown>): void {
-  const required = ["title", "folder", "description", "entry_point"];
-  for (const key of required) {
-    if (data[key] === undefined || data[key] === "") errors.push(`${rel} missing frontmatter key: ${key}`);
-  }
+  errors.push(...requiredKeyDiagnostics(rel, data, ["title", "folder", "description", "entry_point"]));
 
   const expectedFolder = path.dirname(rel) === "." ? "." : path.dirname(rel);
   if (data.folder !== undefined && String(data.folder) !== expectedFolder) {
-    errors.push(`${rel} frontmatter folder must be ${expectedFolder}`);
+    errors.push(frontmatterDiagnostic("FM_README_FOLDER", rel, `frontmatter folder must be ${expectedFolder}`));
   }
 
   if (data.entry_point !== undefined && String(data.entry_point) !== "true") {
-    errors.push(`${rel} frontmatter entry_point must be true`);
+    errors.push(frontmatterDiagnostic("FM_README_ENTRY_POINT", rel, "frontmatter entry_point must be true"));
   }
 }
 
 function validateAdr(rel: string, data: Record<string, unknown>): void {
-  const required = ["id", "title", "status", "date"];
-  for (const key of required) {
-    if (data[key] === undefined || data[key] === "") errors.push(`${rel} missing frontmatter key: ${key}`);
-  }
+  errors.push(...requiredKeyDiagnostics(rel, data, ["id", "title", "status", "date"]));
 
   const fileNumber = path.basename(rel).slice(0, 4);
   if (data.id !== `ADR-${fileNumber}`) {
-    errors.push(`${rel} frontmatter id must be ADR-${fileNumber}`);
+    errors.push(frontmatterDiagnostic("FM_ADR_ID", rel, `frontmatter id must be ADR-${fileNumber}`));
   }
 
   const status = String(data.status || "").toLowerCase();
   if (!["proposed", "accepted", "deprecated"].includes(status) && !status.startsWith("superseded")) {
-    errors.push(`${rel} has unsupported ADR status: ${data.status}`);
+    errors.push(frontmatterDiagnostic("FM_ADR_STATUS", rel, `has unsupported ADR status: ${data.status}`));
   }
 }
 
 function validateWorkflowState(rel: string, data: Record<string, unknown>): void {
-  for (const key of ["current_stage", "status", "last_updated", "last_agent", "artifacts"]) {
-    if (data[key] === undefined || data[key] === "") errors.push(`${rel} missing frontmatter key: ${key}`);
-  }
+  errors.push(
+    ...requiredKeyDiagnostics(rel, data, ["current_stage", "status", "last_updated", "last_agent", "artifacts"]),
+  );
 
   if (data.current_stage && !workflowStages.has(String(data.current_stage))) {
-    errors.push(`${rel} has unsupported current_stage: ${data.current_stage}`);
+    errors.push(frontmatterDiagnostic("FM_WORKFLOW_STAGE", rel, `has unsupported current_stage: ${data.current_stage}`));
   }
   if (data.status && !workflowStatuses.has(String(data.status))) {
-    errors.push(`${rel} has unsupported status: ${data.status}`);
+    errors.push(frontmatterDiagnostic("FM_WORKFLOW_STATUS", rel, `has unsupported status: ${data.status}`));
   }
   if (data.artifacts && typeof data.artifacts === "object") {
     for (const [artifact, status] of Object.entries(data.artifacts)) {
       if (!artifactStatuses.has(String(status))) {
-        errors.push(`${rel} artifact ${artifact} has unsupported status: ${status}`);
+        errors.push(
+          frontmatterDiagnostic("FM_ARTIFACT_STATUS", rel, `artifact ${artifact} has unsupported status: ${status}`),
+        );
       }
     }
   }
 }
 
 function validateDailyReview(rel: string, data: Record<string, unknown>): void {
-  for (const key of ["date", "head_sha", "issue", "finding_count"]) {
-    if (data[key] === undefined || data[key] === "") errors.push(`${rel} missing frontmatter key: ${key}`);
-  }
+  errors.push(...requiredKeyDiagnostics(rel, data, ["date", "head_sha", "issue", "finding_count"]));
   if (data.head_sha && !/^[0-9a-f]{40}$/i.test(String(data.head_sha))) {
-    errors.push(`${rel} head_sha must be a 40-character SHA`);
+    errors.push(frontmatterDiagnostic("FM_REVIEW_SHA", rel, "head_sha must be a 40-character SHA"));
   }
   if (data.issue !== null && !/^#\d+$/.test(String(data.issue))) {
-    errors.push(`${rel} issue must be #NNN or null`);
+    errors.push(frontmatterDiagnostic("FM_REVIEW_ISSUE", rel, "issue must be #NNN or null"));
   }
   if (data.finding_count !== undefined && !Number.isInteger(Number(data.finding_count))) {
-    errors.push(`${rel} finding_count must be an integer`);
+    errors.push(frontmatterDiagnostic("FM_REVIEW_FINDING_COUNT", rel, "finding_count must be an integer"));
   }
 }
 
 function isTrackState(rel: string): boolean {
-  return /(^|\/)(discovery-state|stock-taking-state|scaffolding-state|project-state|portfolio-state|deal-state)\.md$/.test(rel);
+  return /(^|\/)(discovery-state|stock-taking-state|scaffolding-state|project-state|portfolio-state|deal-state)\.md$/.test(
+    rel,
+  );
 }
 
 function validateTrackState(rel: string, data: Record<string, unknown>): void {
-  const required = ["status", "last_updated", "last_agent", "artifacts"];
-  for (const key of required) {
-    if (data[key] === undefined || data[key] === "") errors.push(`${rel} missing frontmatter key: ${key}`);
-  }
+  errors.push(...requiredKeyDiagnostics(rel, data, ["status", "last_updated", "last_agent", "artifacts"]));
   if (data.artifacts && typeof data.artifacts === "object") {
     for (const [artifact, status] of Object.entries(data.artifacts)) {
       if (!artifactStatuses.has(String(status))) {
-        errors.push(`${rel} artifact ${artifact} has unsupported status: ${status}`);
+        errors.push(
+          frontmatterDiagnostic("FM_ARTIFACT_STATUS", rel, `artifact ${artifact} has unsupported status: ${status}`),
+        );
       }
     }
   }

--- a/scripts/lib/diagnostics.ts
+++ b/scripts/lib/diagnostics.ts
@@ -57,10 +57,11 @@ export function checkResult(heading: string, errors: DiagnosticInput[]): CheckRe
  * @returns {string} Human-readable diagnostic line.
  */
 export function formatDiagnostic(diagnostic: Diagnostic): string {
-  const location =
-    diagnostic.path && diagnostic.line !== undefined
+  const location = diagnostic.path
+    ? diagnostic.line !== undefined
       ? `${diagnostic.path}:${diagnostic.line} `
-      : "";
+      : `${diagnostic.path} `
+    : "";
   const code = diagnostic.code ? `[${diagnostic.code}] ` : "";
   return `${location}${code}${diagnostic.message}`;
 }

--- a/scripts/lib/frontmatter.ts
+++ b/scripts/lib/frontmatter.ts
@@ -1,0 +1,55 @@
+import type { Diagnostic } from "./diagnostics.js";
+
+export type FrontmatterDiagnosticCode =
+  | "FM_README_NAME"
+  | "FM_README_DUPLICATE"
+  | "FM_MISSING"
+  | "FM_KEY"
+  | "FM_README_FOLDER"
+  | "FM_README_ENTRY_POINT"
+  | "FM_ADR_ID"
+  | "FM_ADR_STATUS"
+  | "FM_WORKFLOW_STAGE"
+  | "FM_WORKFLOW_STATUS"
+  | "FM_ARTIFACT_STATUS"
+  | "FM_REVIEW_SHA"
+  | "FM_REVIEW_ISSUE"
+  | "FM_REVIEW_FINDING_COUNT";
+
+/**
+ * Build a structured frontmatter diagnostic.
+ *
+ * @param {FrontmatterDiagnosticCode} code - Stable diagnostic code for the frontmatter failure.
+ * @param {string} filePath - Repository-relative Markdown file path, or a directory for duplicate README failures.
+ * @param {string} message - Human-readable failure message.
+ * @returns {Diagnostic} Structured diagnostic for check output.
+ */
+export function frontmatterDiagnostic(
+  code: FrontmatterDiagnosticCode,
+  filePath: string,
+  message: string,
+): Diagnostic {
+  return {
+    code,
+    path: filePath,
+    message,
+  };
+}
+
+/**
+ * Build diagnostics for required frontmatter keys.
+ *
+ * @param {string} filePath - Repository-relative Markdown file path.
+ * @param {Record<string, unknown>} data - Parsed frontmatter data.
+ * @param {string[]} keys - Required frontmatter keys.
+ * @returns {Diagnostic[]} Missing-key diagnostics.
+ */
+export function requiredKeyDiagnostics(
+  filePath: string,
+  data: Record<string, unknown>,
+  keys: string[],
+): Diagnostic[] {
+  return keys
+    .filter((key) => data[key] === undefined || data[key] === "")
+    .map((key) => frontmatterDiagnostic("FM_KEY", filePath, `missing frontmatter key: ${key}`));
+}

--- a/tests/scripts/diagnostics.test.ts
+++ b/tests/scripts/diagnostics.test.ts
@@ -39,6 +39,15 @@ test("formatDiagnostic preserves location and code when available", () => {
     }),
     "docs/example.md:7 [LINK] missing anchor",
   );
+
+  assert.equal(
+    formatDiagnostic({
+      path: "docs/example.md",
+      code: "FM_MISSING",
+      message: "is missing YAML frontmatter",
+    }),
+    "docs/example.md [FM_MISSING] is missing YAML frontmatter",
+  );
 });
 
 test("wantsJson detects explicit JSON output request", () => {

--- a/tests/scripts/frontmatter.test.ts
+++ b/tests/scripts/frontmatter.test.ts
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { frontmatterDiagnostic, requiredKeyDiagnostics } from "../../scripts/lib/frontmatter.js";
+
+test("frontmatterDiagnostic returns structured failure details", () => {
+  assert.deepEqual(frontmatterDiagnostic("FM_ADR_ID", "docs/adr/0001-example.md", "frontmatter id must be ADR-0001"), {
+    code: "FM_ADR_ID",
+    path: "docs/adr/0001-example.md",
+    message: "frontmatter id must be ADR-0001",
+  });
+});
+
+test("requiredKeyDiagnostics reports only missing or empty keys", () => {
+  assert.deepEqual(
+    requiredKeyDiagnostics(
+      "README.md",
+      {
+        title: "Example",
+        folder: "",
+        description: "Present",
+      },
+      ["title", "folder", "description", "entry_point"],
+    ),
+    [
+      {
+        code: "FM_KEY",
+        path: "README.md",
+        message: "missing frontmatter key: folder",
+      },
+      {
+        code: "FM_KEY",
+        path: "README.md",
+        message: "missing frontmatter key: entry_point",
+      },
+    ],
+  );
+});


### PR DESCRIPTION
## Summary
- Add stable `FM_*` diagnostic codes for `check:frontmatter` failures.
- Add a small frontmatter diagnostics helper with unit coverage.
- Keep human output readable for diagnostics that include a path but no line number, and regenerate script API docs.

## Verification
- `npm run verify`
- `npm run check:frontmatter -- --json`

## Notes
- No linked issue or spec task was provided; this is a focused scripts/tooling improvement following the recent structured diagnostics work.