### PR TITLE
Plan v0.4 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ Full version in [`memory/constitution.md`](memory/constitution.md).
 | v0.1 | Done | Workflow definition, templates, agents, slash commands |
 | v0.2 | Done | Skills layer, operational bots, branching / verify / worktrees guides |
 | v0.3 | Planned | [Worked end-to-end examples, artifact validation](specs/version-0-3-plan/tasks.md) |
-| v0.4 | Planned | CI quality gates, metrics, maturity model |
+| v0.4 | Planned | [CI quality gates, metrics, maturity model](specs/version-0-4-plan/tasks.md) |
 
 ---
 

--- a/specs/version-0-4-plan/design.md
+++ b/specs/version-0-4-plan/design.md
@@ -1,0 +1,93 @@
+---
+id: DESIGN-V04-001
+title: Version 0.4 release plan — Design
+stage: design
+feature: version-0-4-plan
+status: accepted
+owner: architect
+inputs:
+  - PRD-V04-001
+created: 2026-04-28
+updated: 2026-04-28
+---
+
+# Design — Version 0.4 release plan
+
+## Release shape
+
+v0.4 has three tracks that share evidence:
+
+1. **CI gates:** run deterministic repository checks on pull requests.
+2. **Metrics:** summarize workflow health from checked artifacts.
+3. **Maturity model:** explain progressive adoption levels using observable evidence.
+
+The tracks should be implemented in that order. CI establishes trustworthy evidence, metrics summarize it, and maturity guidance translates it into adoption steps.
+
+## User path
+
+1. A contributor runs `npm run verify` locally.
+2. They open a PR and CI runs the same required gate or a documented subset.
+3. A maintainer reviews CI status plus any metrics report.
+4. A team reviewing adoption reads the maturity model and compares its repository evidence with the level criteria.
+
+## CI gate model
+
+| Gate type | Purpose | Candidate checks |
+|---|---|---|
+| Required PR gate | Catch deterministic repository drift before merge. | `npm ci`, `npm run verify` or documented equivalent. |
+| Advisory PR report | Surface useful but non-blocking signals. | Metrics report, maturity hints, long-running diagnostics. |
+| Scheduled review | Catch slow drift outside active PRs. | Daily or weekly health report after local behavior is stable. |
+
+Initial v0.4 scope should prefer required PR gates and local/advisory metrics. Scheduled automation can be included only if it remains read-only and low-noise.
+
+## Metrics model
+
+Metrics should be generated from repository artifacts, not external services:
+
+- Workflow counts by status and stage.
+- Blocked specs and open clarifications.
+- Complete examples and example stage coverage.
+- Validation failures by check.
+- Skipped artifacts by reason.
+- ADR, command, and script documentation drift when existing checks expose it.
+
+Each metric needs an interpretation note: what action it supports and what it must not be used for.
+
+## Maturity model
+
+Suggested levels:
+
+| Level | Name | Evidence |
+|---|---|---|
+| 0 | Ad hoc | Repo has the template but inconsistent artifact use. |
+| 1 | Documented | Core steering, constitution, and lifecycle artifacts exist. |
+| 2 | Verified | Local verify gate runs and workflow artifacts pass deterministic checks. |
+| 3 | Integrated | PR CI gates mirror local verification and docs stay current. |
+| 4 | Managed | Metrics and retrospectives inform maintenance decisions. |
+| 5 | Improving | Operational routines and maturity reviews drive continuous improvement. |
+
+The maturity model should be guidance, not certification. It should avoid per-person scoring and avoid implying process compliance beyond the repository evidence.
+
+## Affected surfaces
+
+| Surface | Change type |
+|---|---|
+| `.github/workflows/` | Add or update PR CI gate workflow. |
+| `scripts/verify.ts` | Confirm local and CI command alignment; adjust only if needed. |
+| `scripts/doctor.ts`, `scripts/lib/doctor.ts` | Extend workflow readiness checks if CI contract changes. |
+| `scripts/metrics*.ts`, `scripts/lib/` | Add deterministic metrics report if implementation chooses a script. |
+| `tests/scripts/` | Add tests for metrics and readiness logic. |
+| `docs/` | Add CI gate, metrics, and maturity documentation. |
+| `README.md` | Link v0.4 plan and update roadmap status when implemented. |
+| `sites/index.html` | Review product positioning after implementation. |
+
+## ADR impact
+
+No ADR is required for this plan. Implementation may need an ADR if v0.4 introduces a mandatory governance gate, changes merge authority, or adds scheduled automation with write permissions.
+
+## Risks and mitigations
+
+- RISK-V04-001: Start with deterministic PR gates and keep advisory reports non-blocking.
+- RISK-V04-002: Require every metric to map to a maintenance decision.
+- RISK-V04-003: Present maturity as adoption guidance, not compliance scoring.
+- RISK-V04-004: Treat v0.3 validators as inputs and avoid reimplementing them in v0.4.

