### PR TITLE
docs: desk-check recipes, add 3 new ones, polish hub and tutorial

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,9 @@ If you are new to the project, start with the tutorial. If you already know the 
 
 Learning-oriented. You follow them step by step; you reach a known end state.
 
-- **[Drive your first feature end-to-end](./tutorials/first-feature.md)** — 60–90 minutes. Add a single term to the README glossary, walking every Specorator stage from Idea to Retrospective. The point is to internalise the lifecycle, not the change.
+- **[Drive your first feature end-to-end](./tutorials/first-feature.md)** — 60–90 minutes. Add the glossary entry `docs/glossary/tracer-bullet.md`, walking every Specorator stage from Idea to Retrospective. The point is to internalise the lifecycle, not the change.
+
+*Quadrant last reviewed: 2026-04-28.*
 
 ---
 
@@ -31,15 +33,16 @@ Learning-oriented. You follow them step by step; you reach a known end state.
 
 Task-oriented recipes — *how do I do X?* You arrive knowing the goal; you leave with the steps.
 
-The MVP set:
+Seventeen recipes are available. Four common starting points:
 
-- [How to fork and personalize the template](./how-to/fork-and-personalize.md)
-- [How to resume a paused feature](./how-to/resume-paused-feature.md)
-- [How to file a new Architecture Decision Record](./how-to/add-adr.md)
-- [How to write a requirement in EARS notation](./how-to/write-ears-requirement.md)
-- [How to run the verify gate](./how-to/run-verify-gate.md)
+- [How to fork and personalize the template](./how-to/fork-and-personalize.md) — first-clone setup.
+- [How to run the verify gate](./how-to/run-verify-gate.md) — `npm run verify` green before pushing.
+- [How to file a new Architecture Decision Record](./how-to/add-adr.md) — capture an irreversible decision.
+- [How to resume a paused feature](./how-to/resume-paused-feature.md) — pick up an in-progress feature at the right stage.
 
-For the planned recipes (🚧) and the recipe template, see the [how-to index](./how-to/README.md).
+For the full set grouped by intent (Onboarding / Day-to-day / Quality and release / Tooling and extensibility), see the [how-to index](./how-to/README.md).
+
+*Quadrant last reviewed: 2026-04-28.*
 
 ### Operational runbooks
 
@@ -65,11 +68,16 @@ Look-it-up, normative. Authoritative; not narrative.
 
 ### Reference + How-to (dual-purpose)
 
-These three are policy on one read, procedure on another:
+These three docs answer two questions side-by-side: *what is the rule?* (Reference) and *how do I follow it?* (How-to). Read the Reference first when you want to know the contract; read the How-to first when you want to do the task.
 
-- [`verify-gate.md`](./verify-gate.md) — *policy* lives here; *procedure* is in [`how-to/run-verify-gate.md`](./how-to/run-verify-gate.md).
-- [`branching.md`](./branching.md) — *policy* lives here; *procedure* (when relevant) is in the resume / verify recipes.
-- [`worktrees.md`](./worktrees.md) — *policy* lives here; *procedure* is in the resume recipe.
+| Topic | Reference (the rule) | How-to (the procedure) |
+|---|---|---|
+| Pre-PR gate | [`verify-gate.md`](./verify-gate.md) | [`how-to/run-verify-gate.md`](./how-to/run-verify-gate.md) |
+| Branch shapes and prefixes | [`branching.md`](./branching.md) | [`how-to/open-pr.md`](./how-to/open-pr.md) |
+| Worktree lifecycle | [`worktrees.md`](./worktrees.md) | [`how-to/resume-paused-feature.md`](./how-to/resume-paused-feature.md), [`how-to/open-pr.md`](./how-to/open-pr.md) |
+| Doctor preflight | [`scripts/doctor/`](./scripts/doctor/) | [`how-to/run-doctor.md`](./how-to/run-doctor.md) |
+
+*Quadrant last reviewed: 2026-04-28.*
 
 ---
 
@@ -84,6 +92,8 @@ Understanding-oriented. Background, rationale, and the *why* behind decisions.
 - [`portfolio-track.md`](./portfolio-track.md) — why portfolios sit above the Specorator lifecycle.
 - [`stock-taking-track.md`](./stock-taking-track.md) — why brownfield projects need a separate inventory step.
 - [`adr/`](./adr/) — the rationale half of each ADR file. (The index lives under Reference above.)
+
+*Quadrant last reviewed: 2026-04-28.*
 
 ---
 

--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -14,11 +14,12 @@ For the full doc map by Diátaxis quadrant — Tutorials / How-to / Reference / 
 
 ## Available recipes
 
-All recipes below are runnable and link out for the *why*. The first five are the original MVP set; the next nine were promoted from stubs as the workflow surface stabilised.
+All recipes below are runnable and link out for the *why*. Each ends with a `Last desk-checked` footer naming the commit it was last validated against — read it as a freshness stamp. Seventeen recipes in five intent groups:
 
 **Onboarding and configuration**
 
 - [How to fork and personalize the template](./fork-and-personalize.md) — turn a fresh clone into your own project.
+- [How to run the doctor preflight](./run-doctor.md) — confirm toolchain, repo state, and dependencies are sane.
 - [How to adapt steering for your own stack](./adapt-steering.md) — rewrite `docs/steering/*.md` so agents read your real context.
 - [How to customize agent permissions](./customize-agent-permissions.md) — change a tool list at the per-agent or project level.
 - [How to migrate an existing project to Specorator](./migrate-to-specorator.md) — overlay the workflow on a brownfield codebase.
@@ -29,7 +30,9 @@ All recipes below are runnable and link out for the *why*. The first five are th
 - [How to skip the Discovery Track on a simple feature](./skip-discovery.md) — go straight to `/spec:idea` and document the skip.
 - [How to write a requirement in EARS notation](./write-ears-requirement.md) — produce one functional requirement, ready for testing.
 - [How to file a new Architecture Decision Record](./add-adr.md) — capture an irreversible decision in `docs/adr/`.
+- [How to add a new glossary term](./add-glossary-term.md) — create a one-file-per-term entry under `docs/glossary/`.
 - [How to run the verify gate](./run-verify-gate.md) — `npm run verify` green before pushing.
+- [How to open a pull request from a worktree](./open-pr.md) — push a topic branch and open the PR.
 
 **Quality and release**
 

--- a/docs/how-to/adapt-steering.md
+++ b/docs/how-to/adapt-steering.md
@@ -29,3 +29,6 @@
 - Reference — [`docs/steering/`](../steering/) — the files an agent reads.
 - How-to — [`fork-and-personalize.md`](./fork-and-personalize.md) — first-time personalization.
 - Explanation — [`docs/specorator.md`](../specorator.md) — how steering plugs into stage agents.
+
+---
+*Last desk-checked 2026-04-28 against commit `81ef60a`.*

--- a/docs/how-to/add-adr.md
+++ b/docs/how-to/add-adr.md
@@ -15,7 +15,14 @@
 1. Open Claude Code in the repo — `claude`.
 2. Run the slash command — `/adr:new "<short title>"`. Example — `/adr:new "use PostgreSQL for the primary store"`.
 3. The command allocates the next number, scaffolds from [`templates/adr-template.md`](../../templates/adr-template.md), and pre-fills sections from the conversation context.
