### PR TITLE
Plan v0.5 release workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@ Full version in [`memory/constitution.md`](memory/constitution.md).
 | v0.2 | Done | Skills layer, operational bots, branching / verify / worktrees guides |
 | v0.3 | Planned | [Worked end-to-end examples, artifact validation](specs/version-0-3-plan/tasks.md) |
 | v0.4 | Planned | [CI quality gates, metrics, maturity model](specs/version-0-4-plan/tasks.md) |
+| v0.5 | Planned | [Release workflow, branching strategy, GitHub Releases and Packages](specs/version-0-5-plan/tasks.md) |
 
 ---
 

--- a/specs/version-0-5-plan/design.md
+++ b/specs/version-0-5-plan/design.md
@@ -1,0 +1,89 @@
+---
+id: DESIGN-V05-001
+title: Version 0.5 release and distribution plan — Design
+stage: design
+feature: version-0-5-plan
+status: accepted
+owner: architect
+inputs:
+  - PRD-V05-001
+created: 2026-04-28
+updated: 2026-04-28
+---
+
+# Design — Version 0.5 release and distribution plan
+
+## Release shape
+
+v0.5 has four connected tracks:
+
+1. **Branching strategy:** decide Shape A continuation versus Shape B promotion with `develop` and `main`.
+2. **GitHub Release workflow:** publish tags, release notes, source archives, and optional assets.
+3. **GitHub Packages workflow:** publish an accepted package type from release authority only.
+4. **Operator documentation:** give maintainers a dry-run, publish, rollback, and recovery playbook.
+
+## Recommended branch model
+
+Start by documenting both paths, then choose one before implementation:
+
+| Option | Use when | Release source |
+|---|---|---|
+| Shape A plus release branch | The project still has low release cadence and wants minimal overhead. | `release/vX.Y.Z` PR merges to `main`; tag is cut from `main`. |
+| Shape B with `develop` | The project has regular releases and needs `main` to represent only promoted releases. | `develop` integrates work; release PR promotes to `main`; tag is cut from `main`. |
+
+For v0.5 planning, Shape A plus an explicit `release/vX.Y.Z` branch is the lower-risk first step. Shape B should be adopted only if maintainers accept the overhead of changing default integration behavior.
+
+## Release workflow model
+
+1. Maintainer prepares `release/vX.Y.Z` from the accepted integration branch.
+2. Release readiness check validates version, changelog, lifecycle release notes, package metadata, and workflow permissions.
+3. PR review and verify pass.
+4. Maintainer merges or promotes the release commit to the release source branch.
+5. Maintainer manually starts a GitHub Actions release workflow with version, tag, draft/pre-release flag, and package publish flag.
+6. Workflow creates or updates the GitHub Release, attaches assets when present, and publishes package only if authorized.
+7. Release notes and post-release cleanup record the result.
+
+## Package contract model
+
+The first GitHub Package should have an explicit contract before automation exists:
+
+| Decision | Required before publish |
+|---|---|
+| Registry type | npm package, container package, or deferred registry target. |
+| Package name | Scoped GitHub-compatible name. |
+| Contents | Which scripts, templates, docs, and metadata are included. |
+| Visibility | Public/private and repository linkage. |
+| Version source | `package.json`, tag, changelog, or release manifest. |
+| Consumer promise | What downstream users can rely on and what remains template-only. |
+
+Given the current Node tooling, the likely first package is an npm package published to GitHub Packages after `private: true`, `name`, `publishConfig`, and files list decisions are resolved.
+
+## Affected surfaces
+
+| Surface | Change type |
+|---|---|
+| `docs/branching.md` | Add release branch and promotion rules. |
+| `docs/release-workflow.md` or equivalent | Add operator workflow and authorization model. |
+| `.github/release.yml` | Configure generated release notes categories. |
+| `.github/workflows/release.yml` | Add manual release and optional package publish workflow. |
+| `package.json` | Define package identity, visibility, publish config, files, and version rules if npm package is accepted. |
+| `scripts/check-release-readiness.ts` | Add deterministic pre-publish validation. |
+| `tests/scripts/` | Add release readiness tests. |
+| `CHANGELOG.md` | Align release entries with tags and GitHub Releases. |
+| `README.md`, `docs/specorator.md`, `sites/index.html` | Update public release and package positioning when implemented. |
+
+## Authorization boundary
+
+Release and package publication are irreversible shared-state operations. Automation may prepare, validate, draft, or dry-run without special approval, but publishing must require human authorization in the workflow inputs and release notes.
+
+## ADR impact
+
+An ADR is likely required if implementation adopts Shape B with `develop`, changes the canonical release branch, or commits the project to a public package contract. If v0.5 only documents Shape A release branches and adds manual publish automation, an ADR may be optional.
+
+## Risks and mitigations
+
+- RISK-V05-001: Use manual workflow dispatch and least-privilege workflow permissions.
+- RISK-V05-002: Require a package contract before editing publish settings.
+- RISK-V05-003: Do not introduce `develop` unless release cadence and maintainer capacity justify it.
+- RISK-V05-004: Treat lifecycle `release-notes.md` as curated input to GitHub Release notes.
+- RISK-V05-005: Add pre-publish release readiness checks before enabling publish.

