### PR TITLE
feat(sites): iterative product-page redesign

### DIFF
--- a/sites/index.html
+++ b/sites/index.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="Specorator is a spec-driven agentic development workflow that keeps humans in charge of intent while AI agents help move software through quality gates.">
-    <meta property="og:title" content="Specorator - Agentic Development Workflow">
-    <meta property="og:description" content="A spec-first workflow template for building software with humans and AI agents.">
+    <meta name="description" content="Specs first. Code second. Specorator is an open-source workflow template that keeps humans in charge of what to build while specialist AI agents handle how.">
+    <meta property="og:title" content="Specorator — Specs first. Code second.">
+    <meta property="og:description" content="An open-source, spec-driven workflow template for building software with humans and AI agents. v0.2 Foundation release.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://luis85.github.io/agentic-workflow/">
     <meta property="og:image" content="https://luis85.github.io/agentic-workflow/assets/specorator-workflow.svg">
@@ -35,25 +35,33 @@
     <main id="main">
       <section class="hero" aria-labelledby="hero-title">
         <div>
-          <p class="eyebrow">Spec-driven software with AI agents</p>
-          <h1 id="hero-title">Specorator</h1>
-          <p class="hero-copy">A ready-to-use workflow template that keeps humans in charge of what to build while AI agents help with the heavy lifting of how.</p>
+          <p class="eyebrow">
+            <span class="status-pill">v0.2 · Foundation release</span>
+            <span class="eyebrow-meta">Open-source · MIT · the <code>agentic-workflow</code> repo</span>
+          </p>
+          <h1 id="hero-title">Specs first.<br>Code second.</h1>
+          <p class="hero-copy">Most AI coding tools jump straight to writing code &mdash; often the <em>wrong</em> code. <strong>Specorator</strong> is a ready-to-use workflow template that flips it: you stay in charge of <em>what</em> to build, specialist AI agents handle <em>how</em>, and every decision is traceable.</p>
           <div class="hero-actions" aria-label="Primary actions">
-            <a class="button highlight" href="https://github.com/Luis85/agentic-workflow/blob/main/docs/specorator.md">Read the workflow</a>
-            <a class="button secondary" href="https://github.com/Luis85/agentic-workflow">View on GitHub</a>
+            <a class="button highlight" href="#start">Get started</a>
+            <a class="button secondary" href="https://github.com/Luis85/agentic-workflow/blob/main/docs/specorator.md">Read the workflow</a>
+            <a class="button ghost" href="https://github.com/Luis85/agentic-workflow" aria-label="View on GitHub">GitHub &rarr;</a>
           </div>
-          <div class="hero-proof" aria-label="Workflow highlights">
+          <div class="hero-quickstart" aria-label="One-line quickstart">
+            <span class="quickstart-prompt" aria-hidden="true">$</span>
+            <code>git clone https://github.com/Luis85/agentic-workflow.git my-project &amp;&amp; cd my-project &amp;&amp; claude</code>
+          </div>
+          <div class="hero-proof" aria-label="At a glance">
             <span class="proof-item">
               <span class="proof-value">11</span>
-              <span class="proof-label">Lifecycle stages</span>
+              <span class="proof-label">stages, idea&nbsp;&rarr;&nbsp;retro</span>
             </span>
             <span class="proof-item">
-              <span class="proof-value">1:1</span>
-              <span class="proof-label">Requirements to tests</span>
+              <span class="proof-value">10</span>
+              <span class="proof-label">conductor skills, pick your fit</span>
             </span>
             <span class="proof-item">
-              <span class="proof-value">PR</span>
-              <span class="proof-label">Worktree to verify gate</span>
+              <span class="proof-value">0</span>
+              <span class="proof-label">vendor lock-in &mdash; fork &amp; own</span>
             </span>
           </div>
         </div>
@@ -177,8 +185,8 @@
         </div>
         <div class="workflow" aria-label="Specorator workflow stages">
           <div class="workflow-row">
