### PR TITLE
Plan v0.3 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ Full version in [`memory/constitution.md`](memory/constitution.md).
 |---|---|---|
 | v0.1 | Done | Workflow definition, templates, agents, slash commands |
 | v0.2 | Done | Skills layer, operational bots, branching / verify / worktrees guides |
-| v0.3 | Planned | Worked end-to-end examples, artifact validation |
+| v0.3 | Planned | [Worked end-to-end examples, artifact validation](specs/version-0-3-plan/tasks.md) |
 | v0.4 | Planned | CI quality gates, metrics, maturity model |
 
 ---

--- a/specs/version-0-3-plan/design.md
+++ b/specs/version-0-3-plan/design.md
@@ -1,0 +1,71 @@
+---
+id: DESIGN-V03-001
+title: Version 0.3 release plan — Design
+stage: design
+feature: version-0-3-plan
+status: accepted
+owner: architect
+inputs:
+  - PRD-V03-001
+created: 2026-04-28
+updated: 2026-04-28
+---
+
+# Design — Version 0.3 release plan
+
+## Release shape
+
+v0.3 is a release-planning concern with two implementation tracks:
+
+1. **Example track:** complete the worked example and make it easy to browse.
+2. **Validation track:** strengthen deterministic artifact checks and verification docs.
+
+The tracks can ship as separate PRs if each keeps docs and verification consistent.
+
+## User path
+
+1. A new evaluator opens the README roadmap and follows the v0.3 plan link.
+2. They open `examples/README.md` and choose the complete example.
+3. They read the example overview, then inspect artifacts in lifecycle order.
+4. A contributor changes or adds artifacts and runs `npm run verify`.
+5. Validation reports missing artifacts, inconsistent workflow state, or traceability drift before review.
+
+## Affected surfaces
+
+| Surface | Change type |
+|---|---|
+| `examples/cli-todo/` | Complete missing lifecycle artifacts and overview. |
+| `examples/README.md` | Update status and reading guidance. |
+| `scripts/check-spec-state.ts` | Extend or confirm artifact completeness checks. |
+| `scripts/check-traceability.ts` | Extend or confirm traceability coverage checks. |
+| `tests/scripts/` | Add focused validator tests when behavior changes. |
+| `scripts/README.md`, `docs/scripts/` | Document validation commands if script API docs change. |
+| `README.md` | Link v0.3 plan and update release status when implemented. |
+| `sites/index.html` | Review for user-visible positioning drift after v0.3 implementation. |
+
+## Validation behavior
+
+Validators should distinguish:
+
+- **Complete/in-progress artifacts:** file must exist and satisfy required structure.
+- **Pending artifacts:** file may be absent.
+- **Skipped artifacts:** absence is allowed, but skip reason must be documented in workflow state.
+- **Done workflows:** all canonical artifacts must be complete or validly skipped; retrospective must be complete.
+- **Examples:** checked by the same state and traceability rules as specs, while staying clearly separate from active product work.
+
+## Alternatives rejected
+
+- **New example first:** Deferred because the existing CLI todo example already provides a low-friction path.
+- **Validation-only release:** Rejected because the roadmap promises worked examples and adoption needs a concrete reading path.
+- **CI-gated release:** Deferred to v0.4 to avoid combining local validation with CI policy rollout.
+
+## ADR impact
+
+No ADR is required for the plan. v0.3 should only need an ADR if implementation changes lifecycle governance, creates a new mandatory gate, or changes artifact ownership.
+
+## Risks and mitigations
+
+- RISK-V03-001: Keep validators state-aware and add tests for pending and skipped workflows.
+- RISK-V03-002: Keep example prose concise and include an overview instead of repeating method docs.
+- RISK-V03-003: Name v0.4 deferrals in tasks and PR descriptions.
+- RISK-V03-004: Include a product-page review task.

