### PR TITLE
[codex] Annotate CI diagnostics from check JSON

### DIFF
--- a/docs/scripts/README.md
+++ b/docs/scripts/README.md
@@ -60,6 +60,8 @@ npm run check:links -- --json
 
 JSON output includes the check name, pass/fail status, and normalized diagnostics with `path`, `line`, `code`, and `message` fields when available. Markdown link diagnostics use stable codes such as `LINK_URI`, `LINK_FILE`, and `LINK_ANCHOR`; frontmatter diagnostics use stable `FM_*` codes such as `FM_MISSING`, `FM_KEY`, and `FM_ARTIFACT_STATUS`.
 
+In GitHub Actions, `verify` requests JSON diagnostics from supported check scripts and emits workflow annotations for each structured error. Local `npm run verify` output stays line-oriented.
+
 ## Checks
 
 | Script | Purpose |

--- a/docs/scripts/lib/diagnostics/README.md
+++ b/docs/scripts/lib/diagnostics/README.md
@@ -22,5 +22,6 @@ entry_point: true
 
 - [checkResult](functions/checkResult.md)
 - [formatDiagnostic](functions/formatDiagnostic.md)
+- [formatGitHubAnnotation](functions/formatGitHubAnnotation.md)
 - [normalizeDiagnostic](functions/normalizeDiagnostic.md)
 - [wantsJson](functions/wantsJson.md)

--- a/docs/scripts/lib/diagnostics/functions/formatGitHubAnnotation.md
+++ b/docs/scripts/lib/diagnostics/functions/formatGitHubAnnotation.md
@@ -1,0 +1,25 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/diagnostics](../README.md) / formatGitHubAnnotation
+
+# Function: formatGitHubAnnotation()
+
+> **formatGitHubAnnotation**(`diagnostic`): `string`
+
+Render a diagnostic as a GitHub Actions workflow annotation.
+
+## Parameters
+
+### diagnostic
+
+[`Diagnostic`](../type-aliases/Diagnostic.md)
+
+Structured diagnostic.
+
+## Returns
+
+`string`
+
+GitHub Actions annotation command.

--- a/docs/scripts/lib/runner/type-aliases/NodeTask.md
+++ b/docs/scripts/lib/runner/type-aliases/NodeTask.md
@@ -16,6 +16,12 @@
 
 ***
 
+### jsonDiagnostics?
+
+> `optional` **jsonDiagnostics?**: `boolean`
+
+***
+
 ### label
 
 > **label**: `string`

--- a/docs/scripts/lib/tasks/variables/checkTasks.md
+++ b/docs/scripts/lib/tasks/variables/checkTasks.md
@@ -6,7 +6,7 @@
 
 # Variable: checkTasks
 
-> `const` **checkTasks**: (\{ `command`: `string`[]; `label`: `string`; `name`: `string`; `script?`: `undefined`; \} \| \{ `command?`: `undefined`; `label`: `string`; `name`: `string`; `script`: `string`; \})[]
+> `const` **checkTasks**: (\{ `command`: `string`[]; `jsonDiagnostics?`: `undefined`; `label`: `string`; `name`: `string`; `script?`: `undefined`; \} \| \{ `command?`: `undefined`; `jsonDiagnostics`: `boolean`; `label`: `string`; `name`: `string`; `script`: `string`; \} \| \{ `command?`: `undefined`; `jsonDiagnostics?`: `undefined`; `label`: `string`; `name`: `string`; `script`: `string`; \})[]
 
 Read-only checks executed by `npm run verify`.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -56,6 +56,8 @@ npm run check:links -- --json
 
 JSON output includes the check name, pass/fail status, and normalized diagnostics with `path`, `line`, `code`, and `message` fields when available. Markdown link diagnostics use stable codes such as `LINK_URI`, `LINK_FILE`, and `LINK_ANCHOR`; frontmatter diagnostics use stable `FM_*` codes such as `FM_MISSING`, `FM_KEY`, and `FM_ARTIFACT_STATUS`.
 
+In GitHub Actions, `verify` requests JSON diagnostics from supported check scripts and emits workflow annotations for each structured error. Local `npm run verify` output stays line-oriented.
+
 ## Checks
 
 | Script | Purpose |

