### PR TITLE
feat(quality): add stage-aware KPI scoring

### DIFF
--- a/.claude/skills/quality-metrics/SKILL.md
+++ b/.claude/skills/quality-metrics/SKILL.md
@@ -37,17 +37,20 @@ npm run quality:metrics -- --json
 - EARS coverage for functional requirements.
 - Open blockers and clarifications in workflow state.
 - QA checklist volume and gap/nonconformity counts under `quality/`.
+- Stage-aware score so future lifecycle evidence is not treated as a defect while work is still in progress.
 
 ## Reporting
 
 Summarize:
 
-- overall workflow score,
+- overall workflow score and stage-aware score,
 - lowest-scoring workflow KPIs,
 - active blockers and open clarifications,
 - missing frontmatter or documentation hygiene signals,
 - QA checklist gaps and nonconformities,
 - whether the result is a deterministic KPI snapshot or a full QA readiness review.
+
+Use `docs/quality-metrics.md` when explaining what a metric means, what action it supports, and what it must not be used to infer.
 
 ## Do Not
 

--- a/docs/quality-framework.md
+++ b/docs/quality-framework.md
@@ -28,7 +28,9 @@ Use the deterministic metrics script when a user asks for current project qualit
 npm run quality:metrics
 ```
 
-The report summarizes workflow deliverable completion, artifact presence, required frontmatter coverage, requirement downstream coverage, test coverage, EARS usage, QA checklist gaps, blockers, and open clarifications. Scope to one feature with `npm run quality:metrics -- --feature <feature-slug>` or emit machine-readable output with `npm run quality:metrics -- --json`.
+The report summarizes stage-aware workflow health, lifecycle deliverable progress, artifact presence, required frontmatter coverage, requirement downstream coverage, test coverage, EARS usage, QA checklist gaps, blockers, and open clarifications. Scope to one feature with `npm run quality:metrics -- --feature <feature-slug>` or emit machine-readable output with `npm run quality:metrics -- --json`.
+
+Interpret metric meaning, decision use, and misuse warnings with [`docs/quality-metrics.md`](quality-metrics.md).
 
 The KPI snapshot is evidence for a quality review, not a replacement for the stage quality gate or critic-agent review.
 

--- a/docs/quality-metrics.md
+++ b/docs/quality-metrics.md
@@ -1,0 +1,63 @@
+---
+title: "Quality Metrics"
+folder: "docs"
+description: "Interpretation guide for deterministic quality KPI reports."
+entry_point: false
+---
+# Quality Metrics
+
+`npm run quality:metrics` reports deterministic repository health signals from local artifacts. It is a quality-status snapshot, not a productivity score, certification result, or replacement for human acceptance.
+
+## How to run
+
+```bash
+npm run quality:metrics
+```
+
+Scope to one workflow:
+
+```bash
+npm run quality:metrics -- --feature <feature-slug>
+```
+
+Use JSON for tooling:
+
+```bash
+npm run quality:metrics -- --json
+```
+
+## Metric interpretation
+
+| Metric | Meaning | Use it for | Do not use it for | Typical action |
+|---|---|---|---|---|
+| Overall workflow score | Average of each workflow's stage-aware score. | Repository-level health trend and triage. | Comparing people, teams, or velocity. | Inspect low-scoring workflow rows before acting. |
+| Stage score | Evidence expected by the workflow's current stage. Future stages are not treated as defects. | Deciding whether the active stage has enough evidence to proceed. | Claiming the whole lifecycle is complete. | Fill missing current-stage artifacts, trace links, or required metadata. |
+| Lifecycle artifacts | Completion across all canonical lifecycle artifacts. | Understanding total lifecycle progress. | Penalizing active features that have not reached later stages. | Use as progress context, not a readiness gate. |
+| Expected artifacts | Completion for artifacts expected up to the current stage. | Current-stage readiness. | Hiding skipped artifacts without rationale. | Create or complete the current stage artifact, or document an allowed skip. |
+| Frontmatter | Workflow artifacts with required metadata. | Mechanical traceability and automation readiness. | Judging artifact content quality. | Add missing frontmatter fields and rerun `npm run check:frontmatter`. |
+| Req chain | Requirement links expected by the current stage: specs at Specification, tasks at Tasks, tests at Testing. | Detecting traceability gaps at the right time. | Requiring tests before the Testing stage. | Add missing `Satisfies:` or `Requirement:` links in the owning artifact. |
+| Test coverage | Requirements with downstream test IDs once Testing is expected. | Testing-stage readiness and review preparation. | Measuring runtime code coverage or test quality. | Add test-plan/report entries mapped to requirement IDs. |
+| EARS | Functional requirements with EARS-style structure once Requirements is expected. | Requirements quality and testability. | Guaranteeing requirements are complete or correct. | Rewrite vague requirements before downstream work proceeds. |
+| Blocks | Explicit blockers in workflow state. | Escalation and planning. | Treating absence of blockers as proof of readiness. | Resolve, owner, or escalate the blocker. |
+| Clarifications | Open questions in workflow state. | Human decision queue. | Deferring unanswered scope or requirement gaps. | Answer or convert to a tracked requirement/risk. |
+| QA checklist gaps | `gap` and `nonconformity` statuses under `quality/`. | QA readiness and corrective-action planning. | ISO certification claims. | Assign owners, due dates, and effectiveness checks. |
+
+## Stage-aware scoring
+
+Stage score avoids false negatives while a workflow is legitimately in progress:
+
+- before Requirements, EARS and downstream traceability are not scored;
+- at Specification, requirement-to-spec links are expected;
+- at Tasks, requirement-to-task links are expected;
+- at Testing and later, requirement-to-test links are expected;
+- when a workflow is `done`, all lifecycle evidence is expected.
+
+The lifecycle artifact percentage remains visible so readers can still see total progress across all 11 stages.
+
+## Guardrails
+
+- Metrics are local repository evidence only.
+- Metrics do not measure individual productivity.
+- Metrics do not replace quality gates, critic review, stage-owner judgment, or release acceptance.
+- Metrics do not grant ISO 9001 certification or external audit approval.
+- Thresholds are project policy. Treat hard pass/fail thresholds as configuration, not universal truth.

--- a/docs/scripts/README.md
+++ b/docs/scripts/README.md
@@ -52,6 +52,8 @@ Use JSON when another tool needs to consume the metrics:
 npm run quality:metrics -- --json
 ```
 