--- a/specs/version-0-4-plan/idea.md
+++ b/specs/version-0-4-plan/idea.md
@@ -1,0 +1,39 @@
+---
+id: IDEA-V04-001
+title: Version 0.4 release plan
+stage: idea
+feature: version-0-4-plan
+status: accepted
+owner: analyst
+created: 2026-04-28
+updated: 2026-04-28
+---
+
+# Idea — Version 0.4 release plan
+
+## Problem
+
+The README roadmap names v0.4 as "CI quality gates, metrics, maturity model," but the repository has no canonical plan for that release. After v0.3 makes examples and local artifact validation stronger, v0.4 should decide how those checks become repeatable quality signals in CI, how maintainers see workflow health, and how adopters understand their maturity without turning the template into a heavy platform.
+
+## Target users
+
+- Maintainers who need repository-level confidence before merging workflow changes.
+- Contributors who need predictable CI feedback that mirrors local verification.
+- Template adopters who want a lightweight maturity model for staged adoption.
+
+## Desired outcome
+
+v0.4 should turn local quality signals into a documented CI and reporting layer: CI runs the right gates, metrics summarize workflow health, and a maturity model explains how teams can adopt Specorator progressively.
+
+## Constraints
+
+- v0.4 depends on v0.3 validation scope being implemented or deliberately narrowed.
+- Keep CI checks deterministic, low-noise, and aligned with `npm run verify`.
+- Avoid collecting private project data or introducing external telemetry.
+- Preserve the process-light v0.1/v0.2 posture: CI helps contributors, it does not replace human stage acceptance.
+
+## Open questions
+
+- Which checks should be blocking in CI on pull requests versus advisory or scheduled?
+- Which metrics are useful enough to maintain without becoming vanity dashboards?
+- What maturity levels should adopters see first: individual practice adoption, repository automation, or team governance?

