### PR TITLE
feat(roadmap): add evidence collector

### DIFF
--- a/docs/roadmap-management-track.md
+++ b/docs/roadmap-management-track.md
@@ -172,7 +172,7 @@ The track starts as Markdown-first workflow infrastructure. The highest-value fo
 | Tool | Purpose | Suggested command |
 |---|---|---|
 | Roadmap state check | Validate required roadmap artifacts, frontmatter, review dates, and append-only log structure | `npm run check:roadmaps` (implemented) |
-| Evidence collector | Summarize linked `specs/`, `projects/`, and `portfolio/` signals for `/roadmap:shape` and `/roadmap:review` | `npm run roadmap:evidence -- <slug>` |
+| Evidence collector | Summarize linked `specs/`, `projects/`, and `portfolio/` signals for `/roadmap:shape` and `/roadmap:review` | `npm run roadmap:evidence -- <slug>` (implemented) |
 | Communication digest | Generate audience-specific draft updates from `roadmap-board.md`, `delivery-plan.md`, and `stakeholder-map.md` | `npm run roadmap:digest -- <slug> <audience>` |
 | Staleness report | Flag old reviews, low-confidence `Now` items, missing success metrics, unresolved decisions, and stale stakeholder updates | `npm run roadmap:review-check` |
 | External export | Render a read-only roadmap summary for GitHub Pages or stakeholder packets | `npm run roadmap:export -- <slug>` |

--- a/docs/scripts/README.md
+++ b/docs/scripts/README.md
@@ -54,6 +54,20 @@ npm run quality:metrics -- --json
 
 Metric interpretation guidance lives in `docs/quality-metrics.md`. The stage score is stage-aware: future lifecycle evidence is not treated as a defect while a workflow is still in progress.
 
+## Roadmap Evidence
+
+Summarize the linked `specs/`, `projects/`, `portfolio/`, `discovery/`, and `quality/` artifacts named in a roadmap strategy:
+
+```bash
+npm run roadmap:evidence -- <roadmap-slug>
+```
+
+Use JSON when another agent or tool needs to consume the evidence report:
+
+```bash
+npm run roadmap:evidence -- <roadmap-slug> --json
+```
+
 ## TypeScript and Tests
 
 Repository scripts are TypeScript files executed with `tsx`.

--- a/docs/scripts/lib/roadmaps/README.md
+++ b/docs/scripts/lib/roadmaps/README.md
@@ -12,6 +12,11 @@ entry_point: true
 
 # lib/roadmaps
 
+## Type Aliases
+
+- [RoadmapEvidenceArtifact](type-aliases/RoadmapEvidenceArtifact.md)
+- [RoadmapEvidenceReport](type-aliases/RoadmapEvidenceReport.md)
+
 ## Variables
 
 - [requiredRoadmapStateSections](variables/requiredRoadmapStateSections.md)
@@ -22,7 +27,11 @@ entry_point: true
 
 ## Functions
 
+- [collectRoadmapEvidence](functions/collectRoadmapEvidence.md)
+- [linkedArtifactPathsFromStrategy](functions/linkedArtifactPathsFromStrategy.md)
+- [renderRoadmapEvidence](functions/renderRoadmapEvidence.md)
 - [roadmapStateDiagnostics](functions/roadmapStateDiagnostics.md)
 - [roadmapStateFiles](functions/roadmapStateFiles.md)
+- [summarizeEvidenceArtifact](functions/summarizeEvidenceArtifact.md)
 - [validateRoadmapStateData](functions/validateRoadmapStateData.md)
 - [validateRoadmapStateFile](functions/validateRoadmapStateFile.md)

--- a/docs/scripts/lib/roadmaps/functions/collectRoadmapEvidence.md
+++ b/docs/scripts/lib/roadmaps/functions/collectRoadmapEvidence.md
@@ -1,0 +1,29 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/roadmaps](../README.md) / collectRoadmapEvidence
+
+# Function: collectRoadmapEvidence()
+
+> **collectRoadmapEvidence**(`slug`): [`RoadmapEvidenceReport`](../type-aliases/RoadmapEvidenceReport.md)
+
+Collect linked artifact evidence for a roadmap.
+
+The collector reads `roadmaps/<slug>/roadmap-strategy.md`, extracts
+repository-local artifact links from backticked paths, and summarizes each
+linked file without modifying it.
+
+## Parameters
+
+### slug
+
+`string`
+
+Roadmap folder slug.
+
+## Returns
+
+[`RoadmapEvidenceReport`](../type-aliases/RoadmapEvidenceReport.md)
+
+Evidence report for the roadmap.

