### PR TITLE
ci: resolve code scanning workflow alerts

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -15,8 +15,13 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   actionlint:
+    name: actionlint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   gitleaks:
     name: scan for committed secrets

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,10 +6,7 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+permissions: {}
 
 concurrency:
   group: pages
@@ -17,6 +14,11 @@ concurrency:
 
 jobs:
   deploy:
+    name: Deploy GitHub Pages
+    permissions:
+      contents: read
+      pages: write # Required to publish the built Pages artifact.
+      id-token: write # Required for GitHub Pages OIDC deployment authentication.
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -17,10 +17,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
-# pull-requests: read — the action queries the PR title via the API.
-# Nothing else is needed; no write surface is granted.
 permissions:
-  pull-requests: read
+  pull-requests: read # Required to read the PR title through the API.
 
 jobs:
   conventional-commits:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -9,8 +9,13 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   verify:
+    name: Verify
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -14,14 +14,19 @@ on:
   schedule:
     - cron: '23 5 * * 1'
 
-permissions:
-  contents: read
-  security-events: write
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   zizmor:
     name: zizmor static analysis
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # Required to upload Zizmor SARIF results to code scanning.
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

- Add missing workflow/job concurrency and job names flagged by Zizmor.
- Move Pages and Zizmor write permissions to job-level permission blocks and make default workflow permissions explicit.
- Add inline permission rationale comments so the auditor can verify why non-default permissions are present.

## Root Cause

The Security tab findings came from Zizmor SARIF alerts against GitHub Actions workflow metadata: anonymous jobs, missing concurrency controls, broad workflow-level write permissions, and permission entries without inline explanations.

## Verification

- `zizmor --persona=auditor .` (no findings)
- `actionlint` v1.7.12 (no output / success)
- `npm ci`
- `npm run verify`

## Known Limitations

- Existing Security tab alerts close only after GitHub reruns code scanning on the PR or after merge to `main`.