--- a/specs/version-0-4-plan/requirements.md
+++ b/specs/version-0-4-plan/requirements.md
@@ -1,0 +1,113 @@
+---
+id: PRD-V04-001
+title: Version 0.4 release plan
+stage: requirements
+feature: version-0-4-plan
+status: accepted
+owner: pm
+inputs:
+  - IDEA-V04-001
+  - RESEARCH-V04-001
+created: 2026-04-28
+updated: 2026-04-28
+---
+
+# PRD — Version 0.4 release plan
+
+## Summary
+
+Plan v0.4 as the quality-signal release: CI quality gates, evidence-backed metrics, and a lightweight maturity model that help maintainers and adopters understand workflow health without changing the lifecycle.
+
+## Goals
+
+- Define which repository checks run in CI and which are blocking.
+- Provide a small metrics report that summarizes workflow health from existing artifacts.
+- Document a maturity model for progressive adoption of Specorator.
+- Keep CI, metrics, and maturity aligned with local verification and v0.3 artifact validation.
+
+## Non-goals
+
+- No external telemetry, hosted dashboard, or analytics service.
+- No mandatory new lifecycle stage.
+- No replacement for human stage acceptance.
+- No certification or compliance claim.
+- No implementation of new v0.3 validators; v0.4 consumes the v0.3 validation baseline.
+
+## Functional requirements (EARS)
+
+### REQ-V04-001 — Define pull request CI gates
+
+- **Pattern:** ubiquitous
+- **Statement:** The repository shall define a pull request CI gate that runs the deterministic verification checks required for template contributions.
+- **Acceptance:** The CI workflow documents the commands it runs, mirrors `npm run verify` where practical, and separates blocking checks from advisory checks.
+- **Priority:** must
+- **Satisfies:** IDEA-V04-001
+
+### REQ-V04-002 — Preserve local-first verification
+
+- **Pattern:** ubiquitous
+- **Statement:** The repository shall keep `npm run verify` as the local source of truth for checks contributors can run before opening a PR.
+- **Acceptance:** CI commands are documented as equivalent to or narrower than local verification, and contributors can reproduce failures locally.
+- **Priority:** must
+- **Satisfies:** RESEARCH-V04-001
+
+### REQ-V04-003 — Report workflow health metrics
+
+- **Pattern:** ubiquitous
+- **Statement:** The repository shall provide a deterministic metrics report that summarizes workflow health from repository artifacts.
+- **Acceptance:** Metrics include actionable counts such as active specs by stage, blocked specs, skipped artifacts, open clarifications, validation failures, and completed examples when data exists.
+- **Priority:** must
+- **Satisfies:** RESEARCH-V04-001
+
+### REQ-V04-004 — Document metric interpretation
+
+- **Pattern:** ubiquitous
+- **Statement:** The repository shall document what each metric means, when it should trigger action, and what it must not be used to infer.
+- **Acceptance:** Metrics documentation distinguishes quality signals from productivity scoring and avoids individual contributor measurement.
+- **Priority:** must
+- **Satisfies:** RESEARCH-V04-001
+
+### REQ-V04-005 — Define adoption maturity levels
+
+- **Pattern:** ubiquitous
+- **Statement:** The template shall provide a maturity model that describes progressive adoption levels for teams using Specorator.
+- **Acceptance:** The model includes clear level names, entry criteria, evidence examples, and next-step guidance tied to existing artifacts and checks.
+- **Priority:** must
+- **Satisfies:** IDEA-V04-001
+
+### REQ-V04-006 — Keep maturity evidence-backed
+
+- **Pattern:** unwanted behavior
+- **Statement:** When the maturity model assigns or suggests a level, the template shall base that level on observable repository evidence rather than subjective scoring alone.
+- **Acceptance:** Each maturity level maps to observable artifacts, checks, or documented practices.
+- **Priority:** must
+- **Satisfies:** RESEARCH-V04-001
+
+### REQ-V04-007 — Review public positioning
+
+- **Pattern:** event-driven
+- **Statement:** When CI gates, metrics, or the maturity model are implemented, the release shall review public docs and the product page for stale positioning.
+- **Acceptance:** README, `docs/specorator.md`, relevant docs, and `sites/index.html` are updated or explicitly marked unaffected.
+- **Priority:** should
+- **Satisfies:** IDEA-V04-001
+
+## Non-functional requirements
+
+| ID | Category | Requirement | Target |
+|---|---|---|---|
+| NFR-V04-001 | reliability | CI gates must be deterministic and low-noise. | No check depends on external network calls except dependency installation and GitHub-hosted workflow execution. |
+| NFR-V04-002 | maintainability | Metrics and maturity logic must reuse existing parsers and workflow schema where possible. | Shared logic lives under `scripts/lib/`; tests cover non-trivial behavior. |
+| NFR-V04-003 | privacy | Metrics must stay local to the repository and avoid personal performance tracking. | No external telemetry and no per-person productivity metrics. |
+| NFR-V04-004 | usability | Maturity guidance must be actionable for small teams and solo builders. | Each level has next-step guidance and examples. |
+
+## Success metrics
+
+- Contributors can reproduce CI failures locally with documented commands.
+- Maintainers can see active, blocked, and completed workflow health without manually scanning every spec.
+- Adopters can identify a realistic next maturity step without treating the model as certification.
+
+## Quality gate
+
+- [x] Functional requirements use EARS and stable IDs.
+- [x] Acceptance criteria are testable.
+- [x] Non-goals prevent telemetry, certification, and lifecycle-stage expansion.