--- a/docs/scripts/lib/roadmaps/functions/linkedArtifactPathsFromStrategy.md
+++ b/docs/scripts/lib/roadmaps/functions/linkedArtifactPathsFromStrategy.md
@@ -1,0 +1,25 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/roadmaps](../README.md) / linkedArtifactPathsFromStrategy
+
+# Function: linkedArtifactPathsFromStrategy()
+
+> **linkedArtifactPathsFromStrategy**(`text`): `string`[]
+
+Extract repository-local artifact paths from a roadmap strategy document.
+
+## Parameters
+
+### text
+
+`string`
+
+Roadmap strategy Markdown.
+
+## Returns
+
+`string`[]
+
+Unique linked artifact paths.

--- a/docs/scripts/lib/roadmaps/functions/renderRoadmapEvidence.md
+++ b/docs/scripts/lib/roadmaps/functions/renderRoadmapEvidence.md
@@ -1,0 +1,25 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/roadmaps](../README.md) / renderRoadmapEvidence
+
+# Function: renderRoadmapEvidence()
+
+> **renderRoadmapEvidence**(`report`): `string`
+
+Render a roadmap evidence report as Markdown.
+
+## Parameters
+
+### report
+
+[`RoadmapEvidenceReport`](../type-aliases/RoadmapEvidenceReport.md)
+
+Evidence report.
+
+## Returns
+
+`string`
+
+Markdown report.

--- a/docs/scripts/lib/roadmaps/functions/summarizeEvidenceArtifact.md
+++ b/docs/scripts/lib/roadmaps/functions/summarizeEvidenceArtifact.md
@@ -1,0 +1,25 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/roadmaps](../README.md) / summarizeEvidenceArtifact
+
+# Function: summarizeEvidenceArtifact()
+
+> **summarizeEvidenceArtifact**(`artifactPath`): [`RoadmapEvidenceArtifact`](../type-aliases/RoadmapEvidenceArtifact.md)
+
+Summarize one linked roadmap evidence artifact.
+
+## Parameters
+
+### artifactPath
+
+`string`
+
+Repository-relative artifact path.
+
+## Returns
+
+[`RoadmapEvidenceArtifact`](../type-aliases/RoadmapEvidenceArtifact.md)
+
+Summary for the artifact.

--- a/docs/scripts/lib/roadmaps/type-aliases/RoadmapEvidenceArtifact.md
+++ b/docs/scripts/lib/roadmaps/type-aliases/RoadmapEvidenceArtifact.md
@@ -1,0 +1,57 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/roadmaps](../README.md) / RoadmapEvidenceArtifact
+
+# Type Alias: RoadmapEvidenceArtifact
+
+> **RoadmapEvidenceArtifact** = `object`
+
+## Properties
+
+### exists
+
+> **exists**: `boolean`
+
+***
+
+### kind
+
+> **kind**: `string`
+
+***
+
+### lastUpdated?
+
+> `optional` **lastUpdated?**: `string`
+
+***
+
+### path
+
+> **path**: `string`
+
+***
+
+### stage?
+
+> `optional` **stage?**: `string`
+
+***
+
+### status?
+
+> `optional` **status?**: `string`
+
+***
+
+### summary
+
+> **summary**: `string`
+
+***
+
+### title
+
+> **title**: `string`

--- a/docs/scripts/lib/roadmaps/type-aliases/RoadmapEvidenceReport.md
+++ b/docs/scripts/lib/roadmaps/type-aliases/RoadmapEvidenceReport.md
@@ -1,0 +1,45 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/roadmaps](../README.md) / RoadmapEvidenceReport
+
+# Type Alias: RoadmapEvidenceReport
+
+> **RoadmapEvidenceReport** = `object`
+
+## Properties
+
+### artifacts
+
+> **artifacts**: [`RoadmapEvidenceArtifact`](RoadmapEvidenceArtifact.md)[]
+
+***
+
+### generatedAt
+
+> **generatedAt**: `string`
+
+***
+
+### linkedArtifacts
+
+> **linkedArtifacts**: `string`[]
+
+***
+
+### roadmap
+
+> **roadmap**: `string`
+
+***
+
+### strategyPath
+
+> **strategyPath**: `string`
+
+***
+
+### warnings
+
+> **warnings**: `string`[]

