### PR TITLE
[codex] Remove template generator CTA from product page

### DIFF
--- a/scripts/check-product-page.ts
+++ b/scripts/check-product-page.ts
@@ -46,8 +46,11 @@ function requireIndexMarkup(html: string) {
     if (!html.includes(needle)) errors.push(message);
   }
   const hrefs = getAttributeValues(html, "href");
-  if (!hrefs.some((href) => /^https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/generate\/?$/.test(href))) {
-    errors.push("primary CTA should point to a GitHub template generator URL");
+  if (hrefs.some((href) => /^https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/generate\/?$/.test(href))) {
+    errors.push("sites/index.html must not link to a GitHub template generator URL");
+  }
+  if (!hrefs.some((href) => /\/docs\/specorator\.md$/.test(href))) {
+    errors.push("primary CTA should point to the workflow documentation");
   }
   if (!hrefs.some((href) => /(^|\/)examples\//.test(href))) {
     errors.push("sites/index.html should link to an example artifact tree");

--- a/sites/index.html
+++ b/sites/index.html
@@ -37,7 +37,7 @@
           <h1 id="hero-title">Specorator</h1>
           <p class="hero-copy">A ready-to-use workflow template that keeps humans in charge of what to build while AI agents help with the heavy lifting of how.</p>
           <div class="hero-actions" aria-label="Primary actions">
-            <a class="button highlight" href="https://github.com/Luis85/agentic-workflow/generate">Use this template</a>
+            <a class="button highlight" href="https://github.com/Luis85/agentic-workflow/blob/main/docs/specorator.md">Read the workflow</a>
             <a class="button secondary" href="https://github.com/Luis85/agentic-workflow">View on GitHub</a>
           </div>
           <div class="hero-proof" aria-label="Workflow highlights">
@@ -78,7 +78,7 @@
       <section class="section dark" id="features" aria-labelledby="features-title">
         <div class="section-header">
           <h2 id="features-title">A workflow that gives agents structure.</h2>
-          <p class="section-kicker">Use it as a template, adapt the steering docs, and let every feature move through the same visible path.</p>
+          <p class="section-kicker">Clone or fork it, adapt the steering docs, and let every feature move through the same visible path.</p>
         </div>
         <div class="feature-grid">
           <article class="card">
@@ -196,13 +196,13 @@
       <section class="section dark" id="start" aria-labelledby="start-title">
         <div class="section-header">
           <h2 id="start-title">Get started in one repository.</h2>
-          <p class="section-kicker">Fork the template, fill in the steering context, and start a feature through natural language or slash commands.</p>
+          <p class="section-kicker">Clone or fork the repository, fill in the steering context, and start a feature through natural language or slash commands.</p>
         </div>
         <div class="steps">
           <article class="step">
             <span class="step-number">1</span>
-            <h3>Use the template</h3>
-            <p>Create a repository from the template, or clone it locally when you want to inspect first.</p>
+            <h3>Clone or fork</h3>
+            <p>Copy the repository into a new workspace, or fork it on GitHub when you want to track changes upstream.</p>
           </article>
           <article class="step">
             <span class="step-number">2</span>


### PR DESCRIPTION
## Summary
- Replace the product page primary CTA that opened GitHub's template generator with a workflow-docs CTA.
- Update getting-started copy to recommend cloning or forking instead of creating a repository from a GitHub template.
- Update the product-page verification rule so generator links are forbidden and workflow documentation remains required.

## Verification
- `npm run check:product-page`
- `npm run verify`

## Notes
- Product page updated.
- This aligns the public page with the repo not being configured as a GitHub template.