-4. Review the draft — fix the **Context**, **Decision**, **Consequences**, and **Alternatives considered** sections so each is one paragraph at most.
+4. Review the draft. The template has these top-level sections — fill each at one paragraph or one short list:
+   - **Status** — `Proposed`, `Accepted`, `Deprecated`, or `Superseded by ADR-<NNNN>`.
+   - **Context** — what forces this decision. Link upstream requirements, research, or steering files.
+   - **Decision** — the choice, in active voice and present tense.
+   - **Considered options** — at least two alternatives. The template uses **Option A / Option B / …** sub-headings; keep that shape.
+   - **Consequences** — sub-headings **Positive**, **Negative**, **Neutral**. One bullet each is enough.
+   - **Compliance** — how a future reader can tell if the decision is being followed.
+   - **References** — links to upstream artifacts, related ADRs, external sources.
 5. Link the ADR from any artifact it constrains — `requirements.md`, `design.md`, `spec.md`, or the relevant steering file.
 6. Commit — `git add docs/adr/<NNNN>-<slug>.md <linking files> && git commit -m "docs(adr): add ADR-<NNNN> <title>"`.
 
@@ -27,5 +34,8 @@
 
 - Reference — [`docs/adr/`](../adr/) — index of every decision recorded so far.
 - Reference — [`templates/adr-template.md`](../../templates/adr-template.md) — the section shape.
-- Explanation — [`memory/constitution.md`](../../memory/constitution.md) — Article VIII on why decisions are written in active voice and present tense.
+- Explanation — [`memory/constitution.md`](../../memory/constitution.md) — Article VIII (Plain Language) on why decisions are written in active voice and present tense.
 - How-to — [`fork-and-personalize.md`](./fork-and-personalize.md) — personalization changes that warrant an ADR.
+
+---
+*Last desk-checked 2026-04-28 against commit `81ef60a`.*