--- a/specs/version-0-4-plan/research.md
+++ b/specs/version-0-4-plan/research.md
@@ -1,0 +1,73 @@
+---
+id: RESEARCH-V04-001
+title: Version 0.4 release plan — Research
+stage: research
+feature: version-0-4-plan
+status: accepted
+owner: analyst
+inputs:
+  - IDEA-V04-001
+created: 2026-04-28
+updated: 2026-04-28
+---
+
+# Research — Version 0.4 release plan
+
+## Context
+
+The repository already has a local verification suite and GitHub Actions workflow-readiness checks. v0.3 is planned to complete worked examples and strengthen deterministic artifact validation. v0.4 should build on that base by deciding which checks belong in CI, what metrics are worth reporting, and how to present a maturity model for teams adopting the template.
+
+## Current signals
+
+- `npm run verify` already orchestrates script tests, links, ADR index, command docs, script docs, workflow docs, product page checks, frontmatter checks, spec state checks, and traceability checks.
+- `scripts/doctor.ts` and `scripts/lib/doctor.ts` already inspect dependency and workflow readiness.
+- `docs/daily-reviews/README.md` notes future aggregation of review counts through frontmatter.
+- `docs/specorator.md` lists metrics, maturity model, and CI quality gates as future extensions.
+- v0.3 plan keeps CI gates, metrics, and maturity model explicitly out of v0.3 scope.
+
+## Alternatives
+
+### Alternative A — CI first, then metrics and maturity from the same evidence
+
+Define PR CI gates around `npm run verify`, add stable machine-readable output where needed, then derive a small metrics report and maturity model from the same checked artifacts.
+
+**Pros:** Keeps one source of truth, avoids duplicate checks, and makes metrics explainable.
+
+**Cons:** Requires care to keep CI from becoming noisy or too slow.
+
+### Alternative B — Metrics dashboard first
+
+Create a metrics report before introducing CI blocking rules.
+
+**Pros:** Gives maintainers visibility without blocking contributors.
+
+**Cons:** Risks measuring drift that CI still allows, and may encourage dashboard work before quality behavior is stable.
+
+### Alternative C — Maturity model first
+
+Document adoption levels and defer automation.
+
+**Pros:** Useful for downstream adopters and low implementation risk.
+
+**Cons:** Does not improve repository merge confidence and may become aspirational rather than evidence-backed.
+
+## Recommendation
+
+Choose Alternative A. v0.4 should establish a small CI quality-gate contract first, then add metrics and maturity language that explicitly derive from the same local and CI evidence.
+
+## Risks
+
+| ID | Risk | Severity | Mitigation |
+|---|---|---|---|
+| RISK-V04-001 | CI blocks contributors for noisy or environment-sensitive checks. | high | Start with deterministic checks and keep advisory reports separate from required PR gates. |
+| RISK-V04-002 | Metrics become vanity counts rather than actionable quality signals. | medium | Tie every metric to a decision or maintenance action. |
+| RISK-V04-003 | Maturity model feels like process certification. | medium | Present maturity as adoption guidance, not compliance scoring. |
+| RISK-V04-004 | v0.4 duplicates v0.3 validation work. | medium | Treat v0.3 validators as inputs and only add CI/reporting/maturity layers. |
+
+## Sources
+
+- `README.md` roadmap row for v0.4.
+- `docs/specorator.md` future extensions.
+- `specs/version-0-3-plan/requirements.md` and `tasks.md`.
+- `package.json` verification scripts.
+- Existing workflow readiness logic in `scripts/lib/doctor.ts`.