--- a/specs/version-0-3-plan/idea.md
+++ b/specs/version-0-3-plan/idea.md
@@ -1,0 +1,39 @@
+---
+id: IDEA-V03-001
+title: Version 0.3 release plan
+stage: idea
+feature: version-0-3-plan
+status: accepted
+owner: analyst
+created: 2026-04-28
+updated: 2026-04-28
+---
+
+# Idea — Version 0.3 release plan
+
+## Problem
+
+Specorator v0.2 has the foundation, skills layer, operational bots, and contributor hygiene in place, but v0.3 is only named in the README roadmap. Contributors need a concrete release plan that explains what v0.3 should deliver, what stays out of scope, and which tasks can be implemented independently.
+
+## Target users
+
+- Template evaluators who want to see a complete example before adopting the workflow.
+- Contributors who need clear tasks for artifact validation and example completion.
+- Maintainers who need a scoped release boundary for v0.3.
+
+## Desired outcome
+
+v0.3 should make the workflow easier to trust by pairing a complete end-to-end example with deterministic artifact checks that catch common workflow drift before review.
+
+## Constraints
+
+- Keep v0.3 focused on adoption confidence, not a broad maturity-model or CI release.
+- Preserve the existing 11-stage lifecycle and optional tracks.
+- Use existing Node/TypeScript script patterns and repository verification commands.
+- Keep examples separate from active `specs/` workflow state.
+
+## Open questions
+
+- Which example should be completed first: the existing `examples/cli-todo` path or a new product-oriented example?
+- Which artifact validation checks should fail `npm run verify` in v0.3 versus remain advisory until v0.4?
+- Should the v0.3 release update the product page once the example and validation commands are implemented?