--- a/scripts/lib/diagnostics.ts
+++ b/scripts/lib/diagnostics.ts
@@ -67,6 +67,22 @@ export function formatDiagnostic(diagnostic: Diagnostic): string {
 }
 
 /**
+ * Render a diagnostic as a GitHub Actions workflow annotation.
+ *
+ * @param {Diagnostic} diagnostic - Structured diagnostic.
+ * @returns {string} GitHub Actions annotation command.
+ */
+export function formatGitHubAnnotation(diagnostic: Diagnostic): string {
+  const properties = [
+    diagnostic.path ? `file=${escapeAnnotationProperty(diagnostic.path)}` : "",
+    diagnostic.line !== undefined ? `line=${diagnostic.line}` : "",
+    diagnostic.code ? `title=${escapeAnnotationProperty(diagnostic.code)}` : "",
+  ].filter(Boolean);
+  const propertySuffix = properties.length > 0 ? ` ${properties.join(",")}` : "";
+  return `::error${propertySuffix}::${escapeAnnotationData(diagnostic.message)}`;
+}
+
+/**
  * Detect whether the current CLI invocation requested JSON diagnostics.
  *
  * @param {string[]} [argv=process.argv] - Process arguments.
@@ -74,4 +90,12 @@ export function formatDiagnostic(diagnostic: Diagnostic): string {
  */
 export function wantsJson(argv: string[] = process.argv): boolean {
   return argv.includes("--json");
+}
+
+function escapeAnnotationData(value: string): string {
+  return value.replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
+}
+
+function escapeAnnotationProperty(value: string): string {
+  return escapeAnnotationData(value).replace(/:/g, "%3A").replace(/,/g, "%2C");
 }

--- a/scripts/lib/runner.ts
+++ b/scripts/lib/runner.ts
@@ -1,10 +1,13 @@
 import { spawnSync } from "node:child_process";
