### PR TITLE
feat(sites): increment 4 — stage-owner attribution on pipeline chips

### DIFF
--- a/sites/index.html
+++ b/sites/index.html
@@ -264,28 +264,28 @@
           <div class="workflow-row">
             <div class="workflow-label">Discovery <span class="workflow-label-meta">optional</span></div>
             <div class="workflow-stages discovery-stages">
-              <span class="stage discovery">Frame</span>
-              <span class="stage discovery">Diverge</span>
-              <span class="stage discovery">Converge</span>
-              <span class="stage discovery">Prototype</span>
-              <span class="stage discovery">Validate</span>
-              <span class="stage gate">Brief gate</span>
+              <span class="stage discovery"><span class="stage-name">Frame</span><span class="stage-owner">product-strategist</span></span>
+              <span class="stage discovery"><span class="stage-name">Diverge</span><span class="stage-owner">divergent-thinker</span></span>
+              <span class="stage discovery"><span class="stage-name">Converge</span><span class="stage-owner">critic</span></span>
+              <span class="stage discovery"><span class="stage-name">Prototype</span><span class="stage-owner">prototyper</span></span>
+              <span class="stage discovery"><span class="stage-name">Validate</span><span class="stage-owner">user-researcher</span></span>
+              <span class="stage gate"><span class="stage-name">Brief gate</span><span class="stage-owner">human</span></span>
             </div>
           </div>
           <div class="workflow-row">
             <div class="workflow-label">Lifecycle <span class="workflow-label-meta">11 stages</span></div>
             <div class="workflow-stages lifecycle-stages">
-              <span class="stage lifecycle">1. Idea</span>
-              <span class="stage lifecycle">2. Research</span>
-              <span class="stage lifecycle">3. Requirements</span>
-              <span class="stage lifecycle">4. Design</span>
-              <span class="stage lifecycle">5. Specification</span>
-              <span class="stage lifecycle">6. Tasks</span>
-              <span class="stage lifecycle">7. Implementation</span>
-              <span class="stage lifecycle">8. Testing</span>
-              <span class="stage lifecycle">9. Review</span>
-              <span class="stage lifecycle">10. Release</span>
-              <span class="stage lifecycle">11. Retrospective</span>
+              <span class="stage lifecycle"><span class="stage-name">1. Idea</span><span class="stage-owner">analyst</span></span>
+              <span class="stage lifecycle"><span class="stage-name">2. Research</span><span class="stage-owner">analyst</span></span>
+              <span class="stage lifecycle"><span class="stage-name">3. Requirements</span><span class="stage-owner">pm</span></span>
+              <span class="stage lifecycle"><span class="stage-name">4. Design</span><span class="stage-owner">ux/ui/architect</span></span>
+              <span class="stage lifecycle"><span class="stage-name">5. Specification</span><span class="stage-owner">architect</span></span>
+              <span class="stage lifecycle"><span class="stage-name">6. Tasks</span><span class="stage-owner">planner</span></span>
+              <span class="stage lifecycle"><span class="stage-name">7. Implementation</span><span class="stage-owner">dev</span></span>
+              <span class="stage lifecycle"><span class="stage-name">8. Testing</span><span class="stage-owner">qa</span></span>
+              <span class="stage lifecycle"><span class="stage-name">9. Review</span><span class="stage-owner">reviewer</span></span>
+              <span class="stage lifecycle"><span class="stage-name">10. Release</span><span class="stage-owner">release-manager</span></span>
+              <span class="stage lifecycle"><span class="stage-name">11. Retrospective</span><span class="stage-owner">retrospective</span></span>
             </div>
           </div>
         </div>

--- a/sites/styles.css
+++ b/sites/styles.css
@@ -463,7 +463,9 @@ h1 {
 
 .stage {
   display: flex;
-  flex: 1 1 130px;
+  flex: 1 1 140px;
+  flex-direction: column;
+  gap: 4px;
   min-height: 64px;
   align-items: center;
   justify-content: center;
@@ -478,8 +480,27 @@ h1 {
 }
 
 .lifecycle-stages .stage {
-  flex: 1 1 100px;
+  flex: 1 1 130px;
   font-size: 12px;
+}
+
+.stage-name {
+  display: block;
+  line-height: 1.15;
+}
+
+.stage-owner {
+  display: block;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--muted);
+  letter-spacing: 0;
+  line-height: 1.2;
+}
+
+.stage.gate .stage-owner {
+  color: #6b5400;
 }
 
 .stage.gate {


### PR DESCRIPTION
## Summary

Closes the loop between the workflow viz and the team grid / roster sections. Each chip now shows two lines: the **stage name** plus the **agent slug** that owns the stage. Visitors can trace any stage back to a specific file in `.claude/agents/`.

## Lifecycle owners

| # | Stage | Owner |
|---|---|---|
| 1 | Idea | `analyst` |
| 2 | Research | `analyst` |
| 3 | Requirements | `pm` |
| 4 | Design | `ux/ui/architect` |
| 5 | Specification | `architect` |
| 6 | Tasks | `planner` |
| 7 | Implementation | `dev` |
| 8 | Testing | `qa` |
| 9 | Review | `reviewer` |
| 10 | Release | `release-manager` |
| 11 | Retrospective | `retrospective` |

Stage 4 keeps a compact `ux/ui/architect` subline because all three contribute Part A / Part B / Part C of `design.md` per the spec.

## Discovery owners (lead specialist per phase)

| Phase | Lead specialist |
|---|---|
| Frame | `product-strategist` |
| Diverge | `divergent-thinker` |
| Converge | `critic` |
| Prototype | `prototyper` |
| Validate | `user-researcher` |
| Brief gate | `human` |

The `facilitator` coordinates every phase; the slug shown is the lead specialist per the `discovery:*` skill commands. Brief gate uses `human` rather than an agent slug because Article VII of the constitution makes acceptance gates a human responsibility.

## Layout tweak

- `.stage` flips to `flex-direction: column` with a 4px gap so name + owner stack vertically.
- Lifecycle chip min-width: `100px → 130px`, general chip min-width: `130px → 140px` — accommodates the longest slug (`release-manager`, 15 chars at 10px monospace).
- New `.stage-owner` reuses the same `ui-monospace` stack as the artifact cards and roster pills so slug rendering stays consistent across the page.
- `.stage.gate .stage-owner` gets a warm tan tint to keep the gate chip visually distinct.

## Verification

- `npm run verify` — green
- `npm run check:product-page` — green
- HTML well-formedness via `python3 html.parser` — no unclosed tags
- Responsive: chips wrap naturally; long slugs (`product-strategist`, `divergent-thinker`, `release-manager`) verified to fit at the new min-width on a 1280px viewport simulation

## Test plan

- [ ] Reviewer opens `sites/index.html` and walks the workflow section.
- [ ] Each chip shows two lines: stage name (bold) + agent slug (muted, monospace).
- [ ] Slugs match the team-grid and roster sections — same naming, same monospace family.
- [ ] Discovery row: lead specialist visible per phase; Brief gate shows `human`.
- [ ] Mobile: chips wrap to multiple rows without truncation.
- [ ] No regressions in any other section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vv4h2vXXKT68UYR3AjrwrN)_