--- a/specs/version-0-3-plan/requirements.md
+++ b/specs/version-0-3-plan/requirements.md
@@ -1,0 +1,102 @@
+---
+id: PRD-V03-001
+title: Version 0.3 release plan
+stage: requirements
+feature: version-0-3-plan
+status: accepted
+owner: pm
+inputs:
+  - IDEA-V03-001
+  - RESEARCH-V03-001
+created: 2026-04-28
+updated: 2026-04-28
+---
+
+# PRD — Version 0.3 release plan
+
+## Summary
+
+Plan v0.3 as an adoption-confidence release: one complete end-to-end example plus deterministic artifact validation that helps contributors catch workflow drift locally.
+
+## Goals
+
+- Make the lifecycle concrete with a complete, readable example.
+- Expand validation around workflow artifacts without changing the lifecycle model.
+- Keep v0.3 small enough to ship as independent PRs.
+
+## Non-goals
+
+- No CI quality-gate rollout; v0.4 owns CI gates.
+- No maturity model or metrics dashboard; v0.4 owns those.
+- No new mandatory lifecycle stage.
+- No constitution changes.
+
+## Functional requirements (EARS)
+
+### REQ-V03-001 — Complete a worked example
+
+- **Pattern:** ubiquitous
+- **Statement:** The template shall include one worked example that demonstrates all 11 lifecycle stages from idea through retrospective.
+- **Acceptance:** `examples/cli-todo` or its chosen replacement has every canonical artifact, a complete workflow state, and a reader-oriented example overview.
+- **Priority:** must
+- **Satisfies:** IDEA-V03-001
+
+### REQ-V03-002 — Validate artifact completeness
+
+- **Pattern:** ubiquitous
+- **Statement:** The repository shall provide a deterministic check that validates required artifact presence and workflow-state consistency for specs and examples.
+- **Acceptance:** `npm run verify` fails when a workflow state marks an artifact complete or in-progress but the artifact is missing, malformed, or inconsistent with the stage table.
+- **Priority:** must
+- **Satisfies:** RESEARCH-V03-001
+
+### REQ-V03-003 — Validate traceability coverage
+
+- **Pattern:** ubiquitous
+- **Statement:** The repository shall provide deterministic traceability checks that detect unresolved requirement, spec, task, and test references in workflow artifacts.
+- **Acceptance:** Checks report stable diagnostics for unknown IDs, wrong area codes, duplicate IDs, and missing required trace fields.
+- **Priority:** must
+- **Satisfies:** RESEARCH-V03-001
+
+### REQ-V03-004 — Document the v0.3 user path
+
+- **Pattern:** ubiquitous
+- **Statement:** The template shall document how readers use the completed example and how contributors run artifact validation.
+- **Acceptance:** README, examples documentation, and script documentation point to the example and validation commands.
+- **Priority:** must
+- **Satisfies:** RESEARCH-V03-001
+
+### REQ-V03-005 — Keep release scope bounded
+
+- **Pattern:** unwanted behavior
+- **Statement:** When contributors plan or implement v0.3 work, the template shall keep CI gates, metrics, and maturity model work outside the v0.3 scope.
+- **Acceptance:** v0.3 tasks name CI gates, metrics, and maturity model as deferred v0.4 work.
+- **Priority:** must
+- **Satisfies:** RESEARCH-V03-001
+
+### REQ-V03-006 — Review public positioning
+
+- **Pattern:** event-driven
+- **Statement:** When the v0.3 example and artifact validation are implemented, the release shall review the public product page for stale positioning.
+- **Acceptance:** The release PR either updates `sites/index.html` or records why the product page is unaffected.
+- **Priority:** should
+- **Satisfies:** RESEARCH-V03-001
+
+## Non-functional requirements
+
+| ID | Category | Requirement | Target |
+|---|---|---|---|
+| NFR-V03-001 | maintainability | Validation code must follow the existing TypeScript script conventions. | Shared logic under `scripts/lib/` when reusable; tests under `tests/scripts/` where behavior is non-trivial. |
+| NFR-V03-002 | usability | Example artifacts must stay concise and navigable for first-time readers. | Example overview explains reading order and artifact purpose. |
+| NFR-V03-003 | compatibility | v0.3 must not break active incremental specs. | Validators account for pending, in-progress, complete, skipped, blocked, active, paused, done states. |
+
+## Success metrics
+
+- A new reader can follow a complete lifecycle in `examples/` without opening template internals first.
+- `npm run verify` catches missing or inconsistent workflow artifacts.
+- v0.3 implementation can be split into small PRs without stacked branches.
+
+## Quality gate
+
+- [x] Functional requirements use EARS and stable IDs.
+- [x] Acceptance criteria are testable.
+- [x] Non-goals and deferred v0.4 scope are explicit.