-            <div class="workflow-label">Discovery</div>
-            <div class="workflow-stages">
+            <div class="workflow-label">Discovery <span class="workflow-label-meta">optional</span></div>
+            <div class="workflow-stages discovery-stages">
               <span class="stage discovery">Frame</span>
               <span class="stage discovery">Diverge</span>
               <span class="stage discovery">Converge</span>
@@ -188,14 +196,19 @@
             </div>
           </div>
           <div class="workflow-row">
-            <div class="workflow-label">Lifecycle</div>
-            <div class="workflow-stages">
-              <span class="stage lifecycle">Idea</span>
-              <span class="stage lifecycle">Requirements</span>
-              <span class="stage lifecycle">Design</span>
-              <span class="stage lifecycle">Tasks</span>
-              <span class="stage lifecycle">Build + test</span>
-              <span class="stage gate">Review + release</span>
+            <div class="workflow-label">Lifecycle <span class="workflow-label-meta">11 stages</span></div>
+            <div class="workflow-stages lifecycle-stages">
+              <span class="stage lifecycle">1. Idea</span>
+              <span class="stage lifecycle">2. Research</span>
+              <span class="stage lifecycle">3. Requirements</span>
+              <span class="stage lifecycle">4. Design</span>
+              <span class="stage lifecycle">5. Specification</span>
+              <span class="stage lifecycle">6. Tasks</span>
+              <span class="stage lifecycle">7. Implementation</span>
+              <span class="stage lifecycle">8. Testing</span>
+              <span class="stage lifecycle">9. Review</span>
+              <span class="stage lifecycle">10. Release</span>
+              <span class="stage lifecycle">11. Retrospective</span>
             </div>
           </div>
         </div>

--- a/sites/index.html
+++ b/sites/index.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="Specs first. Code second. Specorator is an open-source workflow template that keeps humans in charge of what to build while specialist AI agents handle how.">
-    <meta property="og:title" content="Specorator — Specs first. Code second.">
-    <meta property="og:description" content="An open-source, spec-driven workflow template for building software with humans and AI agents. v0.2 Foundation release.">
+    <meta name="description" content="Stop letting AI write the wrong code. Specorator is an open-source, spec-driven workflow template — humans decide what to build, specialist agents handle how, every decision stays traceable.">
+    <meta property="og:title" content="Specorator — Stop letting AI write the wrong code.">
+    <meta property="og:description" content="Open-source workflow template. Specs first, code second. Humans decide what to build; specialist agents handle how.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://luis85.github.io/agentic-workflow/">
     <meta property="og:image" content="https://luis85.github.io/agentic-workflow/assets/specorator-workflow.svg">
@@ -36,19 +36,14 @@
       <section class="hero" aria-labelledby="hero-title">
         <div>
           <p class="eyebrow">
-            <span class="status-pill">v0.2 · Foundation release</span>
-            <span class="eyebrow-meta">Open-source · MIT · the <code>agentic-workflow</code> repo</span>
+            <span class="status-pill">Open-source template</span>
+            <span class="eyebrow-meta">MIT &middot; the <code>agentic-workflow</code> repo</span>
           </p>
-          <h1 id="hero-title">Specs first.<br>Code second.</h1>
-          <p class="hero-copy">Most AI coding tools jump straight to writing code &mdash; often the <em>wrong</em> code. <strong>Specorator</strong> is a ready-to-use workflow template that flips it: you stay in charge of <em>what</em> to build, specialist AI agents handle <em>how</em>, and every decision is traceable.</p>
+          <h1 id="hero-title">Stop letting AI write the wrong code.</h1>
+          <p class="hero-copy">Most AI assistants jump straight to typing. <strong>Specorator</strong> flips it &mdash; specs first, code second. You decide <em>what</em> to build; specialist agents handle <em>how</em>; every decision stays traceable.</p>
           <div class="hero-actions" aria-label="Primary actions">
             <a class="button highlight" href="#start">Get started</a>
             <a class="button secondary" href="https://github.com/Luis85/agentic-workflow/blob/main/docs/specorator.md">Read the workflow</a>