+Metric interpretation guidance lives in `docs/quality-metrics.md`. The stage score is stage-aware: future lifecycle evidence is not treated as a defect while a workflow is still in progress.
+
 ## TypeScript and Tests
 
 Repository scripts are TypeScript files executed with `tsx`.

--- a/docs/scripts/lib/quality-metrics/README.md
+++ b/docs/scripts/lib/quality-metrics/README.md
@@ -16,13 +16,19 @@ entry_point: true
 
 - [QualityMetricOptions](type-aliases/QualityMetricOptions.md)
 - [QualityMetrics](type-aliases/QualityMetrics.md)
+- [TraceabilityCoverageInput](type-aliases/TraceabilityCoverageInput.md)
+- [TraceabilityExpectation](type-aliases/TraceabilityExpectation.md)
 - [WorkflowArtifacts](type-aliases/WorkflowArtifacts.md)
 - [WorkflowMetric](type-aliases/WorkflowMetric.md)
 
 ## Functions
 
 - [collectQualityMetrics](functions/collectQualityMetrics.md)
+- [completeArtifactsFor](functions/completeArtifactsFor.md)
 - [completeCanonicalArtifacts](functions/completeCanonicalArtifacts.md)
+- [expectedArtifactsForStage](functions/expectedArtifactsForStage.md)
 - [markdownTableCells](functions/markdownTableCells.md)
 - [renderQualityMetrics](functions/renderQualityMetrics.md)
 - [rtmLinksFromRow](functions/rtmLinksFromRow.md)
+- [stageTraceabilityCoverage](functions/stageTraceabilityCoverage.md)
+- [traceabilityExpectation](functions/traceabilityExpectation.md)