--- a/specs/version-0-4-plan/spec.md
+++ b/specs/version-0-4-plan/spec.md
@@ -1,0 +1,62 @@
+---
+id: SPECDOC-V04-001
+title: Version 0.4 release plan — Specification
+stage: specification
+feature: version-0-4-plan
+status: accepted
+owner: architect
+inputs:
+  - DESIGN-V04-001
+created: 2026-04-28
+updated: 2026-04-28
+---
+
+# Specification — Version 0.4 release plan
+
+### SPEC-V04-001 — Pull request CI gate
+
+- **Satisfies:** REQ-V04-001, REQ-V04-002, NFR-V04-001
+- **Behavior:** Pull requests run a documented deterministic gate that is locally reproducible through `npm run verify` or a clearly documented subset.
+- **Acceptance:** CI failure output identifies the failing command, and contributor docs show the local reproduction command.
+
+### SPEC-V04-002 — CI readiness contract
+
+- **Satisfies:** REQ-V04-001, REQ-V04-002, NFR-V04-002
+- **Behavior:** Repository readiness checks verify that required workflow files contain the expected checkout, setup, dependency install, and verification steps.
+- **Acceptance:** `npm run doctor` or a related check reports missing or malformed CI contract markers.
+
+### SPEC-V04-003 — Workflow metrics report
+
+- **Satisfies:** REQ-V04-003, REQ-V04-004, NFR-V04-002, NFR-V04-003
+- **Behavior:** A deterministic report summarizes workflow health using local repository artifacts and emits human-readable output, with JSON output if useful for CI or future automation.
+- **Acceptance:** Metrics include active specs by stage, blocked specs, skipped artifacts, open clarifications, validation status, and completed examples when data exists.
+
+### SPEC-V04-004 — Metrics documentation
+
+- **Satisfies:** REQ-V04-004, NFR-V04-003
+- **Behavior:** Documentation explains each metric, its decision use, and prohibited interpretations.
+- **Acceptance:** Documentation states that metrics are repository health signals, not individual productivity measures.
+
+### SPEC-V04-005 — Maturity model
+
+- **Satisfies:** REQ-V04-005, REQ-V04-006, NFR-V04-004
+- **Behavior:** A maturity model defines adoption levels with entry criteria, repository evidence, next steps, and caveats.
+- **Acceptance:** Each level maps to observable artifacts, checks, or documented practices.
+
+### SPEC-V04-006 — Public documentation alignment
+
+- **Satisfies:** REQ-V04-007
+- **Behavior:** README, workflow docs, and product page positioning are reviewed after v0.4 implementation.
+- **Acceptance:** Public docs either describe CI gates, metrics, and maturity model accurately or record why they are unaffected.
+
+## Test scenarios
+
+| ID | Requirement | Scenario | Expected result |
+|---|---|---|---|
+| TEST-V04-001 | REQ-V04-001 | Open a PR with a deterministic verification failure. | CI reports the failing command and blocks the required gate. |
+| TEST-V04-002 | REQ-V04-002 | Run the documented local command for a CI failure. | The same failure is reproducible locally. |
+| TEST-V04-003 | REQ-V04-003 | Generate metrics for a repo with active, blocked, and done specs. | Report includes stage/status counts and blocked-state details. |
+| TEST-V04-004 | REQ-V04-004 | Review metrics documentation. | Each metric has interpretation guidance and misuse warnings. |
+| TEST-V04-005 | REQ-V04-005 | Review the maturity model for a repo at each level. | Each level has criteria, evidence, and next-step guidance. |
+| TEST-V04-006 | REQ-V04-006 | Compare maturity criteria against repository evidence. | Criteria reference observable artifacts or checks. |
+| TEST-V04-007 | REQ-V04-007 | Review public docs after implementation. | README/docs/product page are updated or explicitly unaffected. |