--- a/specs/version-0-3-plan/research.md
+++ b/specs/version-0-3-plan/research.md
@@ -1,0 +1,69 @@
+---
+id: RESEARCH-V03-001
+title: Version 0.3 release plan — Research
+stage: research
+feature: version-0-3-plan
+status: accepted
+owner: analyst
+inputs:
+  - IDEA-V03-001
+created: 2026-04-28
+updated: 2026-04-28
+---
+
+# Research — Version 0.3 release plan
+
+## Context
+
+The README roadmap currently defines v0.3 as "Worked end-to-end examples, artifact validation." The repository already includes:
+
+- `examples/cli-todo/` with stages 1-5 partially present and `workflow-state.md`.
+- Repository checks for workflow state, traceability, frontmatter, links, product page, commands, scripts, ADR index, and workflow docs.
+- v0.2 contributor infrastructure: worktrees, verify gate, operational bots, and Specorator improvement commands.
+
+## Alternatives
+
+### Alternative A — Finish the existing CLI todo example and strengthen artifact checks
+
+Complete `examples/cli-todo` through release and retrospective, then add validation that checks example completeness, required artifact frontmatter, stage-state consistency, and traceability coverage.
+
+**Pros:** Builds on existing material, keeps scope small, demonstrates the full lifecycle, and directly supports the current README roadmap.
+
+**Cons:** CLI todo is intentionally small, so it may not showcase richer UX, architecture, or operations decisions.
+
+### Alternative B — Add a new richer example and defer validation hardening
+
+Create a larger worked example that better demonstrates product, UX, and architecture work, while leaving validation mostly as-is.
+
+**Pros:** More compelling adoption story for evaluators.
+
+**Cons:** Higher writing burden, more review surface, and does not address drift risks already visible in artifact-heavy workflows.
+
+### Alternative C — Focus v0.3 only on validation automation
+
+Add stricter artifact validators, generated reports, and `npm run verify` coverage, deferring examples to a later release.
+
+**Pros:** Improves contributor confidence and quality gates quickly.
+
+**Cons:** Makes the template more enforceable but not more teachable; weakens the adoption story named in the roadmap.
+
+## Recommendation
+
+Choose Alternative A. v0.3 should complete the existing `cli-todo` example and add a pragmatic validation pass for artifact completeness and traceability. This keeps the release narrow, demonstrable, and aligned with the roadmap.
+
+## Risks
+
+| ID | Risk | Severity | Mitigation |
+|---|---|---|---|
+| RISK-V03-001 | Validation becomes too strict and blocks legitimate incremental work. | medium | Start with active-state-aware checks and document when advisory checks become required. |
+| RISK-V03-002 | The example becomes verbose and harder to learn from. | medium | Keep each artifact concise and add an example README map for readers. |
+| RISK-V03-003 | v0.3 scope expands into CI gates, metrics, or maturity scoring. | medium | Keep those items explicit non-goals for v0.3 and defer them to v0.4. |
+| RISK-V03-004 | Product page and README drift from the new example and checks. | low | Add release tasks for docs and product page review. |
+
+## Sources
+
+- `README.md` roadmap row for v0.3.
+- `docs/specorator.md` future extensions and improvement workflow.
+- `docs/quality-framework.md` quality gate definitions.
+- Existing repository validators under `scripts/`.
+- Existing worked example under `examples/cli-todo/`.

--- a/specs/version-0-3-plan/spec.md
+++ b/specs/version-0-3-plan/spec.md
@@ -1,0 +1,54 @@
+---
+id: SPECDOC-V03-001
+title: Version 0.3 release plan — Specification
+stage: specification
+feature: version-0-3-plan
+status: accepted
+owner: architect
+inputs:
+  - DESIGN-V03-001
+created: 2026-04-28
+updated: 2026-04-28
+---
+
+# Specification — Version 0.3 release plan
+
+### SPEC-V03-001 — Complete lifecycle example
+
+- **Satisfies:** REQ-V03-001, NFR-V03-002
+- **Behavior:** The selected example contains canonical lifecycle artifacts for stages 1-11 and a `workflow-state.md` that marks the example done only when all artifacts are complete or validly skipped.
+- **Acceptance:** Example artifacts are concise, linked from `examples/README.md`, and ordered for first-time readers.
+
+### SPEC-V03-002 — Artifact state validation
+
+- **Satisfies:** REQ-V03-002, NFR-V03-003
+- **Behavior:** Workflow-state validation checks required frontmatter, artifact statuses, current-stage consistency, table consistency, and required body sections for both `specs/` and `examples/`.
+- **Acceptance:** The check emits stable file-path diagnostics and fails `npm run verify` on invalid states.
+
+### SPEC-V03-003 — Traceability validation
+
+- **Satisfies:** REQ-V03-003, NFR-V03-001
+- **Behavior:** Traceability validation builds an ID registry per workflow area and reports duplicate IDs, mismatched area codes, unknown references, missing required trace fields, and invalid reference kinds.
+- **Acceptance:** The check covers requirement, NFR, spec, task, and test IDs in existing workflow artifacts.
+
+### SPEC-V03-004 — Documentation path
+
+- **Satisfies:** REQ-V03-004, REQ-V03-006, NFR-V03-002
+- **Behavior:** README and examples documentation explain the v0.3 plan, the complete example, and artifact validation commands. The product page is reviewed when implementation changes user-visible positioning.
+- **Acceptance:** Links resolve under `npm run check:links`; product-page impact is either patched or explicitly recorded.
+
+### SPEC-V03-005 — Scope guard
+
+- **Satisfies:** REQ-V03-005
+- **Behavior:** v0.3 planning and implementation artifacts identify CI gates, metrics, and maturity model work as v0.4 deferrals.
+- **Acceptance:** v0.3 task and release notes separate shipped v0.3 work from deferred v0.4 work.
+
+## Test scenarios
+
+| ID | Requirement | Scenario | Expected result |
+|---|---|---|---|
+| TEST-V03-001 | REQ-V03-001 | Inspect the selected example after implementation. | All canonical lifecycle artifacts are present or validly skipped, with workflow state complete. |
+| TEST-V03-002 | REQ-V03-002 | Run validation against a workflow state that marks a missing artifact complete. | Validation fails with a stable diagnostic. |
+| TEST-V03-003 | REQ-V03-003 | Run validation against an artifact that references an unknown requirement ID. | Validation fails with a stable diagnostic. |
+| TEST-V03-004 | REQ-V03-004 | Run link checks after docs updates. | README and examples links resolve. |
+| TEST-V03-005 | REQ-V03-005 | Review v0.3 tasks and release notes. | CI gates, metrics, and maturity model remain deferred. |