--- a/docs/scripts/modules.md
+++ b/docs/scripts/modules.md
@@ -34,5 +34,6 @@
 - [lib/tasks](lib/tasks/README.md)
 - [lib/workflow-schema](lib/workflow-schema/README.md)
 - [quality-metrics](quality-metrics/README.md)
+- [roadmap-evidence](roadmap-evidence/README.md)
 - [test-scripts](test-scripts/README.md)
 - [verify](verify/README.md)

--- a/docs/scripts/roadmap-evidence/README.md
+++ b/docs/scripts/roadmap-evidence/README.md
@@ -1,0 +1,13 @@
+---
+title: "roadmap-evidence"
+folder: "docs/scripts/roadmap-evidence"
+description: "Entry point for generated API reference for the roadmap-evidence script."
+entry_point: true
+---
+[**agentic-workflow**](../README.md)
+
+***
+
+[agentic-workflow](../modules.md) / roadmap-evidence
+
+# roadmap-evidence

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "doctor": "tsx scripts/doctor.ts",
     "verify": "tsx scripts/verify.ts",
     "quality:metrics": "tsx scripts/quality-metrics.ts",
+    "roadmap:evidence": "tsx scripts/roadmap-evidence.ts",
     "typecheck:scripts": "tsc --project tsconfig.scripts.json --noEmit",
     "test:scripts": "tsx scripts/test-scripts.ts",
     "check:links": "tsx scripts/check-markdown-links.ts",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -50,6 +50,20 @@ npm run quality:metrics -- --json
 
 Metric interpretation guidance lives in `docs/quality-metrics.md`. The stage score is stage-aware: future lifecycle evidence is not treated as a defect while a workflow is still in progress.
 
+## Roadmap Evidence
+
+Summarize the linked `specs/`, `projects/`, `portfolio/`, `discovery/`, and `quality/` artifacts named in a roadmap strategy:
+
+```bash
+npm run roadmap:evidence -- <roadmap-slug>
+```
+
+Use JSON when another agent or tool needs to consume the evidence report:
+
+```bash
+npm run roadmap:evidence -- <roadmap-slug> --json
+```
+
 ## TypeScript and Tests
 
 Repository scripts are TypeScript files executed with `tsx`.