--- a/specs/version-0-5-plan/idea.md
+++ b/specs/version-0-5-plan/idea.md
@@ -1,0 +1,42 @@
+---
+id: IDEA-V05-001
+title: Version 0.5 release and distribution plan
+stage: idea
+feature: version-0-5-plan
+status: accepted
+owner: analyst
+created: 2026-04-28
+updated: 2026-04-28
+---
+
+# Idea — Version 0.5 release and distribution plan
+
+## Problem
+
+Specorator has plans for examples, validation, CI gates, metrics, and maturity signals, but it still lacks a proper release and distribution workflow. The repository currently behaves like a template project with a `main` integration branch and a private npm package, while GitHub provides first-class Releases and Packages features that could make versions easier to discover, install, audit, and promote.
+
+## Target users
+
+- Maintainers who need a repeatable release process with tags, notes, assets, and rollback rules.
+- Contributors who need clear branch promotion rules before release work begins.
+- Adopters who want stable versioned artifacts, not only the latest `main` branch.
+- Automation agents that need an explicit authority boundary for publishing releases and packages.
+
+## Desired outcome
+
+v0.5 should define and prepare a release workflow that uses GitHub Releases for canonical version publication and GitHub Packages for installable package distribution, with a branching strategy that separates integration, release preparation, and published versions.
+
+## Constraints
+
+- Publishing a release, tag, or package is shared-state work and requires explicit human authorization.
+- Do not publish from ordinary feature branches.
+- Preserve local-first verification and PR review before release promotion.
+- Avoid changing the current branch model until the release workflow is documented and accepted.
+- Package naming, scope, visibility, and registry target must be explicit before implementation.
+
+## Open questions
+
+- Should v0.5 introduce a permanent `develop` branch now, or define the release workflow while staying on Shape A until the first published release?
+- Should the GitHub Package be an npm package for tooling/templates, a container package for automation, or both over time?
+- What package name and scope should be used: `@luis85/agentic-workflow`, `@luis85/specorator`, or another scoped name?
+- Should v0.5 publish a draft/pre-release first, then a stable release after a dry run?

