### PR TITLE
[codex] Improve doctor readiness checks

### DIFF
--- a/docs/scripts/README.md
+++ b/docs/scripts/README.md
@@ -20,7 +20,7 @@ Run a local environment and repository diagnostic:
 npm run doctor
 ```
 
-`doctor` checks Node/npm/git availability, branch and worktree state, installed dependencies, generated-block drift, and the full verify gate. It is read-only and exits non-zero if required checks fail.
+`doctor` checks Node/npm/git availability, branch and worktree state, installed dependencies, GitHub workflow readiness, generated-block drift, and the full verify gate. It is read-only and exits non-zero if required checks fail. Dependency hints prefer `npm ci` when `package-lock.json` is present so local setup matches CI.
 
 ## Verify
 

--- a/docs/scripts/lib/doctor/README.md
+++ b/docs/scripts/lib/doctor/README.md
@@ -1,0 +1,23 @@
+---
+title: "lib/doctor"
+folder: "docs/scripts/lib/doctor"
+description: "Entry point for generated API reference for the lib/doctor script helper module."
+entry_point: true
+---
+[**agentic-workflow**](../../README.md)
+
+***
+
+[agentic-workflow](../../modules.md) / lib/doctor
+
+# lib/doctor
+
+## Type Aliases
+
+- [CheckResult](type-aliases/CheckResult.md)
+- [CheckStatus](type-aliases/CheckStatus.md)
+
+## Functions
+
+- [dependencyReadinessCheck](functions/dependencyReadinessCheck.md)
+- [workflowReadinessChecks](functions/workflowReadinessChecks.md)

--- a/docs/scripts/lib/doctor/functions/dependencyReadinessCheck.md
+++ b/docs/scripts/lib/doctor/functions/dependencyReadinessCheck.md
@@ -1,0 +1,25 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/doctor](../README.md) / dependencyReadinessCheck
+
+# Function: dependencyReadinessCheck()
+
+> **dependencyReadinessCheck**(`root`): [`CheckResult`](../type-aliases/CheckResult.md)
+
+Check whether local dependencies are installed consistently with package metadata.
+
+## Parameters
+
+### root
+
+`string`
+
+Repository root to inspect.
+
+## Returns
+
+[`CheckResult`](../type-aliases/CheckResult.md)
+
+Dependency readiness result.

--- a/docs/scripts/lib/doctor/functions/workflowReadinessChecks.md
+++ b/docs/scripts/lib/doctor/functions/workflowReadinessChecks.md
@@ -1,0 +1,25 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/doctor](../README.md) / workflowReadinessChecks
+
+# Function: workflowReadinessChecks()
+
+> **workflowReadinessChecks**(`root`): [`CheckResult`](../type-aliases/CheckResult.md)[]
+
+Check whether repository GitHub workflows expose the expected automation contract.
+
+## Parameters
+
+### root
+
+`string`
+
+Repository root to inspect.
+
+## Returns
+
+[`CheckResult`](../type-aliases/CheckResult.md)[]
+
+Workflow readiness results.

--- a/docs/scripts/lib/doctor/type-aliases/CheckResult.md
+++ b/docs/scripts/lib/doctor/type-aliases/CheckResult.md
@@ -1,0 +1,33 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/doctor](../README.md) / CheckResult
+
+# Type Alias: CheckResult
+
+> **CheckResult** = `object`
+
+## Properties
+
+### detail
+
+> **detail**: `string`
+
+***
+
+### hint?
+
+> `optional` **hint?**: `string`
+
+***
+
+### name
+
+> **name**: `string`
+
+***
+
+### status
+
+> **status**: [`CheckStatus`](CheckStatus.md)

--- a/docs/scripts/lib/doctor/type-aliases/CheckStatus.md
+++ b/docs/scripts/lib/doctor/type-aliases/CheckStatus.md
@@ -1,0 +1,9 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/doctor](../README.md) / CheckStatus
+
+# Type Alias: CheckStatus
+
+> **CheckStatus** = `"pass"` \| `"warn"` \| `"fail"`

--- a/docs/scripts/modules.md
+++ b/docs/scripts/modules.md
@@ -23,6 +23,7 @@
 - [lib/adr](lib/adr/README.md)
 - [lib/commands](lib/commands/README.md)
 - [lib/diagnostics](lib/diagnostics/README.md)
+- [lib/doctor](lib/doctor/README.md)
 - [lib/frontmatter](lib/frontmatter/README.md)
 - [lib/markdown-links](lib/markdown-links/README.md)
 - [lib/repo](lib/repo/README.md)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,7 +16,7 @@ Run a local environment and repository diagnostic:
 npm run doctor
 ```
 