--- a/docs/scripts/lib/quality-metrics/functions/completeArtifactsFor.md
+++ b/docs/scripts/lib/quality-metrics/functions/completeArtifactsFor.md
@@ -1,0 +1,31 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/quality-metrics](../README.md) / completeArtifactsFor
+
+# Function: completeArtifactsFor()
+
+> **completeArtifactsFor**(`expectedArtifacts`, `artifacts`): `number`
+
+Count expected artifacts marked complete or skipped.
+
+## Parameters
+
+### expectedArtifacts
+
+`string`[]
+
+Stage-aware artifact names.
+
+### artifacts
+
+[`WorkflowArtifacts`](../type-aliases/WorkflowArtifacts.md)
+
+Workflow-state artifact status map.
+
+## Returns
+
+`number`
+
+Count of expected artifacts marked `complete` or `skipped`.

--- a/docs/scripts/lib/quality-metrics/functions/expectedArtifactsForStage.md
+++ b/docs/scripts/lib/quality-metrics/functions/expectedArtifactsForStage.md
@@ -1,0 +1,31 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/quality-metrics](../README.md) / expectedArtifactsForStage
+
+# Function: expectedArtifactsForStage()
+
+> **expectedArtifactsForStage**(`currentStage`, `workflowStatus`): `string`[]
+
+Return canonical artifacts expected by the current workflow stage.
+
+## Parameters
+
+### currentStage
+
+`string`
+
+Workflow state's current stage.
+
+### workflowStatus
+
+`string`
+
+Workflow state's status.
+
+## Returns
+
+`string`[]
+
+Canonical artifacts expected at or before the current stage.

--- a/docs/scripts/lib/quality-metrics/functions/stageTraceabilityCoverage.md
+++ b/docs/scripts/lib/quality-metrics/functions/stageTraceabilityCoverage.md
@@ -1,0 +1,25 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/quality-metrics](../README.md) / stageTraceabilityCoverage
+
+# Function: stageTraceabilityCoverage()
+
+> **stageTraceabilityCoverage**(`input`): `number`
+
+Score only the traceability links expected by the current workflow stage.
+
+## Parameters
+
+### input
+
+[`TraceabilityCoverageInput`](../type-aliases/TraceabilityCoverageInput.md)
+
+Requirement coverage counts and stage expectation flags.
+
+## Returns
+
+`number`
+
+Stage-aware traceability coverage percentage.

--- a/docs/scripts/lib/quality-metrics/functions/traceabilityExpectation.md
+++ b/docs/scripts/lib/quality-metrics/functions/traceabilityExpectation.md
@@ -1,0 +1,31 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/quality-metrics](../README.md) / traceabilityExpectation
+
+# Function: traceabilityExpectation()
+
+> **traceabilityExpectation**(`currentStage`, `workflowStatus`): [`TraceabilityExpectation`](../type-aliases/TraceabilityExpectation.md)
+
+Decide which traceability links are expected at the current stage.
+
+## Parameters
+
+### currentStage
+
+`string`
+
+Workflow state's current stage.
+
+### workflowStatus
+
+`string`
+
+Workflow state's status.
+
+## Returns
+
+[`TraceabilityExpectation`](../type-aliases/TraceabilityExpectation.md)
+
+Expected downstream traceability surfaces.

--- a/docs/scripts/lib/quality-metrics/type-aliases/TraceabilityCoverageInput.md
+++ b/docs/scripts/lib/quality-metrics/type-aliases/TraceabilityCoverageInput.md
@@ -1,0 +1,39 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/quality-metrics](../README.md) / TraceabilityCoverageInput
+
+# Type Alias: TraceabilityCoverageInput
+
+> **TraceabilityCoverageInput** = `object`
+
+## Properties
+
+### expectation
+
+> **expectation**: [`TraceabilityExpectation`](TraceabilityExpectation.md)
+
+***
+
+### requirements
+
+> **requirements**: `string`[]
+
+***
+
+### requirementsWithSpec
+
+> **requirementsWithSpec**: `string`[]
+
+***
+
+### requirementsWithTasks
+
+> **requirementsWithTasks**: `string`[]
+
+***
+
+### requirementsWithTests
+
+> **requirementsWithTests**: `string`[]

--- a/docs/scripts/lib/quality-metrics/type-aliases/TraceabilityExpectation.md
+++ b/docs/scripts/lib/quality-metrics/type-aliases/TraceabilityExpectation.md
@@ -1,0 +1,27 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/quality-metrics](../README.md) / TraceabilityExpectation
+
+# Type Alias: TraceabilityExpectation
+
+> **TraceabilityExpectation** = `object`
+
+## Properties
+
+### specs
+
+> **specs**: `boolean`
+
+***
+
+### tasks
+
+> **tasks**: `boolean`
+
+***
+
+### tests
+
+> **tests**: `boolean`