--- a/specs/version-0-5-plan/requirements.md
+++ b/specs/version-0-5-plan/requirements.md
@@ -1,0 +1,130 @@
+---
+id: PRD-V05-001
+title: Version 0.5 release and distribution plan
+stage: requirements
+feature: version-0-5-plan
+status: accepted
+owner: pm
+inputs:
+  - IDEA-V05-001
+  - RESEARCH-V05-001
+created: 2026-04-28
+updated: 2026-04-28
+---
+
+# PRD — Version 0.5 release and distribution plan
+
+## Summary
+
+Plan v0.5 as the release and distribution release: define the branching strategy, release workflow, package contract, and GitHub automation needed to publish Specorator through GitHub Releases and GitHub Packages without bypassing human authorization.
+
+## Goals
+
+- Make GitHub Releases the canonical public version record.
+- Make GitHub Packages the installable package distribution channel once package identity is accepted.
+- Define a branching and promotion strategy suitable for real releases.
+- Add pre-publish validation so versions, tags, release notes, changelog, and package metadata stay aligned.
+- Keep publish operations manually authorized and auditable.
+
+## Non-goals
+
+- No automatic publish from ordinary pushes or feature PRs.
+- No publication to npmjs.com in v0.5.
+- No package deletion or restore automation.
+- No hidden release actions outside GitHub Actions or documented maintainer steps.
+- No guarantee that `develop` is introduced unless the release strategy accepts Shape B.
+
+## Functional requirements (EARS)
+
+### REQ-V05-001 — Define release branching strategy
+
+- **Pattern:** ubiquitous
+- **Statement:** The repository shall define the branch model used for versioned releases, including integration branch, release branch, tag source, and promotion rules.
+- **Acceptance:** Documentation states whether v0.5 keeps Shape A or adopts Shape B, and names the exact branches used for release preparation and publishing.
+- **Priority:** must
+- **Satisfies:** IDEA-V05-001
+
+### REQ-V05-002 — Protect release authority
+
+- **Pattern:** unwanted behavior
+- **Statement:** When a workflow publishes a GitHub Release or GitHub Package, the repository shall require explicit human authorization before the publish step runs.
+- **Acceptance:** Publish workflows use manual dispatch, documented authorization, and least-privilege permissions.
+- **Priority:** must
+- **Satisfies:** RESEARCH-V05-001
+
+### REQ-V05-003 — Create GitHub Release workflow
+
+- **Pattern:** event-driven
+- **Statement:** When an authorized maintainer starts a release, the repository shall create or update a GitHub Release from the accepted release tag and release notes.
+- **Acceptance:** The workflow supports draft or pre-release mode, generated release notes categories, release assets when available, and a stable mapping from lifecycle `release-notes.md` to GitHub release content.
+- **Priority:** must
+- **Satisfies:** RESEARCH-V05-001
+
+### REQ-V05-004 — Configure generated release notes
+
+- **Pattern:** ubiquitous
+- **Statement:** The repository shall configure GitHub generated release notes so merged PRs are grouped into meaningful Specorator release categories.
+- **Acceptance:** `.github/release.yml` maps labels or fallback categories to release-note sections and excludes non-user-facing maintenance when appropriate.
+- **Priority:** should
+- **Satisfies:** RESEARCH-V05-001
+
+### REQ-V05-005 — Define package contract
+
+- **Pattern:** ubiquitous
+- **Statement:** The repository shall define the GitHub Package name, scope, registry type, visibility, contents, and support expectations before publishing.
+- **Acceptance:** The package contract explains whether the first package is an npm package, a container package, or another supported GitHub Packages registry target.
+- **Priority:** must
+- **Satisfies:** IDEA-V05-001
+
+### REQ-V05-006 — Publish GitHub Package from release authority only
+
+- **Pattern:** event-driven
+- **Statement:** When an authorized release publish succeeds and package metadata is valid, the repository shall publish the package version to GitHub Packages from the release workflow.
+- **Acceptance:** The package workflow uses `GITHUB_TOKEN` where supported, grants only required permissions, and publishes only versioned release artifacts.
+- **Priority:** must
+- **Satisfies:** RESEARCH-V05-001
+
+### REQ-V05-007 — Validate release readiness
+
+- **Pattern:** ubiquitous
+- **Statement:** The repository shall provide a deterministic pre-publish check for release readiness.
+- **Acceptance:** The check validates version, tag, changelog, lifecycle release notes, package metadata, release workflow configuration, and package workflow permissions before publish.
+- **Priority:** must
+- **Satisfies:** RESEARCH-V05-001
+
+### REQ-V05-008 — Document release operator workflow
+
+- **Pattern:** ubiquitous
+- **Statement:** The repository shall document the human release operator workflow from release branch preparation through GitHub Release and GitHub Package publication.
+- **Acceptance:** Documentation includes dry run, authorization, publish, rollback, failed publish recovery, and post-release cleanup steps.
+- **Priority:** must
+- **Satisfies:** IDEA-V05-001
+
+### REQ-V05-009 — Keep public positioning current
+
+- **Pattern:** event-driven
+- **Statement:** When v0.5 introduces release and package distribution, the release shall review public documentation and the product page for stale installation, versioning, or distribution language.
+- **Acceptance:** README, `docs/specorator.md`, release docs, and `sites/index.html` are updated or explicitly marked unaffected.
+- **Priority:** should
+- **Satisfies:** IDEA-V05-001
+
+## Non-functional requirements
+
+| ID | Category | Requirement | Target |
+|---|---|---|---|
+| NFR-V05-001 | safety | Publish actions must be manually authorized and least-privilege. | No automatic publish from push or PR events. |
+| NFR-V05-002 | reproducibility | Release artifacts and package versions must be traceable to a tag and commit SHA. | GitHub Release, package version, changelog, and release notes point to the same version. |
+| NFR-V05-003 | maintainability | Release checks and package logic must reuse existing script and workflow conventions. | TypeScript scripts under `scripts/`; tests under `tests/scripts/`; docs generated when script APIs change. |
+| NFR-V05-004 | usability | Release docs must be runnable by a maintainer who has not authored the release. | Step-by-step operator guide with rollback and recovery sections. |
+
+## Success metrics
+
+- A maintainer can perform a dry-run release without publishing shared state.
+- A publish run creates a GitHub Release and GitHub Package that reference the same version and commit.
+- A failed publish has a documented recovery path that does not require force-pushing protected branches.
+
+## Quality gate
+
+- [x] Functional requirements use EARS and stable IDs.
+- [x] Acceptance criteria are testable.
+- [x] Publishing and shared-state operations require explicit human authorization.