-            <a class="button ghost" href="https://github.com/Luis85/agentic-workflow" aria-label="View on GitHub">GitHub &rarr;</a>
-          </div>
-          <div class="hero-quickstart" aria-label="One-line quickstart">
-            <span class="quickstart-prompt" aria-hidden="true">$</span>
-            <code>git clone https://github.com/Luis85/agentic-workflow.git my-project &amp;&amp; cd my-project &amp;&amp; claude</code>
           </div>
           <div class="hero-proof" aria-label="At a glance">
             <span class="proof-item">
@@ -60,8 +55,8 @@
               <span class="proof-label">conductor skills, pick your fit</span>
             </span>
             <span class="proof-item">
-              <span class="proof-value">0</span>
-              <span class="proof-label">vendor lock-in &mdash; fork &amp; own</span>
+              <span class="proof-value">6+</span>
+              <span class="proof-label">AI coding tools supported</span>
             </span>
           </div>
         </div>

--- a/sites/styles.css
+++ b/sites/styles.css
@@ -142,17 +142,6 @@ button:focus-visible {
   color: var(--ink);
 }
 
-.button.ghost {
-  border-color: transparent;
-  background: transparent;
-  color: var(--ink);
-  padding: 0 12px;
-}
-
-.button.ghost:hover {
-  background: #eef1ea;
-}
-
 .hero {
   display: grid;
   grid-template-columns: minmax(0, 0.82fr) minmax(360px, 1fr);
@@ -220,11 +209,11 @@ p {
 }
 
 h1 {
-  max-width: 14ch;
+  max-width: 17ch;
   margin-bottom: 22px;
-  font-size: clamp(48px, 7.4vw, 96px);
-  line-height: 0.95;
-  letter-spacing: -0.01em;
+  font-size: clamp(44px, 6.6vw, 84px);
+  line-height: 0.98;
+  letter-spacing: -0.015em;
 }
 
 .hero-copy {
@@ -253,41 +242,12 @@ h1 {
   margin-top: 28px;
 }
 
-.hero-quickstart {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  margin-top: 20px;
-  max-width: 720px;
-  padding: 14px 16px;
-  border: 1px solid var(--line);
-  border-radius: 10px;
-  background: #0e1512;
-  color: #e6f6ef;
-  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
-  font-size: 13px;
-  overflow-x: auto;
-}
-
-.hero-quickstart code {
-  background: transparent;
-  color: #e6f6ef;
-  font-size: 13px;
-  white-space: nowrap;
-}
-
-.quickstart-prompt {
-  color: var(--highlighter);
-  font-weight: 800;
-  flex-shrink: 0;
-}
-
 .hero-proof {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 14px;
   max-width: 720px;
-  margin-top: 38px;
+  margin-top: 42px;
 }
 
 .proof-item {
@@ -776,21 +736,12 @@ h1 {
   }
 
   h1 {
-    font-size: 52px;
+    font-size: 46px;
   }
 
   .eyebrow {
     flex-direction: column;
     align-items: flex-start;
-  }
-
-  .hero-quickstart {
-    font-size: 12px;
-  }
-
-  .hero-quickstart code {
-    white-space: pre-wrap;
-    word-break: break-all;
   }
 
   .hero-proof,

--- a/sites/styles.css
+++ b/sites/styles.css
@@ -142,6 +142,17 @@ button:focus-visible {
   color: var(--ink);
 }
 
+.button.ghost {
+  border-color: transparent;
+  background: transparent;
+  color: var(--ink);
+  padding: 0 12px;
+}
+
+.button.ghost:hover {
+  background: #eef1ea;
+}
+
 .hero {
   display: grid;
   grid-template-columns: minmax(0, 0.82fr) minmax(360px, 1fr);
@@ -152,12 +163,53 @@ button:focus-visible {
 }
 
 .eyebrow {
-  margin: 0 0 16px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  margin: 0 0 18px;
   color: var(--accent-strong);
   font-size: 13px;
   font-weight: 800;
   letter-spacing: 0.11em;
   text-transform: uppercase;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: var(--soft-green);
+  color: var(--accent-strong);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+}
+
+.status-pill::before {
+  content: "";
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+
+.eyebrow-meta {
+  color: var(--muted);
+  font-weight: 700;
+  text-transform: none;
+  letter-spacing: 0.02em;
+  font-size: 12px;
+}
+
+.eyebrow-meta code {
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: rgba(23, 32, 27, 0.06);
+  color: var(--ink);
+  font-size: 11px;
 }
 
 h1,
@@ -168,33 +220,74 @@ p {
 }
 
 h1 {
-  max-width: 11ch;
+  max-width: 14ch;
   margin-bottom: 22px;
-  font-size: clamp(52px, 8vw, 104px);
-  line-height: 0.93;
-  letter-spacing: 0;
+  font-size: clamp(48px, 7.4vw, 96px);
+  line-height: 0.95;
+  letter-spacing: -0.01em;
 }
 
 .hero-copy {
-  max-width: 690px;
+  max-width: 640px;
   color: var(--muted);
-  font-size: clamp(20px, 2.2vw, 28px);
-  line-height: 1.3;
+  font-size: clamp(18px, 1.9vw, 24px);
+  line-height: 1.4;
+}
+
+.hero-copy strong {
+  color: var(--ink);
+  font-weight: 800;
+}
+
+.hero-copy em {
+  color: var(--accent-strong);
+  font-style: normal;
+  font-weight: 700;
 }
 
 .hero-actions {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: 12px;
-  margin-top: 32px;
+  margin-top: 28px;
+}
+
+.hero-quickstart {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 20px;
+  max-width: 720px;
+  padding: 14px 16px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: #0e1512;
+  color: #e6f6ef;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 13px;
+  overflow-x: auto;
+}
+
+.hero-quickstart code {
+  background: transparent;
+  color: #e6f6ef;
+  font-size: 13px;
+  white-space: nowrap;
+}
+
+.quickstart-prompt {
+  color: var(--highlighter);
+  font-weight: 800;
+  flex-shrink: 0;
 }
 
 .hero-proof {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 14px;
-  max-width: 650px;
-  margin-top: 42px;
+  max-width: 720px;
+  margin-top: 38px;
 }
 
 .proof-item {
@@ -384,7 +477,8 @@ h1 {
 
 .workflow-label {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  justify-content: center;
   padding: 20px;
   border-radius: 8px;
   background: var(--ink);
@@ -392,25 +486,40 @@ h1 {
   font-weight: 800;
 }
 
+.workflow-label-meta {
+  margin-top: 6px;
+  color: rgba(248, 250, 245, 0.65);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
 .workflow-stages {
-  display: grid;
-  grid-template-columns: repeat(6, minmax(0, 1fr));
+  display: flex;
+  flex-wrap: wrap;
   gap: 10px;
 }
 
 .stage {
   display: flex;
-  min-height: 74px;
+  flex: 1 1 130px;
+  min-height: 64px;
   align-items: center;
   justify-content: center;
-  padding: 14px 10px;
+  padding: 12px 10px;
   border: 1px solid var(--line);
   border-radius: 8px;
   background: var(--surface);
   color: var(--ink);
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 760;
   text-align: center;
+}
+
+.lifecycle-stages .stage {
+  flex: 1 1 100px;
+  font-size: 12px;
 }
 
 .stage.gate {
@@ -640,10 +749,6 @@ h1 {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .workflow-stages {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-
   .section-header {
     display: block;
   }
@@ -671,7 +776,21 @@ h1 {
   }
 
   h1 {
-    font-size: 56px;
+    font-size: 52px;
+  }
+
+  .eyebrow {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .hero-quickstart {
+    font-size: 12px;
+  }
+
+  .hero-quickstart code {
+    white-space: pre-wrap;
+    word-break: break-all;
   }
 
   .hero-proof,
@@ -679,8 +798,7 @@ h1 {
   .audience-grid,
   .repo-grid,
   .steps,
-  .path-list,
-  .workflow-stages {
+  .path-list {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
## Summary

Iterative redesign of the public product page at <https://luis85.github.io/agentic-workflow/>. Driven by a critique of the current page (abstract messaging, brand/URL mismatch, internal "11 stages" inconsistency, weak CTAs, under-evidenced value, narrow track coverage) and built up in small reviewable increments on this same branch.

**This PR is intentionally not a one-shot.** The user (page owner) is reviewing each increment before the next lands. Subsequent increments will land as additional commits here, not separate PRs — same branch, one concern.

## Increment 1 (this commit) — hero, status, quickstart, stage-count fix

- Hero H1 now `Specs first. / Code second.` (the README's actual lede). Brand stays in the navbar.
- Eyebrow gains a `v0.2 · Foundation release` status pill + `Open-source · MIT · the agentic-workflow repo` meta line so visitors can connect the page to the repo URL they came from.
- Hero copy uses the README's "wrong code" framing instead of vague positioning.
- Three hero CTAs: highlighted **Get started** (anchored to #start) / **Read the workflow** / ghost **GitHub →**.
- New copy-able terminal-style quickstart inline in the hero: `git clone … && claude`.
- Proof items rewritten without internal jargon: `11 stages, idea → retro` / `10 conductor skills, pick your fit` / `0 vendor lock-in — fork & own`.
- **Workflow viz now lists all 11 lifecycle stages, numbered.** Resolves the page's biggest internal contradiction (hero claimed 11, viz showed 6 collapsed chips).
- Discovery row labelled `optional` to signal it's a track, not a requirement.
- Workflow chip layout switched from fixed 6-column grid to flex-wrap so any chip count fits cleanly.
- Mobile: eyebrow stacks; quickstart wraps; the now-stale 980px workflow override removed.

## Planned increments (not yet committed)

| # | Increment | Status |
|---|---|---|
| 2 | Replace abstract artifact-chain SVG with real `idea.md → requirements.md → tasks.md` excerpts | pending |
| 3 | Surface the full track catalog (Discovery, Stock-taking, Sales, Project, Portfolio, Roadmap, QA, Scaffolding) | pending |
| 4 | Role-based CTAs (each persona card gets a copy-able one-liner) | pending |
| 5 | FAQ + differentiator block (vs spec-kit, "do I have to use Claude?", etc.) | pending |
| 6 | Recast `.claude/`, `docs/`, `templates/` repo grid as "what you'll produce" | pending |
| 7 | PNG OG image + final polish + a11y/responsive sweep | pending |

## Verification

- `npm run verify` — green (incl. `check:product-page`).
- HTML well-formedness: `python3 html.parser` reports no unclosed tags / no mismatches.
- xmllint complaints (`header`, `nav`, `main`, `section` "invalid") are HTML4-only-knowledge artefacts — not real errors.
- **Not visually verified in a browser** — the agent has no browser access. Reviewer (page owner) will eyeball each increment via GitHub Pages or local preview.

## Test plan

- [ ] Reviewer opens `sites/index.html` (or the GitHub Pages preview if branch deploys are enabled) and walks the page on desktop + mobile.
- [ ] Hero proof items / status pill / quickstart render as intended.
- [ ] Workflow row with 11 numbered chips wraps cleanly at 980px and 720px breakpoints.
- [ ] No regressions in the rest of the page (problem/solution panels, fit grid, features, audience, repo grid, example, get-started, footer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vv4h2vXXKT68UYR3AjrwrN)_