--- a/docs/how-to/add-glossary-term.md
+++ b/docs/how-to/add-glossary-term.md
@@ -1,0 +1,40 @@
+# How to add a new glossary term
+
+**Goal:** add one new domain term to `docs/glossary/<slug>.md` so future agents and humans share the same vocabulary.
+
+**When to use:** a new domain concept appeared in a workflow (a stage agent flagged an ambiguous word, a discovery sprint coined a label, a steering doc invented a name) and the term is not yet in [`docs/glossary/`](../glossary/).
+
+**Prerequisites:**
+
+- Working tree on a topic branch.
+- A canonical, one-sentence definition of the term in mind. If you are still hedging, run [`grill`](../../.claude/skills/grill/SKILL.md) on the term first.
+- The term is *domain language*, not an implementation detail (class names, transient flags, file paths don't belong in the glossary).
+
+## Steps
+
+1. Open Claude Code — `claude`.
+2. Run the slash command — `/glossary:new "<Term in display case>"`. Example — `/glossary:new "Quality gate"`. The command invokes the [`new-glossary-entry`](../../.claude/skills/new-glossary-entry/SKILL.md) skill.
+3. The skill slugifies the term, refuses to overwrite an existing entry (offers to refine in place instead), copies [`templates/glossary-entry-template.md`](../../templates/glossary-entry-template.md) to `docs/glossary/<slug>.md`, and pre-fills `term`, `slug`, and `last-updated` in the frontmatter.
+4. Fill the body — five sections, one paragraph or one short list each:
+   - **Definition** — one sentence in domain language. No implementation jargon.
+   - **Why it matters** — what distinguishes this term from neighbours; cite the article, command, or skill that introduces it.
+   - **Examples** — concrete usage. A short artifact excerpt or dialogue line beats abstract prose.
+   - **Avoid** — synonyms, near-misses, common misuses. One line each.
+   - **See also** — at least one related entry and the relative path that introduces the term.
+5. Set `status: draft` initially; humans promote to `accepted` after review. Leave `aliases: []` empty unless you are renaming an existing term.
+6. If the new entry relates to an existing one, add the new slug to the existing entry's `related:` list and `## See also` section so the link is bidirectional.
+7. Commit — `git add docs/glossary/<slug>.md <related entries> && git commit -m "docs(glossary): add <slug>"`.
+
+## Verify
+
+`ls docs/glossary/<slug>.md` returns the new file; its frontmatter has `term`, `slug`, `status: draft`, and a real `last-updated` date; `npm run verify` is green.
+
+## Related
+
+- Reference — [`templates/glossary-entry-template.md`](../../templates/glossary-entry-template.md) — the section shape and frontmatter contract.
+- Reference — [`docs/glossary/`](../glossary/) — the directory listing is the index.
+- Explanation — [ADR-0010](../adr/0010-shard-glossary-into-one-file-per-term.md) — why the glossary is sharded one-file-per-term.
+- How-to — [`add-adr.md`](./add-adr.md) — file an ADR if a new term forces a definitional shift in a load-bearing concept.
+
+---
+*Last desk-checked 2026-04-28 against commit `81ef60a`.*

--- a/docs/how-to/authorize-destructive-release.md
+++ b/docs/how-to/authorize-destructive-release.md
@@ -2,7 +2,7 @@
 
 **Goal:** scope, approve, log, and execute an irreversible release action — deploy, force-push to a release branch, prod data migration — so the agent runs it once with explicit human authorization and a paper trail.
 
-**When to use:** Stage 10 (`/spec:release`) has produced a release plan that includes a step the agent cannot run autonomously per [Article IX](../../memory/constitution.md).
+**When to use:** Stage 10 (`/spec:release`) has produced a release plan that includes a step the agent cannot run autonomously per Article IX (Reversibility) of [`memory/constitution.md`](../../memory/constitution.md).
 
 **Prerequisites:**
 
@@ -10,23 +10,39 @@
 - A named human Decider available to authorize the action.
 - Both the destructive command AND its rollback procedure written down before you ask.
 
+> The release-notes template ([`templates/release-notes-template.md`](../../templates/release-notes-template.md)) does not ship a built-in Authorization section, because most releases don't need one. When yours does, add a top-level `## Authorization` section just above `## Verification steps` and follow the steps below to fill it.
+
 ## Steps
 
-1. Open `specs/<slug>/release-notes.md` and find the section labelled `Authorization required:`. Each item there is a destructive action.
-2. For each item, write a one-line **scope statement** — exactly which command, against which environment, on which artifact. No vague verbs (no "deploy"; instead, "run `kubectl apply -f manifests/prod/api.yaml` against cluster `prod-eu`").
-3. Write a one-line **rollback statement** — what the human will run if the action goes wrong, within how many minutes. If there is no rollback, say so explicitly.
-4. Send the scope + rollback to the named Decider. Wait for an explicit *"approved"* response. Capture the approval (Slack permalink, email, signed PR comment) in `release-notes.md` under `Authorization log:` with a UTC timestamp.
-5. Run the command exactly as scoped. Do not generalise the scope; do not retry without re-asking the Decider.
-6. Capture the actual outcome — exit code, full output — in `release-notes.md` under `Execution log:`. Time-stamp it.
-7. If the action failed, run the rollback. Authorization to rollback is implied by the prior approval; authorization to **retry** is not — re-ask the Decider.
-8. Commit the updated `release-notes.md` with message `docs(release): authorize <slug> step <N>`.
+1. Walk the release plan. Mark every step that is irreversible *or* affects shared state (deploy, prod data migration, force-push to a release branch, public announcement). Each one needs its own authorization entry.
+2. In `specs/<slug>/release-notes.md`, add `## Authorization` if it isn't there yet. Under it, scaffold one sub-section per destructive step using this shape:
+
+   ```markdown
+   ### Step <N> — <one-line title>
+
+   - **Scope:** <exact command, env, artifact — no vague verbs>
+   - **Rollback:** <what the human runs if it goes wrong, within how many minutes; "no rollback" if true>
+   - **Decider:** <named human>
+   - **Approval:** <link to Slack / email / PR comment> · <UTC timestamp>
+   - **Execution:** <exit code, key output line> · <UTC timestamp>
+   - **Outcome:** ✅ success | ❌ rolled back — <one-line reason>
+   ```
+3. Send the **Scope** and **Rollback** lines to the named Decider. Wait for an explicit *"approved"* response. Paste the link or quote into **Approval** with a UTC timestamp.
+4. Run the command exactly as scoped. Do not generalise the scope; do not retry without re-asking the Decider.
+5. Fill **Execution** with the actual exit code and the key line of output. Time-stamp it.
+6. If the action failed, run the rollback. Authorization to rollback is implied by the prior approval; authorization to **retry** is not — re-ask the Decider, then add a new `### Step <N> — <title> (retry)` sub-section rather than overwriting the failed one.
+7. Update **Outcome**, then commit the updated `release-notes.md` with message `docs(release): authorize <slug> step <N>`.
 
 ## Verify
 
-`release-notes.md` has both `Authorization log:` and `Execution log:` filled with UTC timestamps and the Decider's identity, and the production environment is in the expected post-release state.
+`grep -nE "^## Authorization|^### Step|Approval:|Execution:" specs/<slug>/release-notes.md` shows the Authorization heading, one sub-section per destructive step, and an `Approval` and `Execution` line per step — each with a UTC timestamp and the Decider's identity.
 
 ## Related
 
+- Reference — [`templates/release-notes-template.md`](../../templates/release-notes-template.md) — base template; the Authorization section is added on demand.
 - Reference — [`docs/specorator.md`](../specorator.md) — Stage 10 definition.
 - Reference — [`.claude/agents/release-manager.md`](../../.claude/agents/release-manager.md) — agent scope.
-- Explanation — [`memory/constitution.md`](../../memory/constitution.md) — Article IX on reversibility.
+- Explanation — [`memory/constitution.md`](../../memory/constitution.md) — Article IX (Reversibility) on why irreversible actions need scoped human approval.
+
+---
+*Last desk-checked 2026-04-28 against commit `81ef60a`.*

--- a/docs/how-to/bootstrap-operational-bot.md
+++ b/docs/how-to/bootstrap-operational-bot.md
@@ -30,3 +30,6 @@
 - Reference — [`agents/operational/README.md`](../../agents/operational/README.md) — the eight-section shape and severity scale.
 - Reference — [`agents/operational/`](../../agents/operational/) — existing bots as examples.
 - Explanation — [`docs/specorator.md`](../specorator.md) — where operational agents fit relative to lifecycle agents.
+
+---
+*Last desk-checked 2026-04-28 against commit `81ef60a`.*

--- a/docs/how-to/customize-agent-permissions.md
+++ b/docs/how-to/customize-agent-permissions.md
@@ -28,5 +28,8 @@ The previously-failing operation now succeeds in the agent's session, AND `npm r
 
 - Reference — [`.claude/settings.json`](../../.claude/settings.json) — permission baseline.
 - Reference — [`.claude/agents/`](../../.claude/agents/) — per-agent tool lists.
-- Explanation — [`AGENTS.md`](../../AGENTS.md) — why tool restrictions are deliberate.
+- Explanation — [`AGENTS.md`](../../AGENTS.md) — why tool restrictions are deliberate (Article VI — Agent Specialisation).
 - How-to — [`add-adr.md`](./add-adr.md) — file the ADR when loosening.
+
+---
+*Last desk-checked 2026-04-28 against commit `81ef60a`.*

--- a/docs/how-to/fork-and-personalize.md
+++ b/docs/how-to/fork-and-personalize.md
@@ -13,20 +13,27 @@
 ## Steps
 
 1. Clone the template — `git clone <your-fork-url> my-project && cd my-project`.
-2. Open [`memory/constitution.md`](../../memory/constitution.md) and replace the placeholder principles with the ones your team actually follows.
-3. Open [`docs/steering/product.md`](../steering/product.md) and write one paragraph on what the product does and who it serves.
-4. Open [`docs/steering/tech.md`](../steering/tech.md) and list your language, framework, datastore, and any non-default tooling agents need to know about.
-5. Open [`docs/steering/quality.md`](../steering/quality.md) and capture your test, lint, and review expectations.
-6. Replace the project-name in [`README.md`](../../README.md) line 1 and the `## What is this?` section.
-7. Stage and commit — `git add -A && git commit -m "chore: personalize template for <project name>"`.
+2. Install the verify-gate dependencies — `npm install`. The repo ships a Node-based gate (`npm run verify`) you'll need before opening PRs; see [`run-verify-gate.md`](./run-verify-gate.md).
+3. Run the doctor once to confirm the toolchain is happy — `npm run doctor`. See [`run-doctor.md`](./run-doctor.md).
+4. Open [`memory/constitution.md`](../../memory/constitution.md) and replace the placeholder principles with the ones your team actually follows.
+5. Open [`docs/steering/product.md`](../steering/product.md) and write one paragraph on what the product does and who it serves.
+6. Open [`docs/steering/tech.md`](../steering/tech.md) and list your language, framework, datastore, and any non-default tooling agents need to know about.
+7. Open [`docs/steering/quality.md`](../steering/quality.md) and capture your test, lint, and review expectations.
+8. Replace the project-name in [`README.md`](../../README.md) line 1 and the `## What is this?` section.
+9. Stage and commit — `git add -A && git commit -m "chore: personalize template for <project name>"`.
 
 ## Verify
 
-`git log --oneline -1` shows your personalization commit and `cat docs/steering/tech.md` returns your stack, not the placeholder.
+`git log --oneline -1` shows your personalization commit, `cat docs/steering/tech.md` returns your stack (not the placeholder), and `npm run verify` exits 0.
 
 ## Related
 
 - Reference — [`docs/specorator.md`](../specorator.md) — full workflow definition.
 - Reference — [`docs/steering/`](../steering/) — what each steering file is for.
 - Explanation — [`memory/constitution.md`](../../memory/constitution.md) — why principles are loaded ahead of every command.
+- How-to — [`run-doctor.md`](./run-doctor.md) — confirm the toolchain after install.
+- How-to — [`run-verify-gate.md`](./run-verify-gate.md) — pre-PR gate.
 - How-to — [`add-adr.md`](./add-adr.md) — record any constitution change as a decision.
+
+---
+*Last desk-checked 2026-04-28 against commit `81ef60a`.*

--- a/docs/how-to/migrate-to-specorator.md
+++ b/docs/how-to/migrate-to-specorator.md
@@ -30,3 +30,6 @@
 - Reference — [`docs/specorator.md`](../specorator.md) — the workflow being adopted.
 - Explanation — [ADR-0007](../adr/0007-add-stock-taking-track-for-legacy-projects.md) — why brownfield gets its own track.
 - How-to — [`fork-and-personalize.md`](./fork-and-personalize.md), [`adapt-steering.md`](./adapt-steering.md), [`add-adr.md`](./add-adr.md).
+
+---
+*Last desk-checked 2026-04-28 against commit `81ef60a`.*

--- a/docs/how-to/open-pr.md
+++ b/docs/how-to/open-pr.md
@@ -17,7 +17,23 @@
 3. Run the verify gate — `npm run verify`. It must exit 0 before you push. See [`run-verify-gate.md`](./run-verify-gate.md). Never `--no-verify`.
 4. Push — `git push -u origin HEAD`. The `-u` sets upstream so future pushes are bare `git push`. The deny list in [`.claude/settings.json`](../../.claude/settings.json) blocks pushes to `main` / `develop`; topic branches are allowed.
 5. Open the PR. Two equivalent options:
-   - **`gh` CLI** — `gh pr create --base main --title "<imperative summary>" --body "$(cat <<'EOF'\n## Summary\n- bullet 1\n- bullet 2\n\n## Test plan\n- [ ] verify gate green\n- [ ] <other checks>\nEOF\n)"`. Replace `main` with `develop` if your project uses Shape B in [`docs/branching.md`](../branching.md).
+   - **`gh` CLI** — write the PR body to a scratch file first, then pass it via `--body-file`. Replace `main` with `develop` if your project uses Shape B in [`docs/branching.md`](../branching.md).
+
+     ```bash
+     cat > /tmp/pr-body.md <<'EOF'
+     ## Summary
+     - bullet 1
+     - bullet 2
+
+     ## Test plan
+     - [ ] verify gate green
+     - [ ] <other checks>
+     EOF
+
+     gh pr create --base main \
+       --title "<imperative summary>" \
+       --body-file /tmp/pr-body.md
+     ```
    - **Browser** — open the URL `git push` printed.
 6. Confirm the PR uses the right base branch. For a fork, the base remote is the upstream repo, not your fork.
 7. If the PR depends on another open PR, do *not* stack — close it, rebase the topic branch off the merged integration branch once the upstream PR lands, and re-push. See [`docs/branching.md`](../branching.md) and `feedback_pr_hygiene.md`.

--- a/docs/how-to/open-pr.md
+++ b/docs/how-to/open-pr.md
@@ -1,0 +1,39 @@
+# How to open a pull request from a worktree
+
+**Goal:** take a topic branch from a `.worktrees/<slug>/` checkout to an open PR on GitHub, with the verify gate green and one concern per PR.
+
+**When to use:** you've finished a unit of work on a topic branch and need it reviewed and merged. Use this every time — there is no "small enough to skip the PR" case.
+
+**Prerequisites:**
+
+- Working tree under `.worktrees/<slug>/` on a topic branch (prefix `feat/`, `fix/`, `refactor/`, `chore/`, or `docs/`).
+- Commits scoped to one concern. If the diff is two concerns, split it before pushing.
+- `gh` CLI authenticated, OR willingness to open the PR in the browser at the URL `git push` prints.
+
+## Steps
+
+1. Confirm you are on the right branch and worktree — `git worktree list` and `git branch --show-current`. The branch name must match the `.worktrees/<slug>/` directory name (slug only, prefix optional).
+2. Make sure your commits follow the project's message convention — imperative mood, reference IDs where relevant. Example — `feat(auth): add T-AUTH-014 password reset`. See [`AGENTS.md`](../../AGENTS.md) → "Repo conventions".
+3. Run the verify gate — `npm run verify`. It must exit 0 before you push. See [`run-verify-gate.md`](./run-verify-gate.md). Never `--no-verify`.
+4. Push — `git push -u origin HEAD`. The `-u` sets upstream so future pushes are bare `git push`. The deny list in [`.claude/settings.json`](../../.claude/settings.json) blocks pushes to `main` / `develop`; topic branches are allowed.
+5. Open the PR. Two equivalent options:
+   - **`gh` CLI** — `gh pr create --base main --title "<imperative summary>" --body "$(cat <<'EOF'\n## Summary\n- bullet 1\n- bullet 2\n\n## Test plan\n- [ ] verify gate green\n- [ ] <other checks>\nEOF\n)"`. Replace `main` with `develop` if your project uses Shape B in [`docs/branching.md`](../branching.md).
+   - **Browser** — open the URL `git push` printed.
+6. Confirm the PR uses the right base branch. For a fork, the base remote is the upstream repo, not your fork.
+7. If the PR depends on another open PR, do *not* stack — close it, rebase the topic branch off the merged integration branch once the upstream PR lands, and re-push. See [`docs/branching.md`](../branching.md) and `feedback_pr_hygiene.md`.
+8. Reply on the PR thread when CI / review feedback lands. Drain feedback in batches; one implementation pass + one sweep pass beats N serial round-trips.
+
+## Verify
+
+`gh pr view --json url,state,baseRefName` returns `state: OPEN`, `baseRefName: main` (or `develop`), and a non-empty URL — and the GitHub PR page shows your verify-gate green check.
+
+## Related
+
+- Reference — [`docs/branching.md`](../branching.md) — branch shapes and prefixes.
+- Reference — [`docs/worktrees.md`](../worktrees.md) — worktree lifecycle, including cleanup after merge.
+- Reference — [`AGENTS.md`](../../AGENTS.md) — commit-message convention and "branch per concern" rule.
+- How-to — [`run-verify-gate.md`](./run-verify-gate.md) — the gate to run before pushing.
+- How-to — [`run-doctor.md`](./run-doctor.md) — preflight if the gate reports environment errors.
+
+---
+*Last desk-checked 2026-04-28 against commit `81ef60a`.*

--- a/docs/how-to/resume-paused-feature.md
+++ b/docs/how-to/resume-paused-feature.md
@@ -12,20 +12,24 @@
 
 ## Steps
 
-1. Read the state file — `cat specs/<slug>/workflow-state.md`. Identify the `Active stage` and the last completed stage.
-2. List the artifacts present — `ls specs/<slug>/`. Confirm every stage marked complete has its expected file (e.g. `requirements.md` for Stage 3, `design.md` for Stage 4).
+1. Read the state file — `cat specs/<slug>/workflow-state.md`. The frontmatter has `current_stage` (one of `idea | research | requirements | design | specification | tasks | implementation | testing | review | release | learning`), `status` (`active | blocked | paused | done`), `last_updated`, `last_agent`, and an `artifacts:` map. Use these to identify where the feature is.
+2. List the artifacts present — `ls specs/<slug>/`. Cross-check against the `artifacts:` map: every key marked `complete` must have its file on disk; anything marked `pending` or `in-progress` is your candidate for the next move.
 3. Open Claude Code — `claude`.
-4. Resume conversationally — say `continue the <slug> feature`. The `orchestrate` skill picks up at the active stage and dispatches the right specialist agent.
+4. Resume conversationally — say `continue the <slug> feature`. The `orchestrate` skill reads `current_stage` and dispatches the right specialist agent.
 5. Or resume manually — run the matching `/spec:*` command for the active stage (`/spec:design`, `/spec:tasks`, `/spec:implement`, etc.).
-6. If the state file is missing or contradictory, escalate — do not invent the stage. Rebuild state from the artifacts present plus a brief from a human.
+6. If the state file is missing or contradictory (artifact map disagrees with files on disk), escalate — do not invent the stage. Rebuild state from the artifacts present plus a brief from a human.
 
 ## Verify
 
-After your first action, `cat specs/<slug>/workflow-state.md` shows an updated `Last activity` timestamp and the new stage's artifact appears in `specs/<slug>/`.
+After your first action, `cat specs/<slug>/workflow-state.md` shows an updated `last_updated` date and `last_agent`, and the new stage's artifact appears in `specs/<slug>/` and is no longer marked `pending` in the `artifacts:` map.
 
 ## Related
 
+- Reference — [`templates/workflow-state-template.md`](../../templates/workflow-state-template.md) — the frontmatter shape and stage table.
 - Reference — [`docs/specorator.md`](../specorator.md) — full stage definitions and gates.
 - Reference — [`docs/workflow-overview.md`](../workflow-overview.md) — slash-command cheat sheet.
 - Reference — [`docs/sink.md`](../sink.md) — which artifact each stage produces.
 - How-to — [`run-verify-gate.md`](./run-verify-gate.md) — gate to run before pushing once implementation resumes.
+
+---
+*Last desk-checked 2026-04-28 against commit `81ef60a`.*

--- a/docs/how-to/run-doctor.md
+++ b/docs/how-to/run-doctor.md
@@ -1,0 +1,42 @@
+# How to run the doctor preflight
+
+**Goal:** confirm your local toolchain, repo state, and dependency tree are healthy before you start (or resume) work — so the verify gate doesn't surprise you later.
+
+**When to use:** you just cloned or forked the template; you switched branches; `npm run verify` reported a confusing environment error; you want a single command that summarises *"is my checkout sane?"*
+
+**Prerequisites:**
+
+- Repo cloned with a working tree on disk.
+- `node` and `npm` on `PATH`.
+
+## Steps
+
+1. From the repo root, run — `npm run doctor`.
+2. Read the output top-to-bottom. The script runs ten checks and prints one line per check (`pass` / `warn` / `fail`):
+   - **Node** — version satisfies the engines field (`>=20`).
+   - **npm** — present on `PATH`.
+   - **git** — present on `PATH`.
+   - **branch** — current branch and upstream.
+   - **git status** — clean / dirty.
+   - **worktrees** — every entry under `.worktrees/` is registered with git.
+   - **dependencies** — `node_modules/` matches `package.json`.
+   - **ADR index** — re-runs `check:adr-index`.
+   - **command inventories** — re-runs `check:commands`.
+   - **verify gate** — re-runs `npm run verify` end-to-end.
+3. For every `warn` line, read the `hint` to decide if it matters for your task. Many warns (e.g. dirty tree on a topic branch) are expected.
+4. For every `fail` line, fix the underlying cause before continuing. The doctor exits non-zero on any failure.
+5. Re-run until the trailing line reads `doctor: ok`.
+
+## Verify
+
+`npm run doctor` exits 0 and the final line reads `doctor: ok`.
+
+## Related
+
+- Reference — [`docs/scripts/doctor/`](../scripts/doctor/) — what each check does and why it exists.
+- Reference — [`scripts/doctor.ts`](../../scripts/doctor.ts) — the source of the check list.
+- How-to — [`run-verify-gate.md`](./run-verify-gate.md) — the per-PR gate the doctor wraps.
+- How-to — [`fork-and-personalize.md`](./fork-and-personalize.md) — first-clone flow that calls the doctor.
+
+---
+*Last desk-checked 2026-04-28 against commit `81ef60a`.*

--- a/docs/how-to/run-retrospective.md
+++ b/docs/how-to/run-retrospective.md
@@ -2,31 +2,35 @@
 
 **Goal:** run Stage 11 (`/spec:retro`) on a feature, capture what worked / didn't / what to change, and propose concrete amendments to templates, agents, or the constitution.
 
-**When to use:** the feature has shipped or been killed; the retrospective is mandatory before marking the feature complete (Article X).
+**When to use:** the feature has shipped or been killed; the retrospective is mandatory before marking the feature complete (Article X — Iteration).
 
 **Prerequisites:**
 
 - Feature has reached Stage 9 (Review) with a verdict; Stage 10 (Release) is either done or explicitly skipped.
-- `specs/<slug>/workflow-state.md` says `Active stage: Stage 11 — Retrospective`.
+- `specs/<slug>/workflow-state.md` frontmatter has `current_stage: learning` (set automatically when `/spec:release` finishes).
 - Open Claude Code session, OR willingness to run the retrospective agent manually in another tool.
 
 ## Steps
 
 1. Open Claude Code — `claude`.
 2. Run `/spec:retro`. The retrospective agent reads every prior artifact in `specs/<slug>/` and walks you through the questions.
-3. Answer each prompt. The agent captures three sections — **What worked**, **What didn't**, **Actions** (with owner and target date for each).
-4. The agent writes `specs/<slug>/retrospective.md` and proposes amendments to templates, agents, or [`memory/constitution.md`](../../memory/constitution.md). Each amendment is a separate suggestion you accept or reject.
+3. Answer each prompt. The agent fills the seven template sections — **Outcome**, **What worked**, **What didn't work**, **Spec adherence**, **Process observations**, **Actions** (table with Action / Type / Owner / Due), and **Lessons** (one-liners worth remembering).
+4. The agent writes `specs/<slug>/retrospective.md` and proposes amendments to templates, agents, or [`memory/constitution.md`](../../memory/constitution.md). Each amendment becomes a row in the **Actions** table with `Type` set to `template`, `agent`, `adr`, or `constitution`.
 5. File accepted amendments as their own follow-up work — typically a `chore(memory): …` PR for `feedback_*.md`, or an ADR for constitution changes. See [`add-adr.md`](./add-adr.md).
-6. Update `workflow-state.md` to `Active stage: Complete`.
+6. The retrospective agent updates `workflow-state.md` to `current_stage: learning` with `status: complete`. Do not edit by hand.
 7. Commit `retrospective.md` and any accepted amendments.
 
 ## Verify
 
-`cat specs/<slug>/retrospective.md` shows the three sections filled, with at least one Action item (even *"none — feature shipped clean"* counts).
+`cat specs/<slug>/retrospective.md` shows the seven sections filled, with at least one row in the Actions table (even *"none — feature shipped clean"* counts).
 
 ## Related
 
+- Reference — [`templates/retrospective-template.md`](../../templates/retrospective-template.md) — the section list and Actions table shape.
 - Reference — [`docs/specorator.md`](../specorator.md) — Stage 11 definition.
 - Reference — [`.claude/agents/retrospective.md`](../../.claude/agents/retrospective.md) — agent scope.
-- Explanation — [`memory/constitution.md`](../../memory/constitution.md) — Article X on iteration.
+- Explanation — [`memory/constitution.md`](../../memory/constitution.md) — Article X (Iteration) on why retrospectives are mandatory.
 - How-to — [`add-adr.md`](./add-adr.md) — for constitution-level amendments.
+
+---
+*Last desk-checked 2026-04-28 against commit `81ef60a`.*

--- a/docs/how-to/run-verify-gate.md
+++ b/docs/how-to/run-verify-gate.md
@@ -29,4 +29,8 @@ The final line of the verify output reads `verify: OK` (or your project's equiva
 - Reference — [`docs/verify-gate.md`](../verify-gate.md) — what each phase checks and how to extend it.
 - Reference — [`docs/branching.md`](../branching.md) — branch naming and protected branches.
 - Reference — [`docs/worktrees.md`](../worktrees.md) — running parallel branches without trashing caches.
+- How-to — [`run-doctor.md`](./run-doctor.md) — preflight check when verify reports environment errors.
 - How-to — [`add-adr.md`](./add-adr.md) — record a decision if you change what the gate checks.
+
+---
+*Last desk-checked 2026-04-28 against commit `81ef60a`.*

--- a/docs/how-to/skip-discovery.md
+++ b/docs/how-to/skip-discovery.md
@@ -28,3 +28,6 @@
 - Reference — [`docs/specorator.md`](../specorator.md) — Stage 1 (Idea) definition.
 - Explanation — [ADR-0005](../adr/0005-add-discovery-track-before-stage-1.md) — why Discovery exists in the first place.
 - How-to — [`add-adr.md`](./add-adr.md) — file an ADR if the skip is policy-level.
+
+---
+*Last desk-checked 2026-04-28 against commit `81ef60a`.*

--- a/docs/how-to/switch-ai-tool.md
+++ b/docs/how-to/switch-ai-tool.md
@@ -29,3 +29,6 @@ The destination tool successfully advances one stage and updates `workflow-state
 - Reference — [`AGENTS.md`](../../AGENTS.md) — cross-tool root context every supported tool reads.
 - Reference — [`.codex/`](../../.codex/) — Codex-specific instructions.
 - Explanation — [`docs/specorator.md`](../specorator.md) — why the workflow is tool-agnostic.
+
+---
+*Last desk-checked 2026-04-28 against commit `81ef60a`.*

--- a/docs/how-to/trace-failing-test.md
+++ b/docs/how-to/trace-failing-test.md
@@ -16,15 +16,19 @@
 2. Open `specs/<slug>/traceability.md`. Find the row whose Test column contains your ID. Note the linked `T-<AREA>-NNN` (task) and `REQ-<AREA>-NNN` (requirement).
 3. Open the test source. Re-read the assertion. Ask: does it actually verify the requirement, or does it test something close-but-different? If close-but-different, the defect is in the **test** — fix the test.
 4. Open the code under test. Step through the assertion mentally. Does the code do what the test expects? If no, the defect is in the **code** — fix the code, leave the test.
-5. Open the originating `REQ-<AREA>-NNN` in `requirements.md`. Does the requirement actually say what the test is checking? If no, the defect is in the **requirement** — escalate per [Article IV](../../memory/constitution.md): update `requirements.md` first, then re-spec, re-task, re-implement, re-test.
-6. Document your finding in the test report's `Notes:` field for the failure, with a one-liner naming the layer.
+5. Open the originating `REQ-<AREA>-NNN` in `requirements.md`. Does the requirement actually say what the test is checking? If no, the defect is in the **requirement** — escalate per Article IV (Quality Gates) of [`memory/constitution.md`](../../memory/constitution.md): update `requirements.md` first, then re-spec, re-task, re-implement, re-test.
+6. Update the failure block in `test-report.md`. The template shape is `### TEST-<AREA>-NNN — <short title>` followed by bullets `Requirement`, `Expected`, `Actual`, `Reproduction`, `Severity` (S1–S4), `Suspected root cause`, `Owner`. Set `Suspected root cause` to one of *test layer*, *code layer*, or *requirement layer* — that is your finding.
 
 ## Verify
 
-`grep "<TEST-ID>" specs/<slug>/test-report.md` shows your finding line, and `git diff` shows the fix at exactly one layer (test, code, or requirement chain) — not all three.
+`grep -nE "TEST-[A-Z]+-[0-9]{3}|Suspected root cause" specs/<slug>/test-report.md` shows the failure heading and your updated `Suspected root cause:` line, and `git diff` shows the fix at exactly one layer (test, code, or requirement chain) — not all three.
 
 ## Related
 
+- Reference — [`templates/test-report-template.md`](../../templates/test-report-template.md) — the failure-block field list.
 - Reference — [`docs/traceability.md`](../traceability.md) — the chain of IDs.
 - Reference — [`docs/quality-framework.md`](../quality-framework.md) — gates per stage.
-- Explanation — [`memory/constitution.md`](../../memory/constitution.md) — Article IV on resolving defects at the earliest stage.
+- Explanation — [`memory/constitution.md`](../../memory/constitution.md) — Article IV (Quality Gates) on resolving defects at the earliest stage.
+
+---
+*Last desk-checked 2026-04-28 against commit `81ef60a`.*

--- a/docs/how-to/write-ears-requirement.md
+++ b/docs/how-to/write-ears-requirement.md
@@ -10,22 +10,38 @@
 - You know which **area** the requirement covers (the `<AREA>` token in the ID — e.g. `AUTH`, `BILLING`, `UI`).
 - One observable behaviour to describe.
 
+## EARS pattern table
+
+| Pattern             | Keyword shape                          | Example sentence                                                                                       |
+|---------------------|----------------------------------------|--------------------------------------------------------------------------------------------------------|
+| Ubiquitous          | *The system shall …*                   | The system shall log every authentication attempt to the audit stream.                                 |
+| Event-driven        | *When `<trigger>`, the system shall …* | When the user submits valid credentials, the system shall redirect to the dashboard within 500 ms.    |
+| State-driven        | *While `<state>`, the system shall …*  | While the user session is active, the system shall refresh the access token every 14 minutes.         |
+| Unwanted-behaviour  | *If `<condition>`, then the system shall …* | If the password is rejected three times within five minutes, then the system shall lock the account. |
+| Optional-feature    | *Where `<feature>`, the system shall …* | Where SSO is enabled, the system shall skip the local password check.                                  |
+
+See [`docs/ears-notation.md`](../ears-notation.md) for the full catalogue and edge cases.
+
 ## Steps
 
-1. Pick the EARS pattern that matches the behaviour — **ubiquitous** (always true), **event** (`When <trigger>`), **state** (`While <state>`), **unwanted** (`If <condition>, then`), or **optional** (`Where <feature>`). See [`docs/ears-notation.md`](../ears-notation.md) for examples of each.
-2. Write the sentence using the chosen pattern. Use *shall*, name the system as the subject, and describe one observable response. Example — *"When the user submits the login form with valid credentials, the system shall redirect to the dashboard within 500 ms."*
+1. Pick the EARS pattern that matches the behaviour using the table above.
+2. Write the sentence using the chosen pattern. Use *shall*, name the system as the subject, and describe one observable response.
 3. Allocate the next ID in the area — `REQ-<AREA>-NNN`. Look at the existing IDs in `requirements.md` and increment.
-4. Add the requirement to `requirements.md` under the right heading, with the ID prefixed — `**REQ-AUTH-014.** When the user submits…`.
-5. Add a placeholder test ID in your notes — `TEST-AUTH-014` — so the QA agent can pick it up in Stage 8.
+4. Add the requirement to `requirements.md` under `## Functional requirements (EARS)`, as a new sub-section using the template shape — heading `### REQ-<AREA>-NNN — <short title>` followed by the bullet block (`Pattern`, `Statement`, `Acceptance` with Given/When/Then, `Priority`, `Satisfies`). See [`templates/prd-template.md`](../../templates/prd-template.md) for the exact field list.
+5. Add a placeholder test ID in your notes — `TEST-<AREA>-NNN`, matching the requirement's number — so the QA agent can pick it up in Stage 8.
 6. Re-read the sentence as if you were writing the test for it. If you cannot picture exactly one assertion, the sentence is still ambiguous — rewrite it.
 
 ## Verify
 
-`grep -E "REQ-[A-Z]+-[0-9]{3}" specs/<slug>/requirements.md` lists your new ID exactly once, and the sentence on that line uses one of the five EARS keywords.
+`grep -E "REQ-[A-Z]+-[0-9]{3}" specs/<slug>/requirements.md` lists your new ID at least once (the heading and any inline references), and the **Statement** bullet under that heading uses one of the five EARS keyword shapes from the table above.
 
 ## Related
 
 - Reference — [`docs/ears-notation.md`](../ears-notation.md) — full pattern catalogue and worked examples.
+- Reference — [`templates/prd-template.md`](../../templates/prd-template.md) — the section the requirement lives under.
 - Reference — [`docs/traceability.md`](../traceability.md) — the requirement → spec → task → code → test chain.
-- Explanation — [`memory/constitution.md`](../../memory/constitution.md) — Article VIII on why EARS is mandatory.
+- Explanation — [`memory/constitution.md`](../../memory/constitution.md) — Article VIII (Plain Language) on why EARS is mandatory.
 - How-to — [`resume-paused-feature.md`](./resume-paused-feature.md) — where to pick up if your feature is mid-flight.
+
+---
+*Last desk-checked 2026-04-28 against commit `81ef60a`.*

--- a/docs/tutorials/first-feature.md
+++ b/docs/tutorials/first-feature.md
@@ -68,6 +68,23 @@ The first argument is the feature slug; the optional second is the area code tha
 
 **What happens:** Claude Code creates `specs/glossary-term/` and copies `templates/workflow-state-template.md` into it as `workflow-state.md`, filling `feature: glossary-term` and `area: DOCS` in the frontmatter.
 
+**Sample `workflow-state.md` — frontmatter excerpt** *(yours will look like this after Stage 0):*
+
+```yaml
+---
+feature: glossary-term
+area: DOCS
+current_stage: idea
+status: active
+last_updated: 2026-04-28
+last_agent: spec-start
+artifacts:
+  idea.md: pending
+  research.md: pending
+  …
+---
+```
+
 **If you see this, you are on track:** `ls specs/glossary-term/` shows exactly one file — `workflow-state.md`. Open it. Frontmatter has `current_stage: idea`, `status: active`, and an `artifacts:` map listing every future artifact as `pending`. Below the frontmatter is a `## Stage progress` table showing each stage with its expected artifact and status `pending`.
 
 ---
@@ -77,6 +94,31 @@ The first argument is the feature slug; the optional second is the area code tha
 **Command:** `/spec:idea`. Or in plain language: *"I want to add a glossary entry for **Tracer Bullet**, the term defined by Hunt and Thomas in *The Pragmatic Programmer*."*
 
 **What happens:** the `analyst` agent asks a few clarifying questions about the brief, then writes `specs/glossary-term/idea.md` from `templates/idea-template.md`.
+
+**Sample answers to the analyst's gate questions** *(use these verbatim; the analyst is asking what would normally be a one-paragraph brief):*
+
+- *Who's the target reader?* — *"Anyone using this template who hasn't met the term before — primarily new contributors and AI agents reading our skills."*
+- *What's the desired outcome?* — *"A canonical one-sentence definition lives at `docs/glossary/tracer-bullet.md`, linked from the related entry on Spike."*
+- *Any constraints I should respect?* — *"Markdown only. Use `templates/glossary-entry-template.md`. Keep the definition aligned with Hunt & Thomas's original."*
+- *What's out of scope?* — *"Renaming or merging existing glossary entries. Adding more than one term."*
+
+**Sample `idea.md` excerpt** *(after the analyst writes it):*
+
+```markdown
+---
+id: IDEA-DOCS-001
+stage: idea
+status: draft
+---
+
+## Problem statement
+The term *Tracer Bullet* is referenced in our `tracer-bullet` skill but has no canonical
+definition in `docs/glossary/`. Readers must infer the meaning from context.
+
+## Open questions
+- OQ-001: Should the definition follow Hunt & Thomas verbatim or be paraphrased for our context?
+- OQ-002: Which existing entries should bidirectionally link?
+```
 
 **If you see this, you are on track:** `idea.md` exists with frontmatter `id: IDEA-DOCS-001`, `stage: idea`, `status: draft`. Body has these sections: `## Problem statement`, `## Target users`, `## Desired outcome`, `## Constraints`, `## Open questions`. The Open questions section becomes the research agenda for Stage 2. `workflow-state.md`'s frontmatter has advanced to `current_stage: research` and the Stage 1 row in the progress table is now `complete`.
 
@@ -97,6 +139,24 @@ The first argument is the feature slug; the optional second is the area code tha
 **Command:** `/spec:requirements`.
 
 **What happens:** the `pm` agent writes a PRD at `requirements.md` from `templates/prd-template.md`. The document's own ID is `PRD-DOCS-001`; functional requirements inside it use **EARS notation** with stable IDs `REQ-DOCS-NNN`. For this feature you should expect one or two requirements — e.g. *"Where the `docs/glossary/` directory is read, the system shall include a `tracer-bullet.md` entry with a one-sentence canonical definition."*
+
+**Sample `requirements.md` — Functional requirements excerpt** *(showing the `### REQ-…` heading and bullet shape from `templates/prd-template.md`):*
+
+```markdown
+## Functional requirements (EARS)
+
+### REQ-DOCS-001 — Tracer Bullet glossary entry exists
+
+- **Pattern:** ubiquitous
+- **Statement:** *The system shall include a `docs/glossary/tracer-bullet.md` entry whose
+  Definition section names the term in the sense of Hunt and Thomas (1999).*
+- **Acceptance:**
+  - Given a fresh checkout
+  - When `docs/glossary/tracer-bullet.md` is read
+  - Then it parses, has `term: Tracer Bullet`, and the Definition section is non-empty
+- **Priority:** must
+- **Satisfies:** IDEA-DOCS-001
+```
 
 **If you see this, you are on track:** `requirements.md` has frontmatter `id: PRD-DOCS-001`. Body has `## Summary`, `## Goals`, `## Non-goals`, `## Personas / stakeholders`, `## Jobs to be done`, and a `## Functional requirements (EARS)` section listing at least one `REQ-DOCS-NNN` line that uses one of the EARS keywords (`When`, `Where`, `While`, `If`, the optional-feature pattern, or the ubiquitous `the system shall` form). Further sections — `## Non-functional requirements`, `## Success metrics`, `## Release criteria`, `## Open questions / clarifications`, `## Out of scope`, `## Quality gate` — round out the PRD shape. For the EARS reference, see [`docs/ears-notation.md`](../ears-notation.md).
 
@@ -129,6 +189,18 @@ The first argument is the feature slug; the optional second is the area code tha
 **Command:** `/spec:tasks`.
 
 **What happens:** the `planner` decomposes the spec into a tasks list at `tasks.md` from `templates/tasks-template.md`. Each task carries a `T-DOCS-NNN` ID, an emoji marker (🧪 test, 🔨 implementation, 📐 design/scaffolding, 📚 documentation, 🚀 release/ops), an owner from the closed set `dev | qa | sre | human`, and references at least one `REQ-DOCS-NNN`. **TDD ordering** is enforced — the test task for a requirement comes *before* the implementation task for that requirement.
+
+**Sample `tasks.md` excerpt** *(showing TDD ordering — test before implementation):*
+
+```markdown
+- **T-DOCS-001** 🧪 Write a parser test for `docs/glossary/tracer-bullet.md`
+  - Owner: qa · Estimate: S · Satisfies: REQ-DOCS-001
+  - Definition of done: failing test asserts the file's frontmatter and Definition section.
+
+- **T-DOCS-002** 🔨 Create `docs/glossary/tracer-bullet.md` from the template
+  - Owner: dev · Estimate: S · Satisfies: REQ-DOCS-001 · Depends on: T-DOCS-001
+  - Definition of done: T-DOCS-001 passes; entry's `related:` points to `spike`.
+```
 
 **If you see this, you are on track:** `tasks.md` lists at least one 🧪 test task (owner=`qa`) followed by one 🔨 implementation task (owner=`dev`). Each row has `Satisfies: REQ-DOCS-NNN`, a `Definition of done:` checkbox list, and an estimate of S or M.
 
@@ -185,7 +257,30 @@ What it would do, if you did run it: invoke the `release-manager` agent to write
 
 **What happens:** the `retrospective` agent reads every artifact in `specs/glossary-term/` and walks you through the questions. The retrospective is **mandatory**, not optional — even on a tutorial — running it once now is the easiest way to internalise that.
 
-**If you see this, you are on track:** `retrospective.md` has frontmatter `id: RETRO-DOCS-001`, `stage: learning`. Body has the sections from `templates/retrospective-template.md` filled in: `## Outcome`, `## What worked`, `## What didn't work`, `## Spec adherence`, `## Process observations`. The agent also surfaces proposed amendments — to templates, agents, or the constitution — for you to accept or reject. Even a one-line *"none — feature shipped clean"* counts as an answer.
+**Sample answers to the retrospective gate** *(short and honest beats long and performative):*
+
+- *Did we drift from spec?* — *"No. The spec named the file path, frontmatter, and Definition; the implementation matched."*
+- *What worked?* — *"TDD ordering caught a missing `aliases` field before the file was written."*
+- *What didn't?* — *"Stage 4 (Design) felt like overhead for a markdown-only change. Note for `/spec:retro` to suggest a `light` mode for trivial subjects."*
+- *Actions?* — *"None for this feature; one constitution-level note logged for review."*
+
+**Sample `retrospective.md` excerpt:**
+
+```markdown
+---
+id: RETRO-DOCS-001
+stage: learning
+status: complete
+---
+
+## Outcome
+Shipped on plan. No surprises. `docs/glossary/tracer-bullet.md` exists; cross-link added.
+
+## Lessons (one-liners worth remembering)
+- TDD on a markdown change still catches frontmatter drift.
+```
+
+**If you see this, you are on track:** `retrospective.md` has frontmatter `id: RETRO-DOCS-001`, `stage: learning`. Body has the seven sections from `templates/retrospective-template.md`: `## Outcome`, `## What worked`, `## What didn't work`, `## Spec adherence`, `## Process observations`, `## Actions` (table with `Action / Type / Owner / Due`), and `## Lessons` (one-liners). The agent also surfaces proposed amendments — to templates, agents, or the constitution — as rows in the Actions table for you to accept or reject. Even a one-line *"none — feature shipped clean"* counts as an answer.
 
 ---
 


### PR DESCRIPTION
## Summary

Desk-validate every Diátaxis user-doc against templates, `/spec:*` commands, agent definitions, and constitution at commit `81ef60a` — patch drift, fill gaps, stamp each recipe with a `Last desk-checked` footer. No live workflow run; pure desk validation.

**Stack:** A (desk-check 14 recipes) + B (3 new recipes) + C (tutorial samples) + D (hub polish) + E (EARS inline table) + F (constitution audit).

### Drift fixes (6 recipes)
- `add-adr.md` — list real ADR template sections (Considered options, not *Alternatives considered*; add Compliance and References).
- `write-ears-requirement.md` — match `prd-template`'s `### REQ-…` heading shape with the bullet block; add inline 5-row EARS pattern table.
- `trace-failing-test.md` — reference `test-report-template`'s structured Failure block (Severity / Suspected root cause), not a non-existent `Notes:` field.
- `run-retrospective.md` — name all seven retrospective sections, not three.
- `resume-paused-feature.md` — reference real `workflow-state` frontmatter (`current_stage`, `status`, `last_updated`, `last_agent`, `artifacts`), not legacy *Active stage / Last activity* labels.
- `authorize-destructive-release.md` — `release-notes-template` ships no Authorization section; prescribe adding `## Authorization` on demand with explicit Scope / Rollback / Decider / Approval / Execution / Outcome shape.

### New recipes (3)
- `add-glossary-term.md` — wraps `/glossary:new` per ADR-0010.
- `run-doctor.md` — `npm run doctor` preflight, ten checks listed.
- `open-pr.md` — worktree → push → PR with verify-gate gate.

### Hub polish (`docs/README.md`)
- Tutorial description now points at `docs/glossary/tracer-bullet.md` (was: README glossary).
- How-to section lists 17 recipes with four common starting points; full grouped list lives in the index.
- Dual-purpose Reference+How-to converted to a side-by-side table for clarity.
- Per-quadrant `Quadrant last reviewed: 2026-04-28` stamps added.

### Tutorial enrichment
Inline 3–5 line sample artifact excerpts at Stages 0, 1, 3, 6, 11 (`workflow-state.md`, `idea.md`, `requirements.md`, `tasks.md`, `retrospective.md`). Sample reader answers at the Stage 1 and Stage 11 conversational gates.

### Constitution audit (F)
Every recipe + tutorial article reference verified against `memory/constitution.md` (I–X). Article numbers spelled out in prose so anchor slug variants do not break the link.

## Test plan

- [x] `npm run verify` — green (8.4s, all checks pass).
- [x] Constitution article references match the live `memory/constitution.md`.
- [x] Recipe section references match live templates (`prd-template.md`, `adr-template.md`, `test-report-template.md`, `retrospective-template.md`, `workflow-state-template.md`, `release-notes-template.md`).
- [x] Slash commands referenced in recipes resolve to real files in `.claude/commands/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)