--- a/specs/version-0-3-plan/tasks.md
+++ b/specs/version-0-3-plan/tasks.md
@@ -1,0 +1,76 @@
+---
+id: TASKS-V03-001
+title: Version 0.3 release plan — Tasks
+stage: tasks
+feature: version-0-3-plan
+status: complete
+owner: planner
+inputs:
+  - PRD-V03-001
+  - SPECDOC-V03-001
+created: 2026-04-28
+updated: 2026-04-28
+---
+
+# Tasks — Version 0.3 release plan
+
+### T-V03-001 — Complete the CLI todo worked example
+
+- **Description:** Finish `examples/cli-todo` through tasks, implementation log, test plan, test report, review, traceability, release notes, and retrospective.
+- **Satisfies:** REQ-V03-001, SPEC-V03-001
+- **Owner:** dev
+- **Estimate:** M
+
+### T-V03-002 — Add example reading guidance
+
+- **Description:** Update `examples/README.md` and any example-local overview so first-time readers can follow the completed lifecycle in order.
+- **Satisfies:** REQ-V03-001, REQ-V03-004, NFR-V03-002, SPEC-V03-001, SPEC-V03-004
+- **Depends on:** T-V03-001
+- **Owner:** dev
+- **Estimate:** S
+
+### T-V03-003 — Harden artifact state validation
+
+- **Description:** Extend or confirm workflow-state checks for required fields, current-stage consistency, complete/in-progress artifact presence, skipped-stage documentation, done-state rules, and examples coverage.
+- **Satisfies:** REQ-V03-002, NFR-V03-001, NFR-V03-003, SPEC-V03-002
+- **Owner:** dev
+- **Estimate:** M
+
+### T-V03-004 — Harden traceability validation
+
+- **Description:** Extend or confirm traceability checks for duplicate IDs, area mismatches, unknown references, invalid reference kinds, missing required trace fields, and test scenario coverage.
+- **Satisfies:** REQ-V03-003, NFR-V03-001, NFR-V03-003, SPEC-V03-003
+- **Owner:** dev
+- **Estimate:** M
+
+### T-V03-005 — Add validator regression tests
+
+- **Description:** Add focused tests for artifact-state and traceability validation edge cases, including pending, skipped, active, done, missing artifact, duplicate ID, and unknown reference cases.
+- **Satisfies:** REQ-V03-002, REQ-V03-003, NFR-V03-003, SPEC-V03-002, SPEC-V03-003
+- **Depends on:** T-V03-003, T-V03-004
+- **Owner:** qa
+- **Estimate:** M
+
+### T-V03-006 — Update release documentation
+
+- **Description:** Update README roadmap details, scripts documentation if command behavior changes, examples documentation, and v0.3 release notes when implementation lands.
+- **Satisfies:** REQ-V03-004, REQ-V03-005, SPEC-V03-004, SPEC-V03-005
+- **Depends on:** T-V03-001, T-V03-003, T-V03-004
+- **Owner:** release-manager
+- **Estimate:** S
+
+### T-V03-007 — Review product page positioning
+
+- **Description:** Review `sites/index.html` after the example and validation work lands; update it only if v0.3 changes user-visible positioning, onboarding, or CTAs.
+- **Satisfies:** REQ-V03-006, SPEC-V03-004
+- **Depends on:** T-V03-006
+- **Owner:** release-manager
+- **Estimate:** S
+
+### T-V03-008 — Verify v0.3 release readiness
+
+- **Description:** Run targeted validator tests, `npm run check:links`, `npm run check:specs`, `npm run check:traceability`, and `npm run verify`; document any skipped checks or deferred v0.4 work.
+- **Satisfies:** REQ-V03-002, REQ-V03-003, REQ-V03-005, SPEC-V03-002, SPEC-V03-003, SPEC-V03-005
+- **Depends on:** T-V03-005, T-V03-006, T-V03-007
+- **Owner:** qa
+- **Estimate:** S