--- a/scripts/lib/roadmaps.ts
+++ b/scripts/lib/roadmaps.ts
@@ -117,7 +117,8 @@ export function collectRoadmapEvidence(slug: string): RoadmapEvidenceReport {
 export function linkedArtifactPathsFromStrategy(text: string): string[] {
   const paths = new Set<string>();
   for (const match of text.matchAll(/`((?:specs|projects|portfolio|discovery|quality)\/[^`]+\.md)`/g)) {
-    paths.add(match[1].replace(/\\/g, "/"));
+    const safePath = safeRepositoryArtifactPath(match[1]);
+    if (safePath) paths.add(safePath);
   }
   return [...paths].sort();
 }
@@ -129,13 +130,24 @@ export function linkedArtifactPathsFromStrategy(text: string): string[] {
  * @returns Summary for the artifact.
  */
 export function summarizeEvidenceArtifact(artifactPath: string): RoadmapEvidenceArtifact {
-  const absolutePath = path.join(repoRoot, artifactPath);
-  if (!fs.existsSync(absolutePath)) {
+  const safePath = safeRepositoryArtifactPath(artifactPath);
+  if (!safePath) {
     return {
       path: artifactPath,
       exists: false,
-      kind: evidenceKind(artifactPath),
+      kind: "invalid-artifact",
       title: path.basename(artifactPath),
+      summary: "Rejected unsafe linked artifact path.",
+    };
+  }
+
+  const absolutePath = path.join(repoRoot, safePath);
+  if (!fs.existsSync(absolutePath)) {
+    return {
+      path: safePath,
+      exists: false,
+      kind: evidenceKind(safePath),
+      title: path.basename(safePath),
       summary: "Missing linked artifact.",
     };
   }
@@ -143,10 +155,10 @@ export function summarizeEvidenceArtifact(artifactPath: string): RoadmapEvidence
   const text = readText(absolutePath);
   const frontmatter = extractFrontmatter(text);
   const data = frontmatter ? parseSimpleYaml(frontmatter.raw) : {};
-  const title = firstHeading(text) || String(data.title || path.basename(artifactPath));
-  const kind = evidenceKind(artifactPath);
+  const title = firstHeading(text) || String(data.title || path.basename(safePath));
+  const kind = evidenceKind(safePath);
 
-  if (artifactPath.endsWith("workflow-state.md")) {
+  if (safePath.endsWith("workflow-state.md")) {
     const artifacts = data.artifacts && typeof data.artifacts === "object" ? (data.artifacts as Record<string, unknown>) : {};
     const complete = Object.values(artifacts).filter((status) => status === "complete" || status === "skipped").length;
     const total = Object.keys(artifacts).length;
@@ -154,7 +166,7 @@ export function summarizeEvidenceArtifact(artifactPath: string): RoadmapEvidence
     const status = String(data.status || "unknown");
     const lastUpdated = String(data.last_updated || "unknown");
     return {
-      path: artifactPath,
+      path: safePath,
       exists: true,
       kind,
       title,
@@ -175,7 +187,7 @@ export function summarizeEvidenceArtifact(artifactPath: string): RoadmapEvidence
   ].filter(Boolean);
 
   return {
-    path: artifactPath,
+    path: safePath,
     exists: true,
     kind,
     title,
@@ -373,6 +385,16 @@ function validateRoadmapStateSections(rel: string, body: string): Diagnostic[] {
 
 function diagnostic(pathName: string, code: string, message: string): Diagnostic {
   return { path: pathName, code, message };
+}
+
+function safeRepositoryArtifactPath(artifactPath: string): string | null {
+  const normalized = artifactPath.replace(/\\/g, "/");
+  if (!/^(specs|projects|portfolio|discovery|quality)\//.test(normalized)) return null;
+  if (path.posix.isAbsolute(normalized) || normalized.split("/").includes("..")) return null;
+  const absolutePath = path.resolve(repoRoot, ...normalized.split("/"));
+  const relative = path.relative(repoRoot, absolutePath);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) return null;
+  return normalized;
 }
 
 function evidenceKind(artifactPath: string): string {

--- a/scripts/lib/roadmaps.ts
+++ b/scripts/lib/roadmaps.ts
@@ -6,6 +6,7 @@ import {
   parseSimpleYaml,
   readText,
   relativeToRoot,
+  repoRoot,
   walkFiles,
 } from "./repo.js";
 
@@ -21,6 +22,26 @@ export const roadmapDocuments = [
   ["decision_log", "decision-log.md"],
 ] as const;
 export const requiredRoadmapStateSections = ["Roadmap", "Documents", "Review history", "Hand-off notes"];
+
+export type RoadmapEvidenceArtifact = {
+  path: string;
+  exists: boolean;
+  kind: string;
+  title: string;
+  status?: string;
+  stage?: string;
+  lastUpdated?: string;
+  summary: string;
+};
+
+export type RoadmapEvidenceReport = {
+  roadmap: string;
+  strategyPath: string;
+  generatedAt: string;
+  linkedArtifacts: string[];
+  artifacts: RoadmapEvidenceArtifact[];
+  warnings: string[];
+};
 
 /**
  * Find roadmap state files under `roadmaps/<slug>/`.
@@ -42,6 +63,173 @@ export function roadmapStateFiles(): string[] {
  */
 export function roadmapStateDiagnostics(): Diagnostic[] {
   return roadmapStateFiles().flatMap((filePath) => validateRoadmapStateFile(filePath));
+}
+
+/**
+ * Collect linked artifact evidence for a roadmap.
+ *
+ * The collector reads `roadmaps/<slug>/roadmap-strategy.md`, extracts
+ * repository-local artifact links from backticked paths, and summarizes each
+ * linked file without modifying it.
+ *
+ * @param slug - Roadmap folder slug.
+ * @returns Evidence report for the roadmap.
+ */
+export function collectRoadmapEvidence(slug: string): RoadmapEvidenceReport {
+  const strategyPath = path.join(repoRoot, "roadmaps", slug, "roadmap-strategy.md");
+  const strategyRel = relativeToRoot(strategyPath);
+  const warnings: string[] = [];
+
+  if (!fs.existsSync(strategyPath)) {
+    return {
+      roadmap: slug,
+      strategyPath: strategyRel,
+      generatedAt: new Date().toISOString(),
+      linkedArtifacts: [],
+      artifacts: [],
+      warnings: [`${strategyRel} is missing`],
+    };
+  }
+
+  const strategyText = readText(strategyPath);
+  const linkedArtifacts = linkedArtifactPathsFromStrategy(strategyText);
+  const artifacts = linkedArtifacts.map((artifactPath) => summarizeEvidenceArtifact(artifactPath));
+  for (const artifact of artifacts) {
+    if (!artifact.exists) warnings.push(`${artifact.path} is linked but missing`);
+  }
+
+  return {
+    roadmap: slug,
+    strategyPath: strategyRel,
+    generatedAt: new Date().toISOString(),
+    linkedArtifacts,
+    artifacts,
+    warnings,
+  };
+}
+
+/**
+ * Extract repository-local artifact paths from a roadmap strategy document.
+ *
+ * @param text - Roadmap strategy Markdown.
+ * @returns Unique linked artifact paths.
+ */
+export function linkedArtifactPathsFromStrategy(text: string): string[] {
+  const paths = new Set<string>();
+  for (const match of text.matchAll(/`((?:specs|projects|portfolio|discovery|quality)\/[^`]+\.md)`/g)) {
+    paths.add(match[1].replace(/\\/g, "/"));
+  }
+  return [...paths].sort();
+}
+
+/**
+ * Summarize one linked roadmap evidence artifact.
+ *
+ * @param artifactPath - Repository-relative artifact path.
+ * @returns Summary for the artifact.
+ */
+export function summarizeEvidenceArtifact(artifactPath: string): RoadmapEvidenceArtifact {
+  const absolutePath = path.join(repoRoot, artifactPath);
+  if (!fs.existsSync(absolutePath)) {
+    return {
+      path: artifactPath,
+      exists: false,
+      kind: evidenceKind(artifactPath),
+      title: path.basename(artifactPath),
+      summary: "Missing linked artifact.",
+    };
+  }
+
+  const text = readText(absolutePath);
+  const frontmatter = extractFrontmatter(text);
+  const data = frontmatter ? parseSimpleYaml(frontmatter.raw) : {};
+  const title = firstHeading(text) || String(data.title || path.basename(artifactPath));
+  const kind = evidenceKind(artifactPath);
+
+  if (artifactPath.endsWith("workflow-state.md")) {
+    const artifacts = data.artifacts && typeof data.artifacts === "object" ? (data.artifacts as Record<string, unknown>) : {};
+    const complete = Object.values(artifacts).filter((status) => status === "complete" || status === "skipped").length;
+    const total = Object.keys(artifacts).length;
+    const stage = String(data.current_stage || "unknown");
+    const status = String(data.status || "unknown");
+    const lastUpdated = String(data.last_updated || "unknown");
+    return {
+      path: artifactPath,
+      exists: true,
+      kind,
+      title,
+      status,
+      stage,
+      lastUpdated,
+      summary: `${status} at ${stage}; ${complete}/${total} lifecycle artifacts complete; last updated ${lastUpdated}.`,
+    };
+  }
+
+  const status = scalarString(data.status);
+  const phase = scalarString(data.phase) || scalarString(data.current_phase);
+  const lastUpdated = scalarString(data.last_updated) || scalarString(data.date);
+  const summaryParts = [
+    status ? `status ${status}` : "",
+    phase ? `phase ${phase}` : "",
+    lastUpdated ? `updated ${lastUpdated}` : "",
+  ].filter(Boolean);
+
+  return {
+    path: artifactPath,
+    exists: true,
+    kind,
+    title,
+    status,
+    stage: phase,
+    lastUpdated,
+    summary: summaryParts.length > 0 ? `${summaryParts.join("; ")}.` : "Linked artifact exists; no state frontmatter summary available.",
+  };
+}
+
+/**
+ * Render a roadmap evidence report as Markdown.
+ *
+ * @param report - Evidence report.
+ * @returns Markdown report.
+ */
+export function renderRoadmapEvidence(report: RoadmapEvidenceReport): string {
+  const lines = [
+    `# Roadmap evidence - ${report.roadmap}`,
+    "",
+    `Generated: ${report.generatedAt}`,
+    `Strategy: \`${report.strategyPath}\``,
+    "",
+    "## Linked artifacts",
+    "",
+    "| Path | Kind | Status | Stage / phase | Last updated | Summary |",
+    "|---|---|---|---|---|---|",
+  ];
+
+  if (report.artifacts.length === 0) {
+    lines.push("| _None found_ |  |  |  |  |  |");
+  } else {
+    for (const artifact of report.artifacts) {
+      lines.push(
+        [
+          artifact.exists ? `\`${artifact.path}\`` : `\`${artifact.path}\` (missing)`,
+          artifact.kind,
+          artifact.status || "-",
+          artifact.stage || "-",
+          artifact.lastUpdated || "-",
+          artifact.summary,
+        ].join(" | ").replace(/^/, "| ").replace(/$/, " |"),
+      );
+    }
+  }
+
+  lines.push("", "## Warnings", "");
+  if (report.warnings.length === 0) {
+    lines.push("- None.");
+  } else {
+    lines.push(...report.warnings.map((warning) => `- ${warning}`));
+  }
+
+  return `${lines.join("\n")}\n`;
 }
 
 /**
@@ -185,6 +373,25 @@ function validateRoadmapStateSections(rel: string, body: string): Diagnostic[] {
 
 function diagnostic(pathName: string, code: string, message: string): Diagnostic {
   return { path: pathName, code, message };
+}
+
+function evidenceKind(artifactPath: string): string {
+  if (artifactPath.startsWith("specs/")) return artifactPath.endsWith("workflow-state.md") ? "feature-state" : "feature-artifact";
+  if (artifactPath.startsWith("projects/")) return artifactPath.endsWith("project-state.md") ? "project-state" : "project-artifact";
+  if (artifactPath.startsWith("portfolio/")) return "portfolio-artifact";
+  if (artifactPath.startsWith("discovery/")) return "discovery-artifact";
+  if (artifactPath.startsWith("quality/")) return "quality-artifact";
+  return "artifact";
+}
+
+function firstHeading(text: string): string | undefined {
+  const heading = text.match(/^#\s+(.+)$/m);
+  return heading?.[1]?.trim();
+}
+
+function scalarString(value: unknown): string | undefined {
+  if (value === undefined || value === null || typeof value === "object") return undefined;
+  return String(value);
 }
 
 function escapeRegExp(value: string): string {

--- a/scripts/roadmap-evidence.ts
+++ b/scripts/roadmap-evidence.ts
@@ -1,0 +1,22 @@
+import { collectRoadmapEvidence, renderRoadmapEvidence } from "./lib/roadmaps.js";
+
+const args = process.argv.slice(2);
+const json = args.includes("--json");
+const slug = args.find((arg) => !arg.startsWith("--"));
+
+if (!slug) {
+  console.error("usage: npm run roadmap:evidence -- <roadmap-slug> [--json]");
+  process.exit(1);
+}
+
+const report = collectRoadmapEvidence(slug);
+
+if (json) {
+  console.log(JSON.stringify(report, null, 2));
+} else {
+  console.log(renderRoadmapEvidence(report));
+}
+
+if (report.warnings.includes(`${report.strategyPath} is missing`)) {
+  process.exit(1);
+}

--- a/tests/scripts/roadmaps.test.ts
+++ b/tests/scripts/roadmaps.test.ts
@@ -72,9 +72,18 @@ test("roadmap evidence extracts linked artifact paths from strategy markdown", (
 | project | \`projects/client/deliverables-map.md\` | delivery |
 | ignored | \`templates/roadmap-state-template.md\` | template |
 | duplicate | \`specs/auth/workflow-state.md\` | duplicate |
+| traversal | \`specs/../../../../tmp/secret.md\` | unsafe |
 `);
 
   assert.deepEqual(paths, ["projects/client/deliverables-map.md", "specs/auth/workflow-state.md"]);
+});
+
+test("roadmap evidence rejects path traversal before filesystem reads", () => {
+  const artifact = summarizeEvidenceArtifact("specs/../../../../tmp/secret.md");
+
+  assert.equal(artifact.exists, false);
+  assert.equal(artifact.kind, "invalid-artifact");
+  assert.equal(artifact.summary, "Rejected unsafe linked artifact path.");
 });
 
 test("roadmap evidence summarizes missing linked artifacts", () => {

--- a/tests/scripts/roadmaps.test.ts
+++ b/tests/scripts/roadmaps.test.ts
@@ -1,6 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { validateRoadmapStateData } from "../../scripts/lib/roadmaps.js";
+import {
+  linkedArtifactPathsFromStrategy,
+  renderRoadmapEvidence,
+  summarizeEvidenceArtifact,
+  validateRoadmapStateData,
+} from "../../scripts/lib/roadmaps.js";
 
 test("roadmap state validation accepts ISO review dates and pending documents", () => {
   const diagnostics = validateRoadmapStateData(
@@ -57,6 +62,49 @@ test("roadmap state validation checks required document keys and statuses", () =
 
   assert.equal(diagnostics.some((diagnostic) => diagnostic.code === "ROADMAP_STATE_DOCUMENT_STATUS"), true);
   assert.equal(diagnostics.some((diagnostic) => diagnostic.message.includes("documents missing delivery_plan")), true);
+});
+
+test("roadmap evidence extracts linked artifact paths from strategy markdown", () => {
+  const paths = linkedArtifactPathsFromStrategy(`
+| Type | Path | Why |
+|---|---|---|
+| spec | \`specs/auth/workflow-state.md\` | state |
+| project | \`projects/client/deliverables-map.md\` | delivery |
+| ignored | \`templates/roadmap-state-template.md\` | template |
+| duplicate | \`specs/auth/workflow-state.md\` | duplicate |
+`);
+
+  assert.deepEqual(paths, ["projects/client/deliverables-map.md", "specs/auth/workflow-state.md"]);
+});
+
+test("roadmap evidence summarizes missing linked artifacts", () => {
+  const artifact = summarizeEvidenceArtifact("specs/not-a-real-feature/workflow-state.md");
+
+  assert.equal(artifact.exists, false);
+  assert.equal(artifact.kind, "feature-state");
+  assert.equal(artifact.summary, "Missing linked artifact.");
+});
+
+test("roadmap evidence renderer includes warnings", () => {
+  const markdown = renderRoadmapEvidence({
+    roadmap: "product",
+    strategyPath: "roadmaps/product/roadmap-strategy.md",
+    generatedAt: "2026-04-29T00:00:00.000Z",
+    linkedArtifacts: ["specs/missing/workflow-state.md"],
+    artifacts: [
+      {
+        path: "specs/missing/workflow-state.md",
+        exists: false,
+        kind: "feature-state",
+        title: "workflow-state.md",
+        summary: "Missing linked artifact.",
+      },
+    ],
+    warnings: ["specs/missing/workflow-state.md is linked but missing"],
+  });
+
+  assert.match(markdown, /Roadmap evidence - product/);
+  assert.match(markdown, /specs\/missing\/workflow-state\.md is linked but missing/);
 });
 
 function validState(): Record<string, unknown> {


### PR DESCRIPTION
## Summary
- Add `npm run roadmap:evidence -- <slug> [--json]` to summarize artifacts linked from `roadmaps/<slug>/roadmap-strategy.md`.
- Extract linked `specs/`, `projects/`, `portfolio/`, `discovery/`, and `quality/` Markdown paths and summarize their status/stage/date signals where available.
- Add Markdown and JSON renderers, unit coverage, user docs, generated script docs, and mark the evidence collector implemented in the roadmap methodology.

## Verification
- `npm run typecheck:scripts`
- `npm run test:scripts`
- `npm run verify`

## Notes
- The tool is read-only.
- Missing linked artifacts are reported as warnings in the evidence report; a missing roadmap strategy exits nonzero so agents do not shape/review from absent source context.