--- a/specs/version-0-5-plan/research.md
+++ b/specs/version-0-5-plan/research.md
@@ -1,0 +1,73 @@
+---
+id: RESEARCH-V05-001
+title: Version 0.5 release and distribution plan — Research
+stage: research
+feature: version-0-5-plan
+status: accepted
+owner: analyst
+inputs:
+  - IDEA-V05-001
+created: 2026-04-28
+updated: 2026-04-28
+---
+
+# Research — Version 0.5 release and distribution plan
+
+## Context
+
+The repository already documents two branch shapes in `docs/branching.md`: Shape A uses `main` as integration plus release, while Shape B adds `develop` as integration and keeps `main` for tagged release commits. The current `package.json` is private and versioned `0.2.0`, so it is not yet ready to publish as a GitHub Package. Existing GitHub workflows cover Pages and verification, but there is no release workflow.
+
+## GitHub platform notes
+
+- GitHub Releases package software with release notes and links to binary files; releases are based on Git tags and include automatic zip and tarball source archives. See GitHub Docs: <https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases>.
+- GitHub can automatically generate release notes with merged pull requests, contributors, and a changelog link, and `.github/release.yml` can customize categories and exclusions. See GitHub Docs: <https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes>.
+- GitHub Actions can publish packages to GitHub Packages as part of CI/CD when quality standards pass. Workflows should use `GITHUB_TOKEN` where supported, and repository-scoped registries need `contents: read` plus `packages: write`. See GitHub Docs: <https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions>.
+
+## Alternatives
+
+### Alternative A — Release workflow first, package publishing second
+
+Define the release branch/tag/release process, release notes categories, and authorization rules first. Then add package publishing once package identity and contents are explicit.
+
+**Pros:** Establishes governance before irreversible publishing and avoids publishing an ill-defined package.
+
+**Cons:** Does not immediately exercise GitHub Packages unless the plan includes a dry-run package workflow.
+
+### Alternative B — Publish npm package directly from tags
+
+Convert `package.json` to a publishable scoped package and add a tag-triggered workflow that creates a GitHub Release and publishes to GitHub Packages.
+
+**Pros:** Takes advantage of GitHub Releases and Packages quickly.
+
+**Cons:** Higher risk because package contents, name, visibility, and support contract are not yet defined.
+
+### Alternative C — Release assets only, defer GitHub Packages
+
+Use GitHub Releases with generated notes and attached release artifacts, but do not publish any package.
+
+**Pros:** Low risk and matches template distribution well.
+
+**Cons:** Does not satisfy the goal of taking advantage of GitHub Packages.
+
+## Recommendation
+
+Choose Alternative A with a strict v0.5 implementation sequence: define the release workflow and branching strategy, define the package contract, add dry-run validation, then add human-authorized publish automation. The release should use GitHub Releases as the canonical version record and GitHub Packages as the installable distribution channel once the package contract is accepted.
+
+## Risks
+
+| ID | Risk | Severity | Mitigation |
+|---|---|---|---|
+| RISK-V05-001 | A workflow publishes a release or package without explicit human approval. | high | Require manual `workflow_dispatch`, protected environments, and documented authorization before publish jobs run. |
+| RISK-V05-002 | The package name or contents create a support contract the project is not ready to honor. | high | Add package contract and package contents review before publish automation. |
+| RISK-V05-003 | Introducing `develop` too early adds process overhead without release value. | medium | Gate Shape B adoption on an accepted release cadence and first release dry run. |
+| RISK-V05-004 | Release notes duplicate or conflict with lifecycle `release-notes.md`. | medium | Map lifecycle release notes into GitHub release notes and configure `.github/release.yml` categories. |
+| RISK-V05-005 | Tags, package versions, and changelog entries drift. | medium | Add deterministic checks for version, tag, changelog, release notes, and package metadata alignment. |
+
+## Sources
+
+- `docs/branching.md`
+- `templates/release-notes-template.md`
+- `package.json`
+- GitHub Docs: About releases
+- GitHub Docs: Automatically generated release notes
+- GitHub Docs: Publishing and installing a package with GitHub Actions