--- a/specs/version-0-4-plan/tasks.md
+++ b/specs/version-0-4-plan/tasks.md
@@ -1,0 +1,101 @@
+---
+id: TASKS-V04-001
+title: Version 0.4 release plan — Tasks
+stage: tasks
+feature: version-0-4-plan
+status: complete
+owner: planner
+inputs:
+  - PRD-V04-001
+  - SPECDOC-V04-001
+created: 2026-04-28
+updated: 2026-04-28
+---
+
+# Tasks — Version 0.4 release plan
+
+### T-V04-001 — Confirm v0.3 validation baseline
+
+- **Description:** Review the completed v0.3 example and validation work; document which checks are stable enough to become CI gates.
+- **Satisfies:** REQ-V04-001, REQ-V04-002, SPEC-V04-001
+- **Owner:** planner
+- **Estimate:** S
+
+### T-V04-002 — Define CI gate contract
+
+- **Description:** Decide required versus advisory PR checks and document the local reproduction commands.
+- **Satisfies:** REQ-V04-001, REQ-V04-002, NFR-V04-001, SPEC-V04-001, SPEC-V04-002
+- **Depends on:** T-V04-001
+- **Owner:** architect
+- **Estimate:** S
+
+### T-V04-003 — Implement PR CI quality gate
+
+- **Description:** Add or update GitHub Actions workflow files so pull requests run the documented deterministic gate.
+- **Satisfies:** REQ-V04-001, REQ-V04-002, NFR-V04-001, SPEC-V04-001
+- **Depends on:** T-V04-002
+- **Owner:** dev
+- **Estimate:** M
+
+### T-V04-004 — Extend CI readiness checks
+
+- **Description:** Update `doctor` or related workflow-readiness checks to validate the CI gate contract.
+- **Satisfies:** REQ-V04-001, REQ-V04-002, NFR-V04-002, SPEC-V04-002
+- **Depends on:** T-V04-003
+- **Owner:** dev
+- **Estimate:** M
+
+### T-V04-005 — Add workflow metrics report
+
+- **Description:** Add a deterministic local metrics report for workflow health, with human-readable output and JSON output if useful.
+- **Satisfies:** REQ-V04-003, REQ-V04-004, NFR-V04-002, NFR-V04-003, SPEC-V04-003
+- **Depends on:** T-V04-001
+- **Owner:** dev
+- **Estimate:** M
+
+### T-V04-006 — Test CI readiness and metrics behavior
+
+- **Description:** Add focused tests for CI readiness checks and metrics generation, including active, blocked, done, skipped, and open-clarification states.
+- **Satisfies:** REQ-V04-001, REQ-V04-003, REQ-V04-004, NFR-V04-001, NFR-V04-002, SPEC-V04-002, SPEC-V04-003
+- **Depends on:** T-V04-004, T-V04-005
+- **Owner:** qa
+- **Estimate:** M
+
+### T-V04-007 — Document metrics interpretation
+
+- **Description:** Add documentation for each metric, including what decision it supports and what it must not be used to infer.
+- **Satisfies:** REQ-V04-004, NFR-V04-003, SPEC-V04-004
+- **Depends on:** T-V04-005
+- **Owner:** release-manager
+- **Estimate:** S
+
+### T-V04-008 — Add maturity model documentation
+
+- **Description:** Add a lightweight maturity model with levels, entry criteria, evidence examples, and next-step guidance.
+- **Satisfies:** REQ-V04-005, REQ-V04-006, NFR-V04-004, SPEC-V04-005
+- **Owner:** pm
+- **Estimate:** M
+
+### T-V04-009 — Update public release documentation
+
+- **Description:** Update README, `docs/specorator.md`, workflow docs, and release notes when v0.4 implementation lands.
+- **Satisfies:** REQ-V04-007, SPEC-V04-006
+- **Depends on:** T-V04-003, T-V04-005, T-V04-008
+- **Owner:** release-manager
+- **Estimate:** S
+
+### T-V04-010 — Review product page positioning
+
+- **Description:** Review `sites/index.html` after CI gates, metrics, and maturity model are implemented; update it only if public positioning, onboarding, or CTAs are stale.
+- **Satisfies:** REQ-V04-007, SPEC-V04-006
+- **Depends on:** T-V04-009
+- **Owner:** release-manager
+- **Estimate:** S
+
+### T-V04-011 — Verify v0.4 release readiness
+
+- **Description:** Run targeted tests, CI-readiness checks, metrics checks, link checks, and `npm run verify`; document skipped checks and any deferred scheduled automation.
+- **Satisfies:** REQ-V04-001, REQ-V04-002, REQ-V04-003, REQ-V04-007, SPEC-V04-001, SPEC-V04-002, SPEC-V04-003, SPEC-V04-006
+- **Depends on:** T-V04-006, T-V04-007, T-V04-008, T-V04-010
+- **Owner:** qa
+- **Estimate:** S