--- a/docs/scripts/lib/quality-metrics/type-aliases/WorkflowMetric.md
+++ b/docs/scripts/lib/quality-metrics/type-aliases/WorkflowMetric.md
@@ -42,13 +42,25 @@
 
 > **artifactsComplete**: `number`
 
+#### artifactsCompleteForStage
+
+> **artifactsCompleteForStage**: `number`
+
 #### artifactsExpected
 
 > **artifactsExpected**: `number`
 
+#### artifactsExpectedForStage
+
+> **artifactsExpectedForStage**: `number`
+
 #### artifactsPresent
 
 > **artifactsPresent**: `number`
+
+#### artifactsPresentForStage
+
+> **artifactsPresentForStage**: `number`
 
 #### artifactsWithFrontmatter
 
@@ -88,6 +100,24 @@
 
 ***
 
+### earsExpected
+
+> **earsExpected**: `boolean`
+
+***
+
+### expectedArtifactCompletion
+
+> **expectedArtifactCompletion**: `number`
+
+***
+
+### expectedArtifactPresence
+
+> **expectedArtifactPresence**: `number`
+
+***
+
 ### feature
 
 > **feature**: `string`
@@ -118,6 +148,18 @@
 
 ***
 
+### stageScore
+
+> **stageScore**: `number`
+
+***
+
+### stageTraceabilityCoverage
+
+> **stageTraceabilityCoverage**: `number`
+
+***
+
 ### status
 
 > **status**: `string`
@@ -127,3 +169,9 @@
 ### testCoverage
 
 > **testCoverage**: `number`
+
+***
+
+### testCoverageExpected
+
+> **testCoverageExpected**: `boolean`

--- a/docs/sink.md
+++ b/docs/sink.md
@@ -15,6 +15,7 @@ Where every markdown artifact in this kit lives, who owns it, and how it evolves
 │   ├── specorator.md                          # workflow definition (read first)
 │   ├── workflow-overview.md                 # one-page cheat sheet
 │   ├── quality-framework.md                 # quality dimensions, gates, DoD