--- a/specs/version-0-5-plan/spec.md
+++ b/specs/version-0-5-plan/spec.md
@@ -1,0 +1,70 @@
+---
+id: SPECDOC-V05-001
+title: Version 0.5 release and distribution plan — Specification
+stage: specification
+feature: version-0-5-plan
+status: accepted
+owner: architect
+inputs:
+  - DESIGN-V05-001
+created: 2026-04-28
+updated: 2026-04-28
+---
+
+# Specification — Version 0.5 release and distribution plan
+
+### SPEC-V05-001 — Release branching contract
+
+- **Satisfies:** REQ-V05-001, NFR-V05-002
+- **Behavior:** Documentation defines the release source branch, release branch naming, promotion path, tag source, and cleanup rules.
+- **Acceptance:** A maintainer can identify where to branch from, where to merge, where to tag, and when to delete local and remote release branches.
+
+### SPEC-V05-002 — Publish authorization contract
+
+- **Satisfies:** REQ-V05-002, NFR-V05-001
+- **Behavior:** Publish workflows require manual invocation, explicit release version input, explicit publish confirmation input, and least-privilege `permissions`.
+- **Acceptance:** No workflow publishes a GitHub Release or Package on ordinary push or pull request events.
+
+### SPEC-V05-003 — GitHub Release publication
+
+- **Satisfies:** REQ-V05-003, REQ-V05-004, NFR-V05-002
+- **Behavior:** Release automation creates or updates a GitHub Release from a version tag, supports draft/pre-release mode, uses generated release notes categories, and optionally attaches release assets.
+- **Acceptance:** Release output links to the tag, commit SHA, changelog entry, and lifecycle release notes.
+
+### SPEC-V05-004 — Package contract and publication
+
+- **Satisfies:** REQ-V05-005, REQ-V05-006, NFR-V05-001, NFR-V05-002
+- **Behavior:** Package publishing is disabled until a package contract defines registry type, name, scope, contents, visibility, version source, and support expectations.
+- **Acceptance:** Once enabled, package publishing uses the authorized release workflow and publishes only versioned release artifacts to GitHub Packages.
+
+### SPEC-V05-005 — Release readiness validation
+
+- **Satisfies:** REQ-V05-007, NFR-V05-003
+- **Behavior:** A deterministic check validates release version alignment, tag readiness, changelog entry, lifecycle release notes, package metadata, GitHub release configuration, and workflow permissions.
+- **Acceptance:** The check fails before publish when release metadata is incomplete or inconsistent.
+
+### SPEC-V05-006 — Release operator documentation
+
+- **Satisfies:** REQ-V05-008, NFR-V05-004
+- **Behavior:** Documentation gives maintainers a step-by-step release operator path covering dry run, authorization, publish, rollback, failed package publish recovery, and post-release cleanup.
+- **Acceptance:** The guide names exact commands, GitHub workflow inputs, approval records, and cleanup actions.
+
+### SPEC-V05-007 — Public distribution documentation
+
+- **Satisfies:** REQ-V05-009
+- **Behavior:** Public docs describe how users consume stable GitHub Releases and, when enabled, GitHub Packages.
+- **Acceptance:** README, workflow docs, and product page language are accurate after v0.5 implementation.
+
+## Test scenarios
+
+| ID | Requirement | Scenario | Expected result |
+|---|---|---|---|
+| TEST-V05-001 | REQ-V05-001 | Review release branching docs for a v0.5 release. | Branch source, promotion path, tag source, and cleanup rules are explicit. |
+| TEST-V05-002 | REQ-V05-002 | Inspect release workflow triggers and permissions. | Publish jobs require manual authorization and least-privilege permissions. |
+| TEST-V05-003 | REQ-V05-003 | Run a dry-run release workflow. | Workflow validates release inputs without publishing shared state. |
+| TEST-V05-004 | REQ-V05-004 | Generate release notes from labeled PRs. | PRs are grouped into configured Specorator categories. |
+| TEST-V05-005 | REQ-V05-005 | Review package contract before package workflow is enabled. | Package registry, name, contents, visibility, and support promise are accepted. |
+| TEST-V05-006 | REQ-V05-006 | Publish a package from an authorized release run. | Package version matches release tag and commit SHA. |
+| TEST-V05-007 | REQ-V05-007 | Run release readiness with mismatched version metadata. | Check fails with stable diagnostics. |
+| TEST-V05-008 | REQ-V05-008 | Follow the operator guide for a dry run. | Maintainer reaches a dry-run result without publishing. |
+| TEST-V05-009 | REQ-V05-009 | Review public docs after implementation. | Release and package distribution language is current. |