--- a/specs/version-0-4-plan/workflow-state.md
+++ b/specs/version-0-4-plan/workflow-state.md
@@ -1,0 +1,57 @@
+---
+feature: version-0-4-plan
+area: V04
+current_stage: implementation
+status: active
+last_updated: 2026-04-28
+last_agent: planner
+artifacts:
+  idea.md: complete
+  research.md: complete
+  requirements.md: complete
+  design.md: complete
+  spec.md: complete
+  tasks.md: complete
+  implementation-log.md: pending
+  test-plan.md: pending
+  test-report.md: pending
+  review.md: pending
+  traceability.md: pending
+  release-notes.md: pending
+  retrospective.md: pending
+---
+
+# Workflow state — version-0-4-plan
+
+## Stage progress
+
+| Stage | Artifact | Status |
+|---|---|---|
+| 1. Idea | `idea.md` | complete |
+| 2. Research | `research.md` | complete |
+| 3. Requirements | `requirements.md` | complete |
+| 4. Design | `design.md` | complete |
+| 5. Specification | `spec.md` | complete |
+| 6. Tasks | `tasks.md` | complete |
+| 7. Implementation | `implementation-log.md` + code | pending |
+| 8. Testing | `test-plan.md`, `test-report.md` | pending |
+| 9. Review | `review.md`, `traceability.md` | pending |
+| 10. Release | `release-notes.md` | pending |
+| 11. Learning | `retrospective.md` | pending |
+
+## Skips
+
+- None.
+
+## Blocks
+
+- None.
+
+## Hand-off notes
+
+- 2026-04-28 (codex): Planned v0.4 through Stage 6. Recommended implementation order is v0.3 validation baseline confirmation, CI gate contract, PR CI workflow, CI readiness checks, metrics report, maturity documentation, public docs/product page review, then release readiness verification.
+
+## Open clarifications
+
+- [ ] CLAR-V04-001 — Confirm which v0.3 validation checks are stable enough to become required PR CI gates.
+- [ ] CLAR-V04-002 — Confirm whether v0.4 should include scheduled read-only health reporting or defer scheduled automation beyond v0.4.


### PR DESCRIPTION
## Summary
- Add a canonical v0.4 planning spec under `specs/version-0-4-plan/` through Stage 6 tasks.
- Scope v0.4 around CI quality gates, workflow health metrics, and an evidence-backed maturity model.
- Link the README roadmap v0.4 row to the new task plan.

## Verification
- `npm run check:specs`
- `npm run check:traceability`
- `npm run check:links`
- `npm run verify`

## Notes
- This is a planning PR only. Implementation remains pending in `workflow-state.md`.
- Open clarifications remain on which v0.3 validation checks become required PR CI gates and whether scheduled read-only health reporting belongs in v0.4.