--- a/specs/version-0-3-plan/workflow-state.md
+++ b/specs/version-0-3-plan/workflow-state.md
@@ -1,0 +1,57 @@
+---
+feature: version-0-3-plan
+area: V03
+current_stage: implementation
+status: active
+last_updated: 2026-04-28
+last_agent: planner
+artifacts:
+  idea.md: complete
+  research.md: complete
+  requirements.md: complete
+  design.md: complete
+  spec.md: complete
+  tasks.md: complete
+  implementation-log.md: pending
+  test-plan.md: pending
+  test-report.md: pending
+  review.md: pending
+  traceability.md: pending
+  release-notes.md: pending
+  retrospective.md: pending
+---
+
+# Workflow state — version-0-3-plan
+
+## Stage progress
+
+| Stage | Artifact | Status |
+|---|---|---|
+| 1. Idea | `idea.md` | complete |
+| 2. Research | `research.md` | complete |
+| 3. Requirements | `requirements.md` | complete |
+| 4. Design | `design.md` | complete |
+| 5. Specification | `spec.md` | complete |
+| 6. Tasks | `tasks.md` | complete |
+| 7. Implementation | `implementation-log.md` + code | pending |
+| 8. Testing | `test-plan.md`, `test-report.md` | pending |
+| 9. Review | `review.md`, `traceability.md` | pending |
+| 10. Release | `release-notes.md` | pending |
+| 11. Learning | `retrospective.md` | pending |
+
+## Skips
+
+- None.
+
+## Blocks
+
+- None.
+
+## Hand-off notes
+
+- 2026-04-28 (codex): Planned v0.3 through Stage 6. Recommended implementation order is example completion, validation hardening, validator tests, documentation, product-page review, then release readiness verification.
+
+## Open clarifications
+
+- [ ] CLAR-V03-001 — Confirm whether `examples/cli-todo` remains the selected complete example for v0.3 or whether a different example should replace it.
+- [ ] CLAR-V03-002 — Confirm which strengthened validation checks must fail `npm run verify` in v0.3 versus remain advisory until v0.4.


### PR DESCRIPTION
## Summary
- Add a canonical v0.3 planning spec under `specs/version-0-3-plan/` through Stage 6 tasks.
- Define v0.3 scope around a complete worked example plus deterministic artifact validation.
- Link the README roadmap v0.3 row to the new task plan.

## Verification
- `npm run verify`

## Notes
- This is a planning PR only. Implementation remains pending in `workflow-state.md`.
- Open clarifications remain on the selected complete example and which validation checks should become required in v0.3.