--- a/specs/version-0-5-plan/tasks.md
+++ b/specs/version-0-5-plan/tasks.md
@@ -1,0 +1,101 @@
+---
+id: TASKS-V05-001
+title: Version 0.5 release and distribution plan — Tasks
+stage: tasks
+feature: version-0-5-plan
+status: complete
+owner: planner
+inputs:
+  - PRD-V05-001
+  - SPECDOC-V05-001
+created: 2026-04-28
+updated: 2026-04-28
+---
+
+# Tasks — Version 0.5 release and distribution plan
+
+### T-V05-001 — Decide release branch strategy
+
+- **Description:** Choose Shape A plus `release/vX.Y.Z` branches or Shape B with `develop`; update branching docs and add an ADR if branch roles change.
+- **Satisfies:** REQ-V05-001, NFR-V05-002, SPEC-V05-001
+- **Owner:** architect
+- **Estimate:** M
+
+### T-V05-002 — Define package contract
+
+- **Description:** Document package registry type, package name, scope, contents, visibility, version source, and support expectations before enabling publish.
+- **Satisfies:** REQ-V05-005, NFR-V05-002, SPEC-V05-004
+- **Owner:** pm
+- **Estimate:** M
+
+### T-V05-003 — Add release notes configuration
+
+- **Description:** Add `.github/release.yml` categories and exclusions for GitHub generated release notes.
+- **Satisfies:** REQ-V05-003, REQ-V05-004, SPEC-V05-003
+- **Depends on:** T-V05-001
+- **Owner:** dev
+- **Estimate:** S
+
+### T-V05-004 — Add release readiness check
+
+- **Description:** Implement a deterministic release readiness check for version, tag, changelog, lifecycle release notes, package metadata, release config, and workflow permissions.
+- **Satisfies:** REQ-V05-007, NFR-V05-003, SPEC-V05-005
+- **Depends on:** T-V05-001, T-V05-002
+- **Owner:** dev
+- **Estimate:** M
+
+### T-V05-005 — Test release readiness behavior
+
+- **Description:** Add focused tests for valid releases, missing changelog entries, missing lifecycle release notes, package metadata drift, and unsafe workflow permissions.
+- **Satisfies:** REQ-V05-007, NFR-V05-003, SPEC-V05-005
+- **Depends on:** T-V05-004
+- **Owner:** qa
+- **Estimate:** M
+
+### T-V05-006 — Add manual GitHub Release workflow
+
+- **Description:** Add a `workflow_dispatch` release workflow that supports dry run, draft/pre-release mode, release notes generation, and release asset attachment without package publishing by default.
+- **Satisfies:** REQ-V05-002, REQ-V05-003, REQ-V05-004, NFR-V05-001, NFR-V05-002, SPEC-V05-002, SPEC-V05-003
+- **Depends on:** T-V05-003, T-V05-004
+- **Owner:** dev
+- **Estimate:** M
+
+### T-V05-007 — Add package publish path
+
+- **Description:** After package contract approval, update package metadata and extend the manual release workflow to publish the accepted package type to GitHub Packages with least-privilege permissions.
+- **Satisfies:** REQ-V05-005, REQ-V05-006, NFR-V05-001, NFR-V05-002, SPEC-V05-004
+- **Depends on:** T-V05-002, T-V05-006
+- **Owner:** dev
+- **Estimate:** L
+
+### T-V05-008 — Add release operator guide
+
+- **Description:** Document dry run, authorization, publish, rollback, failed publish recovery, and post-release cleanup for maintainers.
+- **Satisfies:** REQ-V05-008, NFR-V05-004, SPEC-V05-006
+- **Depends on:** T-V05-006, T-V05-007
+- **Owner:** release-manager
+- **Estimate:** M
+
+### T-V05-009 — Update public distribution docs
+
+- **Description:** Update README, `docs/specorator.md`, release docs, package docs, and product page language for GitHub Releases and GitHub Packages.
+- **Satisfies:** REQ-V05-009, SPEC-V05-007
+- **Depends on:** T-V05-006, T-V05-007, T-V05-008
+- **Owner:** release-manager
+- **Estimate:** M
+
+### T-V05-010 — Run release dry run
+
+- **Description:** Execute the release workflow in dry-run mode and record outputs in implementation and test artifacts without publishing a release or package.
+- **Satisfies:** REQ-V05-002, REQ-V05-003, REQ-V05-007, REQ-V05-008, SPEC-V05-002, SPEC-V05-003, SPEC-V05-005, SPEC-V05-006
+- **Depends on:** T-V05-006, T-V05-008
+- **Owner:** qa
+- **Estimate:** S
+
+### T-V05-011 — Verify v0.5 release readiness
+
+- **Description:** Run release readiness checks, targeted tests, link checks, package dry-run checks, and `npm run verify`; document skipped publish checks and remaining authorization needs.
+- **Satisfies:** REQ-V05-001, REQ-V05-002, REQ-V05-006, REQ-V05-007, REQ-V05-008, REQ-V05-009, SPEC-V05-001, SPEC-V05-002, SPEC-V05-004, SPEC-V05-005, SPEC-V05-006, SPEC-V05-007
+- **Depends on:** T-V05-005, T-V05-009, T-V05-010
+- **Owner:** qa
+- **Estimate:** S