-`doctor` checks Node/npm/git availability, branch and worktree state, installed dependencies, generated-block drift, and the full verify gate. It is read-only and exits non-zero if required checks fail.
+`doctor` checks Node/npm/git availability, branch and worktree state, installed dependencies, GitHub workflow readiness, generated-block drift, and the full verify gate. It is read-only and exits non-zero if required checks fail. Dependency hints prefer `npm ci` when `package-lock.json` is present so local setup matches CI.
 
 ## Verify
 

--- a/scripts/doctor.ts
+++ b/scripts/doctor.ts
@@ -1,16 +1,6 @@
 import { SpawnSyncReturns, spawnSync } from "node:child_process";
-import fs from "node:fs";
-import path from "node:path";
+import { CheckResult, dependencyReadinessCheck, workflowReadinessChecks } from "./lib/doctor.js";
 import { repoRoot } from "./lib/repo.js";
-
-type CheckStatus = "pass" | "warn" | "fail";
-
-type CheckResult = {
-  name: string;
-  status: CheckStatus;
-  detail: string;
-  hint?: string;
-};
 
 type Check = {
   run(): CheckResult;
@@ -29,6 +19,7 @@ const checks: Check[] = [
   checkGitStatus(),
   checkWorktrees(),
   checkDependencies(),
+  ...workflowReadinessChecks(repoRoot).map(checkStaticResult),
   checkTask("ADR index", "npm", ["run", "check:adr-index"]),
   checkTask("command inventories", "npm", ["run", "check:commands"]),
   checkTask("verify gate", "npm", ["run", "verify"]),
@@ -120,21 +111,15 @@ function checkWorktrees(): Check {
 function checkDependencies(): Check {
   return {
     run() {
-      const packageJson = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"));
-      const dependencyCount = ["dependencies", "devDependencies", "optionalDependencies"]
-        .flatMap((key) => Object.keys(packageJson[key] || {}))
-        .length;
-      if (dependencyCount === 0) return { name: "dependencies", status: "pass", detail: "no external packages" };
+      return dependencyReadinessCheck(repoRoot);
+    },
+  };
+}
 
-      const nodeModules = path.join(repoRoot, "node_modules");
-      if (fs.existsSync(nodeModules)) return { name: "dependencies", status: "pass", detail: "node_modules present" };
-
-      return {
-        name: "dependencies",
-        status: "warn",
-        detail: "node_modules missing",
-        hint: "run npm install or npm ci",
-      };
+function checkStaticResult(result: CheckResult): Check {
+  return {
+    run() {
+      return result;
     },
   };
 }

--- a/scripts/lib/doctor.ts
+++ b/scripts/lib/doctor.ts
@@ -1,0 +1,130 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export type CheckStatus = "pass" | "warn" | "fail";
+
+export type CheckResult = {
+  name: string;
+  status: CheckStatus;
+  detail: string;
+  hint?: string;
+};
+
+type PackageJson = {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+};
+
+type WorkflowContract = {
+  name: string;
+  filePath: string;
+  requiredMarkers: string[];
+  hint: string;
+};
+
+const workflowContracts: WorkflowContract[] = [
+  {
+    name: "verify workflow",
+    filePath: ".github/workflows/verify.yml",
+    requiredMarkers: ["actions/checkout", "actions/setup-node", "cache: npm", "npm ci", "npm run verify"],
+    hint: "restore the verify workflow contract so CI mirrors the local verify gate",
+  },
+  {
+    name: "pages workflow",
+    filePath: ".github/workflows/pages.yml",
+    requiredMarkers: [
+      "actions/configure-pages",
+      "actions/upload-pages-artifact",
+      "actions/deploy-pages",
+      "path: sites",
+    ],
+    hint: "restore the Pages workflow so the product page can deploy from sites/",
+  },
+];
+
+/**
+ * Check whether local dependencies are installed consistently with package metadata.
+ *
+ * @param {string} root - Repository root to inspect.
+ * @returns {CheckResult} Dependency readiness result.
+ */
+export function dependencyReadinessCheck(root: string): CheckResult {
+  const packagePath = path.join(root, "package.json");
+  if (!fs.existsSync(packagePath)) {
+    return {
+      name: "dependencies",
+      status: "fail",
+      detail: "package.json missing",
+      hint: "restore package.json before running repository scripts",
+    };
+  }
+
+  const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf8")) as PackageJson;
+  const dependencyCount = ["dependencies", "devDependencies", "optionalDependencies"]
+    .flatMap((key) => Object.keys(packageJson[key as keyof PackageJson] || {}))
+    .length;
+  if (dependencyCount === 0) return { name: "dependencies", status: "pass", detail: "no external packages" };
+
+  const hasNodeModules = fs.existsSync(path.join(root, "node_modules"));
+  const hasLockfile = fs.existsSync(path.join(root, "package-lock.json"));
+
+  if (!hasLockfile) {
+    return {
+      name: "dependencies",
+      status: "warn",
+      detail: "package-lock.json missing",
+      hint: "run npm install to recreate the lockfile, then review the diff",
+    };
+  }
+
+  if (!hasNodeModules) {
+    return {
+      name: "dependencies",
+      status: "warn",
+      detail: "node_modules missing; package-lock.json present",
+      hint: "run npm ci",
+    };
+  }
+
+  return { name: "dependencies", status: "pass", detail: "node_modules and package-lock.json present" };
+}
+
+/**
+ * Check whether repository GitHub workflows expose the expected automation contract.
+ *
+ * @param {string} root - Repository root to inspect.
+ * @returns {CheckResult[]} Workflow readiness results.
+ */
+export function workflowReadinessChecks(root: string): CheckResult[] {
+  return workflowContracts.map((contract) => workflowReadinessCheck(root, contract));
+}
+
+function workflowReadinessCheck(root: string, contract: WorkflowContract): CheckResult {
+  const absolutePath = path.join(root, contract.filePath);
+  if (!fs.existsSync(absolutePath)) {
+    return {
+      name: contract.name,
+      status: "fail",
+      detail: `${contract.filePath} missing`,
+      hint: contract.hint,
+    };
+  }
+
+  const text = fs.readFileSync(absolutePath, "utf8");
+  const missingMarkers = contract.requiredMarkers.filter((marker) => !text.includes(marker));
+  if (missingMarkers.length > 0) {
+    return {
+      name: contract.name,
+      status: "fail",
+      detail: `${contract.filePath} missing ${missingMarkers.join(", ")}`,
+      hint: contract.hint,
+    };
+  }
+
+  return {
+    name: contract.name,
+    status: "pass",
+    detail: `${contract.filePath} ready`,
+  };
+}

--- a/scripts/lib/doctor.ts
+++ b/scripts/lib/doctor.ts
@@ -34,6 +34,7 @@ const workflowContracts: WorkflowContract[] = [
     name: "pages workflow",
     filePath: ".github/workflows/pages.yml",
     requiredMarkers: [
+      "actions/checkout",
       "actions/configure-pages",
       "actions/upload-pages-artifact",
       "actions/deploy-pages",

--- a/tests/scripts/doctor.test.ts
+++ b/tests/scripts/doctor.test.ts
@@ -1,0 +1,123 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { dependencyReadinessCheck, workflowReadinessChecks } from "../../scripts/lib/doctor.js";
+
+test("dependencyReadinessCheck points lockfile installs at npm ci", () => {
+  const root = tempRepo();
+  try {
+    writeJson(path.join(root, "package.json"), {
+      devDependencies: {
+        tsx: "^4.0.0",
+      },
+    });
+    fs.writeFileSync(path.join(root, "package-lock.json"), "{}\n", "utf8");
+
+    assert.deepEqual(dependencyReadinessCheck(root), {
+      name: "dependencies",
+      status: "warn",
+      detail: "node_modules missing; package-lock.json present",
+      hint: "run npm ci",
+    });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("dependencyReadinessCheck warns when dependencies lack a lockfile", () => {
+  const root = tempRepo();
+  try {
+    writeJson(path.join(root, "package.json"), {
+      dependencies: {
+        typedoc: "^0.28.0",
+      },
+    });
+
+    assert.deepEqual(dependencyReadinessCheck(root), {
+      name: "dependencies",
+      status: "warn",
+      detail: "package-lock.json missing",
+      hint: "run npm install to recreate the lockfile, then review the diff",
+    });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("workflowReadinessChecks validates verify and Pages workflow contracts", () => {
+  const root = tempRepo();
+  try {
+    const workflowDir = path.join(root, ".github", "workflows");
+    fs.mkdirSync(workflowDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(workflowDir, "verify.yml"),
+      [
+        "steps:",
+        "  - uses: actions/checkout@v6",
+        "  - uses: actions/setup-node@v6",
+        "    with:",
+        "      cache: npm",
+        "  - run: npm ci",
+        "  - run: npm run verify",
+      ].join("\n"),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(workflowDir, "pages.yml"),
+      [
+        "steps:",
+        "  - uses: actions/configure-pages@v6",
+        "  - uses: actions/upload-pages-artifact@v5",
+        "    with:",
+        "      path: sites",
+        "  - uses: actions/deploy-pages@v5",
+      ].join("\n"),
+      "utf8",
+    );
+
+    assert.deepEqual(workflowReadinessChecks(root), [
+      {
+        name: "verify workflow",
+        status: "pass",
+        detail: ".github/workflows/verify.yml ready",
+      },
+      {
+        name: "pages workflow",
+        status: "pass",
+        detail: ".github/workflows/pages.yml ready",
+      },
+    ]);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("workflowReadinessChecks reports missing workflow contract markers", () => {
+  const root = tempRepo();
+  try {
+    const workflowDir = path.join(root, ".github", "workflows");
+    fs.mkdirSync(workflowDir, { recursive: true });
+    fs.writeFileSync(path.join(workflowDir, "verify.yml"), "steps:\n  - run: npm test\n", "utf8");
+
+    const results = workflowReadinessChecks(root);
+    assert.equal(results[0].status, "fail");
+    assert.equal(
+      results[0].detail,
+      ".github/workflows/verify.yml missing actions/checkout, actions/setup-node, cache: npm, npm ci, npm run verify",
+    );
+    assert.equal(results[1].status, "fail");
+    assert.equal(results[1].detail, ".github/workflows/pages.yml missing");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function tempRepo(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "agentic-workflow-doctor-test-"));
+}
+
+function writeJson(filePath: string, value: unknown): void {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}

--- a/tests/scripts/doctor.test.ts
+++ b/tests/scripts/doctor.test.ts
@@ -68,6 +68,7 @@ test("workflowReadinessChecks validates verify and Pages workflow contracts", ()
       path.join(workflowDir, "pages.yml"),
       [
         "steps:",
+        "  - uses: actions/checkout@v6",
         "  - uses: actions/configure-pages@v6",
         "  - uses: actions/upload-pages-artifact@v5",
         "    with:",
@@ -109,6 +110,45 @@ test("workflowReadinessChecks reports missing workflow contract markers", () => 
     );
     assert.equal(results[1].status, "fail");
     assert.equal(results[1].detail, ".github/workflows/pages.yml missing");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("workflowReadinessChecks requires checkout before uploading Pages artifacts", () => {
+  const root = tempRepo();
+  try {
+    const workflowDir = path.join(root, ".github", "workflows");
+    fs.mkdirSync(workflowDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(workflowDir, "verify.yml"),
+      [
+        "steps:",
+        "  - uses: actions/checkout@v6",
+        "  - uses: actions/setup-node@v6",
+        "    with:",
+        "      cache: npm",
+        "  - run: npm ci",
+        "  - run: npm run verify",
+      ].join("\n"),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(workflowDir, "pages.yml"),
+      [
+        "steps:",
+        "  - uses: actions/configure-pages@v6",
+        "  - uses: actions/upload-pages-artifact@v5",
+        "    with:",
+        "      path: sites",
+        "  - uses: actions/deploy-pages@v5",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const results = workflowReadinessChecks(root);
+    assert.equal(results[1].status, "fail");
+    assert.equal(results[1].detail, ".github/workflows/pages.yml missing actions/checkout");
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- Add tested `doctor` helpers for dependency and GitHub workflow readiness checks.
- Make `doctor` report verify workflow and Pages workflow readiness directly.
- Improve dependency setup hints so lockfile-backed repos point users and agents at `npm ci`.
- Regenerate script API docs.

## Verification
- `npm run typecheck:scripts`
- `npm run test:scripts`
- `npm run doctor`
- `npm run verify`

## Notes
- No linked issue or spec task was provided; this is a focused scripts/tooling improvement for the template quality harness.