+│   ├── quality-metrics.md                   # deterministic KPI interpretation guide
 │   ├── traceability.md                      # ID scheme REQ → SPEC → T → code → TEST
 │   ├── ears-notation.md                     # EARS reference
 │   ├── sink.md                              # this file

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -48,6 +48,8 @@ Use JSON when another tool needs to consume the metrics:
 npm run quality:metrics -- --json
 ```
 
+Metric interpretation guidance lives in `docs/quality-metrics.md`. The stage score is stage-aware: future lifecycle evidence is not treated as a defect while a workflow is still in progress.
+
 ## TypeScript and Tests
 
 Repository scripts are TypeScript files executed with `tsx`.

--- a/scripts/lib/quality-metrics.ts
+++ b/scripts/lib/quality-metrics.ts
@@ -11,6 +11,7 @@ import {
 } from "./repo.js";
 import {
   canonicalArtifacts,
+  stageArtifacts,
   traceabilityIdPattern,
   traceabilityItemHeadingPattern,
 } from "./workflow-schema.js";
@@ -25,18 +26,27 @@ export type WorkflowMetric = {
   path: string;
   status: string;
   currentStage: string;
+  stageScore: number;
   artifactCompletion: number;
   artifactPresence: number;
+  expectedArtifactCompletion: number;
+  expectedArtifactPresence: number;
   frontmatterCoverage: number;
   requirementCoverage: number;
+  stageTraceabilityCoverage: number;
   testCoverage: number;
+  testCoverageExpected: boolean;
   earsCoverage: number;
+  earsExpected: boolean;
   openClarifications: number;
   blockers: number;
   counts: {
     artifactsExpected: number;
+    artifactsExpectedForStage: number;
     artifactsComplete: number;
+    artifactsCompleteForStage: number;
     artifactsPresent: number;
+    artifactsPresentForStage: number;
     artifactsWithFrontmatter: number;
     requirements: number;
     requirementsWithSpec: number;
@@ -124,16 +134,7 @@ export function collectQualityMetrics(options: QualityMetricOptions = {}): Quali
       qualityReviews: qualityReviewCount(),
       checklistItems,
       checklistGaps,
-      overallScore: average(
-        workflows.flatMap((workflow) => [
-          workflow.artifactCompletion,
-          workflow.artifactPresence,
-          workflow.frontmatterCoverage,
-          workflow.requirementCoverage,
-          workflow.testCoverage,
-          workflow.earsCoverage,
-        ]),
-      ),
+      overallScore: average(workflows.map((workflow) => workflow.stageScore)),
     },
     workflows,
     signals: {
@@ -170,12 +171,12 @@ export function renderQualityMetrics(metrics: QualityMetrics): string {
     "",
     "## Workflow deliverables",
     "",
-    "| Feature | Stage | Status | Artifacts | Presence | Frontmatter | Req chain | Test coverage | EARS | Blocks | Clarifications |",
-    "|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|",
+    "| Feature | Stage | Status | Stage score | Lifecycle artifacts | Expected artifacts | Frontmatter | Req chain | Test coverage | EARS | Blocks | Clarifications |",
+    "|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
   ];
 
   if (metrics.workflows.length === 0) {
-    lines.push("| _None found_ |  |  |  |  |  |  |  |  |  |  |");
+    lines.push("| _None found_ |  |  |  |  |  |  |  |  |  |  |  |");
   } else {
     for (const workflow of metrics.workflows) {
       lines.push(
@@ -183,12 +184,13 @@ export function renderQualityMetrics(metrics: QualityMetrics): string {
           workflow.feature,
           workflow.currentStage,
           workflow.status,
+          formatPercent(workflow.stageScore),
           formatPercent(workflow.artifactCompletion),
-          formatPercent(workflow.artifactPresence),
+          formatPercent(workflow.expectedArtifactCompletion),
           formatPercent(workflow.frontmatterCoverage),
           formatPercent(workflow.requirementCoverage),
-          formatPercent(workflow.testCoverage),
-          formatPercent(workflow.earsCoverage),
+          workflow.testCoverageExpected ? formatPercent(workflow.testCoverage) : "not expected yet",
+          workflow.earsExpected ? formatPercent(workflow.earsCoverage) : "not expected yet",
           String(workflow.blockers),
           String(workflow.openClarifications),
         ].join(" | ").replace(/^/, "| ").replace(/$/, " |"),
@@ -226,39 +228,69 @@ function readWorkflowMetric(statePath: string): WorkflowMetric | null {
   const artifacts = (state.artifacts || {}) as WorkflowArtifacts;
   const featureDir = path.dirname(statePath);
   const artifactNames = canonicalArtifacts;
+  const currentStage = String(state.current_stage || "unknown");
+  const workflowStatus = String(state.status || "unknown");
+  const expectedArtifacts = expectedArtifactsForStage(currentStage, workflowStatus);
   const existingArtifacts = artifactNames.filter((artifact) => fs.existsSync(path.join(featureDir, artifact)));
+  const existingExpectedArtifacts = expectedArtifacts.filter((artifact) => fs.existsSync(path.join(featureDir, artifact)));
   const artifactsWithFrontmatter = existingArtifacts.filter((artifact) =>
     Boolean(extractFrontmatter(readText(path.join(featureDir, artifact)))),
   );
   const completeArtifacts = completeCanonicalArtifacts(artifacts);
+  const completeExpectedArtifacts = completeArtifactsFor(expectedArtifacts, artifacts);
   const registry = collectTraceability(featureDir);
   const requirements = [...registry.reqs];
   const requirementsWithSpec = requirements.filter((id) => (registry.specsByReq.get(id)?.size || 0) > 0);
   const requirementsWithTasks = requirements.filter((id) => (registry.tasksByReq.get(id)?.size || 0) > 0);
   const requirementsWithTests = requirements.filter((id) => (registry.testsByReq.get(id)?.size || 0) > 0);
+  const expectation = traceabilityExpectation(currentStage, workflowStatus);
+  const requirementCoverage = stageTraceabilityCoverage({
+    requirements,
+    requirementsWithSpec,
+    requirementsWithTasks,
+    requirementsWithTests,
+    expectation,
+  });
+  const testCoverageExpected = expectation.tests;
+  const earsExpected = stageReached(currentStage, workflowStatus, "requirements");
+  const expectedArtifactCompletion = ratio(completeExpectedArtifacts, expectedArtifacts.length);
+  const expectedArtifactPresence = ratio(existingExpectedArtifacts.length, expectedArtifacts.length);
+  const earsCoverage = collectEarsCoverage(featureDir);
+  const scoredSignals = [
+    expectedArtifactCompletion,
+    expectedArtifactPresence,
+    ratio(artifactsWithFrontmatter.length, existingArtifacts.length),
+    requirementCoverage,
+  ];
+  if (earsExpected) scoredSignals.push(earsCoverage);
 
   return {
     feature,
     area,
     path: relativeToRoot(statePath),
-    status: String(state.status || "unknown"),
-    currentStage: String(state.current_stage || "unknown"),
+    status: workflowStatus,
+    currentStage,
+    stageScore: average(scoredSignals),
     artifactCompletion: ratio(completeArtifacts, artifactNames.length),
     artifactPresence: ratio(existingArtifacts.length, artifactNames.length),
+    expectedArtifactCompletion,
+    expectedArtifactPresence,
     frontmatterCoverage: ratio(artifactsWithFrontmatter.length, existingArtifacts.length),
-    requirementCoverage: average([
-      ratio(requirementsWithSpec.length, requirements.length),
-      ratio(requirementsWithTasks.length, requirements.length),
-      ratio(requirementsWithTests.length, requirements.length),
-    ]),
+    requirementCoverage,
+    stageTraceabilityCoverage: requirementCoverage,
     testCoverage: ratio(requirementsWithTests.length, requirements.length),
-    earsCoverage: collectEarsCoverage(featureDir),
+    testCoverageExpected,
+    earsCoverage,
+    earsExpected,
     openClarifications: sectionItemCount(text, "Open clarifications"),
     blockers: sectionItemCount(text, "Blocks"),
     counts: {
       artifactsExpected: artifactNames.length,
+      artifactsExpectedForStage: expectedArtifacts.length,
       artifactsComplete: completeArtifacts,
+      artifactsCompleteForStage: completeExpectedArtifacts,
       artifactsPresent: existingArtifacts.length,
+      artifactsPresentForStage: existingExpectedArtifacts.length,
       artifactsWithFrontmatter: artifactsWithFrontmatter.length,
       requirements: requirements.length,
       requirementsWithSpec: requirementsWithSpec.length,
@@ -267,6 +299,89 @@ function readWorkflowMetric(statePath: string): WorkflowMetric | null {
       tests: registry.tests.size,
     },
   };
+}
+
+export type TraceabilityExpectation = {
+  specs: boolean;
+  tasks: boolean;
+  tests: boolean;
+};
+
+export type TraceabilityCoverageInput = {
+  requirements: string[];
+  requirementsWithSpec: string[];
+  requirementsWithTasks: string[];
+  requirementsWithTests: string[];
+  expectation: TraceabilityExpectation;
+};
+
+/**
+ * Return canonical artifacts expected by the current workflow stage.
+ *
+ * @param currentStage - Workflow state's current stage.
+ * @param workflowStatus - Workflow state's status.
+ * @returns Canonical artifacts expected at or before the current stage.
+ */
+export function expectedArtifactsForStage(currentStage: string, workflowStatus: string): string[] {
+  if (workflowStatus === "done") return [...canonicalArtifacts];
+  const stageIndex = stageIndexOf(currentStage);
+  if (stageIndex === -1) return [...canonicalArtifacts];
+  return stageArtifacts.slice(0, stageIndex + 1).flatMap(([, artifacts]) => artifacts);
+}
+
+/**
+ * Count expected artifacts marked complete or skipped.
+ *
+ * @param expectedArtifacts - Stage-aware artifact names.
+ * @param artifacts - Workflow-state artifact status map.
+ * @returns Count of expected artifacts marked `complete` or `skipped`.
+ */
+export function completeArtifactsFor(expectedArtifacts: string[], artifacts: WorkflowArtifacts): number {
+  return expectedArtifacts.filter((artifact) => {
+    const status = artifacts[artifact];
+    return status === "complete" || status === "skipped";
+  }).length;
+}
+
+/**
+ * Decide which traceability links are expected at the current stage.
+ *
+ * @param currentStage - Workflow state's current stage.
+ * @param workflowStatus - Workflow state's status.
+ * @returns Expected downstream traceability surfaces.
+ */
+export function traceabilityExpectation(currentStage: string, workflowStatus: string): TraceabilityExpectation {
+  return {
+    specs: stageReached(currentStage, workflowStatus, "specification"),
+    tasks: stageReached(currentStage, workflowStatus, "tasks"),
+    tests: stageReached(currentStage, workflowStatus, "testing"),
+  };
+}
+
+/**
+ * Score only the traceability links expected by the current workflow stage.
+ *
+ * @param input - Requirement coverage counts and stage expectation flags.
+ * @returns Stage-aware traceability coverage percentage.
+ */
+export function stageTraceabilityCoverage(input: TraceabilityCoverageInput): number {
+  const scores: number[] = [];
+  if (input.expectation.specs) scores.push(ratio(input.requirementsWithSpec.length, input.requirements.length));
+  if (input.expectation.tasks) scores.push(ratio(input.requirementsWithTasks.length, input.requirements.length));
+  if (input.expectation.tests) scores.push(ratio(input.requirementsWithTests.length, input.requirements.length));
+  return scores.length === 0 ? 100 : average(scores);
+}
+
+function stageReached(currentStage: string, workflowStatus: string, targetStage: string): boolean {
+  if (workflowStatus === "done") return true;
+  const currentIndex = stageIndexOf(currentStage);
+  const targetIndex = stageIndexOf(targetStage);
+  if (currentIndex === -1 || targetIndex === -1) return false;
+  return currentIndex >= targetIndex;
+}
+
+function stageIndexOf(stage: string): number {
+  return stageArtifacts.findIndex(([stageName]) => stageName === stage);
 }
 
 function collectTraceability(featureDir: string): IdRegistry {

--- a/specs/version-0-4-plan/implementation-log.md
+++ b/specs/version-0-4-plan/implementation-log.md
@@ -1,0 +1,34 @@
+---
+id: IMPL-LOG-V04-001
+title: Version 0.4 implementation log
+stage: implementation
+feature: version-0-4-plan
+status: in-progress
+owner: dev
+inputs:
+  - TASKS-V04-001
+created: 2026-04-28
+updated: 2026-04-28
+---
+
+# Implementation log - Version 0.4
+
+## Task T-V04-005 - Workflow metrics report
+
+- Extended `scripts/lib/quality-metrics.ts` with stage-aware scoring.
+- Kept full lifecycle artifact progress visible while excluding future-stage evidence from the stage score.
+- Rendered test and EARS coverage as `not expected yet` when the workflow has not reached the relevant stage.
+- Added regression tests for stage-aware artifact and traceability expectations.
+
+## Task T-V04-007 - Metrics interpretation
+
+- Added `docs/quality-metrics.md` with metric meaning, decision use, misuse warnings, and typical actions.
+- Linked the interpretation guide from `docs/quality-framework.md`, `scripts/README.md`, and the `quality-metrics` skill.
+
+## Verification
+
+- `npm run typecheck:scripts`
+- `npm run test:scripts`
+- `npm run quality:metrics`
+- `npm run quality:metrics -- --feature=version-0-4-plan`
+- `npm run verify`

--- a/specs/version-0-4-plan/workflow-state.md
+++ b/specs/version-0-4-plan/workflow-state.md
@@ -4,7 +4,7 @@ area: V04
 current_stage: implementation
 status: active
 last_updated: 2026-04-28
-last_agent: planner
+last_agent: codex
 artifacts:
   idea.md: complete
   research.md: complete
@@ -12,7 +12,7 @@ artifacts:
   design.md: complete
   spec.md: complete
   tasks.md: complete
-  implementation-log.md: pending
+  implementation-log.md: in-progress
   test-plan.md: pending
   test-report.md: pending
   review.md: pending
@@ -33,7 +33,7 @@ artifacts:
 | 4. Design | `design.md` | complete |
 | 5. Specification | `spec.md` | complete |
 | 6. Tasks | `tasks.md` | complete |
-| 7. Implementation | `implementation-log.md` + code | pending |
+| 7. Implementation | `implementation-log.md` + code | in-progress |
 | 8. Testing | `test-plan.md`, `test-report.md` | pending |
 | 9. Review | `review.md`, `traceability.md` | pending |
 | 10. Release | `release-notes.md` | pending |
@@ -50,6 +50,7 @@ artifacts:
 ## Hand-off notes
 
 - 2026-04-28 (codex): Planned v0.4 through Stage 6. Recommended implementation order is v0.3 validation baseline confirmation, CI gate contract, PR CI workflow, CI readiness checks, metrics report, maturity documentation, public docs/product page review, then release readiness verification.
+- 2026-04-28 (codex): Started T-V04-005/T-V04-007 by making quality metrics stage-aware and adding metric interpretation guidance.
 
 ## Open clarifications
 

--- a/tests/scripts/quality-metrics.test.ts
+++ b/tests/scripts/quality-metrics.test.ts
@@ -3,9 +3,12 @@ import assert from "node:assert/strict";
 import {
   collectQualityMetrics,
   completeCanonicalArtifacts,
+  expectedArtifactsForStage,
   markdownTableCells,
   renderQualityMetrics,
   rtmLinksFromRow,
+  stageTraceabilityCoverage,
+  traceabilityExpectation,
 } from "../../scripts/lib/quality-metrics.js";
 
 test("collectQualityMetrics reports repository workflow KPIs", () => {
@@ -22,8 +25,19 @@ test("renderQualityMetrics includes the headline KPIs and attention signals", ()
   const report = renderQualityMetrics(metrics);
   assert.match(report, /^# Quality metrics/m);
   assert.match(report, /Overall workflow score/);
+  assert.match(report, /Stage score/);
   assert.match(report, /Workflow deliverables/);
   assert.match(report, /Attention signals/);
+});
+
+test("collectQualityMetrics scores active workflows by current stage", () => {
+  const metrics = collectQualityMetrics({ feature: "version-0-4-plan" });
+  const workflow = metrics.workflows[0];
+  assert.equal(workflow.currentStage, "implementation");
+  assert.equal(workflow.testCoverageExpected, false);
+  assert.equal(workflow.testCoverage, 0);
+  assert.equal(workflow.requirementCoverage, 100);
+  assert.equal(workflow.stageScore > workflow.artifactCompletion, true);
 });
 
 test("completeCanonicalArtifacts ignores non-lifecycle workflow-state keys", () => {
@@ -34,6 +48,29 @@ test("completeCanonicalArtifacts ignores non-lifecycle workflow-state keys", () 
       "custom-report.md": "complete",
     }),
     2,
+  );
+});
+
+test("stage-aware helpers derive expected artifacts and traceability links", () => {
+  assert.deepEqual(expectedArtifactsForStage("requirements", "active"), [
+    "idea.md",
+    "research.md",
+    "requirements.md",
+  ]);
+  assert.deepEqual(traceabilityExpectation("implementation", "active"), {
+    specs: true,
+    tasks: true,
+    tests: false,
+  });
+  assert.equal(
+    stageTraceabilityCoverage({
+      requirements: ["REQ-QMR-001"],
+      requirementsWithSpec: ["REQ-QMR-001"],
+      requirementsWithTasks: ["REQ-QMR-001"],
+      requirementsWithTests: [],
+      expectation: traceabilityExpectation("implementation", "active"),
+    }),
+    100,
   );
 });
 


### PR DESCRIPTION
## Summary
- Make `npm run quality:metrics` report a stage-aware `Stage score` so future lifecycle evidence is not treated as a defect while workflows are still in progress.
- Keep lifecycle artifact progress visible separately from expected current-stage evidence.
- Add `docs/quality-metrics.md` with metric meaning, decision use, misuse warnings, and typical actions.
- Record the v0.4 implementation progress for `T-V04-005` and `T-V04-007`.

## Verification
- `npm run typecheck:scripts`
- `npm run test:scripts`
- `npm run quality:metrics`
- `npm run quality:metrics -- --feature=version-0-4-plan`
- `npm run verify`

## Traceability
- `REQ-V04-003`, `REQ-V04-004`
- `T-V04-005`, `T-V04-007`

## Known limitations
- This does not add maturity levels yet (`T-V04-008`).
- This does not add trend snapshots or QA corrective-action metrics yet.