--- a/specs/version-0-5-plan/workflow-state.md
+++ b/specs/version-0-5-plan/workflow-state.md
@@ -1,0 +1,58 @@
+---
+feature: version-0-5-plan
+area: V05
+current_stage: implementation
+status: active
+last_updated: 2026-04-28
+last_agent: planner
+artifacts:
+  idea.md: complete
+  research.md: complete
+  requirements.md: complete
+  design.md: complete
+  spec.md: complete
+  tasks.md: complete
+  implementation-log.md: pending
+  test-plan.md: pending
+  test-report.md: pending
+  review.md: pending
+  traceability.md: pending
+  release-notes.md: pending
+  retrospective.md: pending
+---
+
+# Workflow state — version-0-5-plan
+
+## Stage progress
+
+| Stage | Artifact | Status |
+|---|---|---|
+| 1. Idea | `idea.md` | complete |
+| 2. Research | `research.md` | complete |
+| 3. Requirements | `requirements.md` | complete |
+| 4. Design | `design.md` | complete |
+| 5. Specification | `spec.md` | complete |
+| 6. Tasks | `tasks.md` | complete |
+| 7. Implementation | `implementation-log.md` + code | pending |
+| 8. Testing | `test-plan.md`, `test-report.md` | pending |
+| 9. Review | `review.md`, `traceability.md` | pending |
+| 10. Release | `release-notes.md` | pending |
+| 11. Learning | `retrospective.md` | pending |
+
+## Skips
+
+- None.
+
+## Blocks
+
+- None.
+
+## Hand-off notes
+
+- 2026-04-28 (codex): Planned v0.5 through Stage 6. Recommended implementation order is branch strategy decision, package contract, release notes configuration, release readiness check, manual GitHub Release workflow, package publish path, operator guide, public docs/product page update, dry run, then release readiness verification.
+
+## Open clarifications
+
+- [ ] CLAR-V05-001 — Confirm whether v0.5 should keep Shape A with `release/vX.Y.Z` branches or adopt Shape B with a permanent `develop` branch.
+- [ ] CLAR-V05-002 — Confirm the first GitHub Package type, package name, scope, visibility, and contents.
+- [ ] CLAR-V05-003 — Confirm whether the first publish should be draft/pre-release only before a stable GitHub Release and package are published.


### PR DESCRIPTION
## Summary
- Add a canonical v0.5 planning spec under `specs/version-0-5-plan/` through Stage 6 tasks.
- Scope v0.5 around release branching strategy, GitHub Releases, GitHub Packages, package contract, and release operator workflow.
- Link the README roadmap v0.5 row to the new task plan.

## Verification
- `npm run check:specs`
- `npm run check:traceability`
- `npm run check:links`
- `npm run verify`

## Notes
- This is a planning PR only. Implementation remains pending in `workflow-state.md`.
- Open clarifications remain on Shape A vs Shape B, first GitHub Package type/name/scope/visibility/contents, and whether the first publish should be draft/pre-release only.
- Research cites current GitHub docs for Releases, generated release notes, and publishing packages from GitHub Actions.