+import type { CheckResult } from "./diagnostics.js";
+import { formatDiagnostic, formatGitHubAnnotation } from "./diagnostics.js";
 
 export type NodeTask = {
   name: string;
   label: string;
   script?: string;
   command?: string[];
+  jsonDiagnostics?: boolean;
 };
 
 /**
@@ -30,13 +33,16 @@ export function runNodeTasks(
     const taskStartedAt = Date.now();
     console.log(`${heading}: ${task.name} (${task.label})`);
     const invocation = taskInvocation(task);
-    const result = spawnSync(invocation.command, invocation.args, {
-      stdio: "inherit",
+    const annotate = shouldAnnotate(task);
+    const result = spawnSync(invocation.command, annotate ? [...invocation.args, "--json"] : invocation.args, {
+      encoding: annotate ? "utf8" : undefined,
+      stdio: annotate ? "pipe" : "inherit",
       windowsHide: true,
     });
 
     const elapsed = formatDuration(Date.now() - taskStartedAt);
     if (result.status !== 0) {
+      if (annotate) renderAnnotatedFailure(task, result.stdout, result.stderr);
       console.error(`${heading}: failed at ${task.name} after ${elapsed}`);
       console.error(`reproduce: npm run ${task.name}`);
       if (stopOnFailure) process.exit(result.status || 1);
@@ -56,6 +62,38 @@ function taskInvocation(task: NodeTask): { command: string; args: string[] } {
   }
   if (!task.script) throw new Error(`Task ${task.name} has no command or script`);
   return { command: process.execPath, args: ["--import", "tsx", task.script] };
+}
+
+function shouldAnnotate(task: NodeTask): boolean {
+  return process.env.GITHUB_ACTIONS === "true" && task.jsonDiagnostics === true && task.script !== undefined;
+}
+
+function renderAnnotatedFailure(task: NodeTask, stdout: string | Buffer | null, stderr: string | Buffer | null): void {
+  const rawStdout = String(stdout || "").trim();
+  const rawStderr = String(stderr || "").trim();
+  const result = parseCheckResult(rawStdout);
+
+  if (!result) {
+    if (rawStdout) console.error(rawStdout);
+    if (rawStderr) console.error(rawStderr);
+    console.error(`${task.name}: could not parse JSON diagnostics for GitHub Actions annotations`);
+    return;
+  }
+
+  console.error(`${task.name}: ${result.errors.length} error(s)`);
+  for (const error of result.errors) {
+    console.error(formatGitHubAnnotation(error));
+    console.error(`- ${formatDiagnostic(error)}`);
+  }
+}
+
+function parseCheckResult(raw: string): CheckResult | null {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as CheckResult;
+  } catch {
+    return null;
+  }
 }
 
 function commandInvocation(command: string | undefined, args: string[]): { command: string; args: string[] } {

--- a/scripts/lib/runner.ts
+++ b/scripts/lib/runner.ts
@@ -82,7 +82,7 @@ function renderAnnotatedFailure(task: NodeTask, stdout: string | Buffer | null, 
 
   console.error(`${task.name}: ${result.errors.length} error(s)`);
   for (const error of result.errors) {
-    console.error(formatGitHubAnnotation(error));
+    console.log(formatGitHubAnnotation(error));
     console.error(`- ${formatDiagnostic(error)}`);
   }
 }

--- a/scripts/lib/tasks.ts
+++ b/scripts/lib/tasks.ts
@@ -6,6 +6,7 @@
  * @property {string} label - Human-readable task label.
  * @property {string} [script] - Repository-relative TypeScript script path.
  * @property {string[]} [command] - Command and arguments to execute directly.
+ * @property {boolean} [jsonDiagnostics] - Whether CI may request `--json` and emit GitHub Actions annotations.
  */
 
 /**
@@ -31,6 +32,7 @@ export const checkTasks = [
     name: "check:links",
     label: "Markdown links",
     script: "scripts/check-markdown-links.ts",
+    jsonDiagnostics: true,
   },
   {
     name: "check:adr-index",
@@ -61,6 +63,7 @@ export const checkTasks = [
     name: "check:frontmatter",
     label: "Frontmatter conventions",
     script: "scripts/check-frontmatter.ts",
+    jsonDiagnostics: true,
   },
   {
     name: "check:specs",

--- a/tests/scripts/diagnostics.test.ts
+++ b/tests/scripts/diagnostics.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   checkResult,
   formatDiagnostic,
+  formatGitHubAnnotation,
   normalizeDiagnostic,
   wantsJson,
 } from "../../scripts/lib/diagnostics.js";
@@ -53,4 +54,16 @@ test("formatDiagnostic preserves location and code when available", () => {
 test("wantsJson detects explicit JSON output request", () => {
   assert.equal(wantsJson(["node", "script.ts", "--json"]), true);
   assert.equal(wantsJson(["node", "script.ts"]), false);
+});
+
+test("formatGitHubAnnotation escapes Actions command syntax", () => {
+  assert.equal(
+    formatGitHubAnnotation({
+      path: "docs/example:one,two.md",
+      line: 7,
+      code: "LINK_ANCHOR",
+      message: "bad 100% link\nmissing anchor",
+    }),
+    "::error file=docs/example%3Aone%2Ctwo.md,line=7,title=LINK_ANCHOR::bad 100%25 link%0Amissing anchor",
+  );
 });

--- a/tests/scripts/runner.test.ts
+++ b/tests/scripts/runner.test.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { runNodeTasks } from "../../scripts/lib/runner.js";
+
+test("runNodeTasks emits GitHub Actions annotations for JSON diagnostics", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentic-workflow-runner-test-"));
+  const scriptPath = path.join(tempDir, "failing-check.ts");
+  const previousActions = process.env.GITHUB_ACTIONS;
+  const errors: string[] = [];
+  const logs: string[] = [];
+  const originalError = console.error;
+  const originalLog = console.log;
+
+  fs.writeFileSync(
+    scriptPath,
+    [
+      "if (!process.argv.includes('--json')) process.exit(2);",
+      "console.log(JSON.stringify({",
+      "  check: 'check:fixture',",
+      "  status: 'fail',",
+      "  errors: [{",
+      "    path: 'docs/example.md',",
+      "    line: 3,",
+      "    code: 'LINK_FILE',",
+      "    message: 'links to missing file ./missing.md'",
+      "  }]",
+      "}));",
+      "process.exit(1);",
+    ].join("\n"),
+    "utf8",
+  );
+
+  try {
+    process.env.GITHUB_ACTIONS = "true";
+    console.error = (message?: unknown) => {
+      errors.push(String(message));
+    };
+    console.log = (message?: unknown) => {
+      logs.push(String(message));
+    };
+
+    runNodeTasks(
+      [{ name: "check:fixture", label: "Fixture check", script: scriptPath, jsonDiagnostics: true }],
+      { heading: "test", stopOnFailure: false },
+    );
+  } finally {
+    console.error = originalError;
+    console.log = originalLog;
+    if (previousActions === undefined) {
+      delete process.env.GITHUB_ACTIONS;
+    } else {
+      process.env.GITHUB_ACTIONS = previousActions;
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+
+  assert.equal(logs.some((line) => line.includes("test: check:fixture (Fixture check)")), true);
+  assert.equal(
+    errors.includes(
+      "::error file=docs/example.md,line=3,title=LINK_FILE::links to missing file ./missing.md",
+    ),
+    true,
+  );
+  assert.equal(errors.includes("- docs/example.md:3 [LINK_FILE] links to missing file ./missing.md"), true);
+});

--- a/tests/scripts/runner.test.ts
+++ b/tests/scripts/runner.test.ts
@@ -59,7 +59,7 @@ test("runNodeTasks emits GitHub Actions annotations for JSON diagnostics", () =>
 
   assert.equal(logs.some((line) => line.includes("test: check:fixture (Fixture check)")), true);
   assert.equal(
-    errors.includes(
+    logs.includes(
       "::error file=docs/example.md,line=3,title=LINK_FILE::links to missing file ./missing.md",
     ),
     true,


### PR DESCRIPTION
## Summary
- Teach the shared verify runner to request JSON diagnostics from opt-in check scripts when running in GitHub Actions.
- Emit GitHub Actions `::error` annotations for structured diagnostics while preserving local line-oriented verify output.
- Opt in Markdown links and frontmatter checks, and add unit coverage for annotation escaping plus the runner failure path.
- Regenerate script API docs.

## Verification
- `npm run verify`
- `$env:GITHUB_ACTIONS='true'; npm run verify`

## Notes
- No linked issue or spec task was provided; this is a focused scripts/tooling follow-up to the structured diagnostics work.