### PR TITLE
feat(sites): increment 5 — surface all 8 opt-in tracks as a card grid

### DIFF
--- a/sites/index.html
+++ b/sites/index.html
@@ -25,6 +25,7 @@
         <a href="#team">Team</a>
         <a href="#fit">Fit</a>
         <a href="#workflow">Workflow</a>
+        <a href="#tracks">Tracks</a>
         <a href="#roster">Roster</a>
         <a href="#start">Start</a>
         <a href="https://github.com/Luis85/agentic-workflow/blob/main/docs/specorator.md">Docs</a>
@@ -289,6 +290,130 @@
             </div>
           </div>
         </div>
+      </section>
+
+      <section class="section tracks-section" id="tracks" aria-labelledby="tracks-title">
+        <div class="section-header">
+          <h2 id="tracks-title">Eight more tracks. All opt-in.</h2>
+          <p class="section-kicker">Specorator stays small at the core and grows on demand. Each track is a separate set of slash commands and agents &mdash; invoke the ones that match your context.</p>
+        </div>
+        <div class="track-grid" aria-label="Opt-in workflow tracks">
+          <article class="track-card">
+            <header class="track-card-head">
+              <span class="track-when">Pre-brief</span>
+              <h3>Discovery</h3>
+            </header>
+            <ol class="track-phases">
+              <li>Frame</li>
+              <li>Diverge</li>
+              <li>Converge</li>
+              <li>Prototype</li>
+              <li>Validate</li>
+            </ol>
+            <p class="track-purpose">From blank page to validated brief, before any code.</p>
+            <code class="track-cmd">/discovery:start</code>
+          </article>
+          <article class="track-card">
+            <header class="track-card-head">
+              <span class="track-when">Legacy systems</span>
+              <h3>Stock-taking</h3>
+            </header>
+            <ol class="track-phases">
+              <li>Scope</li>
+              <li>Audit</li>
+              <li>Synthesize</li>
+              <li>Handoff</li>
+            </ol>
+            <p class="track-purpose">Inventory what's already there before changing it.</p>
+            <code class="track-cmd">/stock:start</code>
+          </article>
+          <article class="track-card">
+            <header class="track-card-head">
+              <span class="track-when">Pre-contract</span>
+              <h3>Sales Cycle</h3>
+            </header>
+            <ol class="track-phases">
+              <li>Qualify</li>
+              <li>Scope</li>
+              <li>Estimate</li>
+              <li>Propose</li>
+              <li>Order</li>
+            </ol>
+            <p class="track-purpose">Win the engagement, then hand off the kickoff brief.</p>
+            <code class="track-cmd">/sales:start</code>
+          </article>
+          <article class="track-card">
+            <header class="track-card-head">
+              <span class="track-when">Post-contract</span>
+              <h3>Project Manager</h3>
+            </header>
+            <ol class="track-phases">
+              <li>Initiate</li>
+              <li>Weekly</li>
+              <li>Change</li>
+              <li>Report</li>
+              <li>Close</li>
+            </ol>
+            <p class="track-purpose">Govern client delivery with P3.Express cadence.</p>
+            <code class="track-cmd">/project:start</code>
+          </article>
+          <article class="track-card">
+            <header class="track-card-head">
+              <span class="track-when">Multi-project</span>
+              <h3>Portfolio</h3>
+            </header>
+            <ol class="track-phases">
+              <li>X &middot; 6-monthly</li>
+              <li>Y &middot; monthly</li>
+              <li>Z &middot; daily</li>
+            </ol>
+            <p class="track-purpose">Manage a portfolio of programs with P5 Express cycles.</p>
+            <code class="track-cmd">/portfolio:start</code>
+          </article>
+          <article class="track-card">
+            <header class="track-card-head">
+              <span class="track-when">Always-on</span>
+              <h3>Roadmap Management</h3>
+            </header>
+            <ol class="track-phases">
+              <li>Shape</li>
+              <li>Align</li>
+              <li>Review</li>
+              <li>Communicate</li>
+            </ol>
+            <p class="track-purpose">Outcome roadmaps that stay current with delivery signals.</p>
+            <code class="track-cmd">/roadmap:start</code>
+          </article>
+          <article class="track-card">
+            <header class="track-card-head">
+              <span class="track-when">Readiness</span>
+              <h3>Quality Assurance</h3>
+            </header>
+            <ol class="track-phases">
+              <li>Plan</li>
+              <li>Check</li>
+              <li>Review</li>
+              <li>Improve</li>
+            </ol>
+            <p class="track-purpose">ISO 9001-aligned readiness reviews and corrective actions.</p>
+            <code class="track-cmd">/quality:start</code>
+          </article>
+          <article class="track-card">
+            <header class="track-card-head">
+              <span class="track-when">Onboarding</span>
+              <h3>Project Scaffolding</h3>
+            </header>
+            <ol class="track-phases">
+              <li>Intake</li>
+              <li>Extract</li>
+              <li>Assemble</li>
+              <li>Handoff</li>
+            </ol>
+            <p class="track-purpose">Turn folders and Markdown notes into a reviewable starter pack.</p>
+            <code class="track-cmd">/scaffold:start</code>
+          </article>
+        </div>
+        <p class="track-footnote">All eight tracks are optional and pluggable. <a href="#roster">See the agents that drive them &rarr;</a></p>
       </section>
 
       <section class="section dark roster-section" id="roster" aria-labelledby="roster-title">

--- a/sites/styles.css
+++ b/sites/styles.css
@@ -655,6 +655,120 @@ h1 {
   color: var(--ink);
 }
 
+.tracks-section {
+  background: var(--paper);
+}
+
+.track-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.track-card {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: clamp(20px, 2.4vw, 26px);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--surface);
+  transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.track-card:hover {
+  border-color: var(--ink);
+  transform: translateY(-2px);
+  box-shadow: 0 12px 30px rgba(23, 32, 27, 0.07);
+}
+
+.track-card-head {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.track-when {
+  align-self: flex-start;
+  padding: 3px 9px;
+  border-radius: 999px;
+  background: var(--soft-green);
+  color: var(--accent-strong);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.track-card h3 {
+  margin: 0;
+  font-size: 20px;
+  letter-spacing: -0.01em;
+}
+
+.track-phases {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.track-phases li {
+  display: inline-flex;
+  align-items: center;
+}
+
+.track-phases li::after {
+  content: "\2027";
+  margin: 0 8px;
+  color: rgba(89, 100, 94, 0.45);
+}
+
+.track-phases li:last-child::after {
+  content: "";
+  margin: 0;
+}
+
+.track-purpose {
+  margin: 0;
+  flex: 1 1 auto;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.track-cmd {
+  align-self: flex-start;
+  padding: 5px 10px;
+  border-radius: 6px;
+  background: rgba(27, 111, 85, 0.08);
+  color: var(--accent-strong);
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 12.5px;
+  font-weight: 800;
+}
+
+.track-footnote {
+  margin: 28px 0 0;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.track-footnote a {
+  color: var(--accent-strong);
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.track-footnote a:hover {
+  color: var(--ink);
+}
+
 .roster-section {
   background: var(--ink);
 }
@@ -993,7 +1107,8 @@ h1 {
   .audience-grid,
   .repo-grid,
   .steps,
-  .team-grid {
+  .team-grid,
+  .track-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
@@ -1041,7 +1156,8 @@ h1 {
   .audience-grid,
   .repo-grid,
   .steps,
-  .team-grid {
+  .team-grid,
+  .track-grid {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
## Summary

Surfaces all eight opt-in tracks the repo ships beyond the core lifecycle. Today the workflow viz only shows Discovery + Lifecycle; visitors had no way to learn about Stock-taking, Sales Cycle, Project Manager, Portfolio, Roadmap Management, Quality Assurance, or Project Scaffolding from the page itself.

New `#tracks` section sits between `#workflow` and `#roster` — eight cards in a 4-column grid (collapsing to 2 at tablet, 1 at mobile).

## Card content

| Track | When | Entry |
|---|---|---|
| Discovery | Pre-brief | `/discovery:start` |
| Stock-taking | Legacy systems | `/stock:start` |
| Sales Cycle | Pre-contract | `/sales:start` |
| Project Manager | Post-contract | `/project:start` |
| Portfolio | Multi-project | `/portfolio:start` |
| Roadmap Management | Always-on | `/roadmap:start` |
| Quality Assurance | Readiness | `/quality:start` |
| Project Scaffolding | Onboarding | `/scaffold:start` |

Each card shows: a "when to use it" pill, the track name, the phase chain (small monospace list with middle-dot separators), a one-line purpose, and the slash-command entry point as a green-tinted code chip.

## Page-flow rationale

```
#workflow      → here's the one canonical lifecycle
#tracks  (new) → here are eight more tracks that attach to it
#roster        → and here are the agents that drive all of the above
```

Section heading **"Eight more tracks. All opt-in."** reinforces that Specorator stays small at the core and grows on demand. Phrasing deliberately avoids "9 tracks" — the lifecycle itself is the 9th and it's shown above.

Footnote cross-links from `#tracks` → `#roster` so readers curious about which agents drive each track land on the deeper reference section.

## Visual approach

- Section background: `--paper` (calm bridge between the light `#workflow` and the dark `#roster`).
- Phase chain reuses the existing `ui-monospace` family already established in artifact cards, roster pills, and stage-owner sublines — page stays visually coherent without new font tokens.
- "When to use" pill, accent text, and command chip all use the existing `--soft-green` / `--accent-strong` / `--line` tokens. No new colors introduced.
- Track cards have the same hover treatment as team cards (border darkens, slight lift, soft shadow).

## Navbar

`Tracks` entry slotted between `Workflow` and `Roster`. The visitor's pivot from "the lifecycle" to "everything that attaches to it" is now one click.

## Verification

- `npm run verify` — green
- `npm run check:product-page` — green (no snapshot changes needed)
- HTML well-formedness via `python3 html.parser` — no unclosed tags
- All eight slash commands cross-checked against `CLAUDE.md` track entries and `.claude/skills/` skill list
- Responsive: 4→2→1 columns at 980px / 720px

## Test plan

- [ ] Reviewer opens `sites/index.html` and walks the new `#tracks` section.
- [ ] Eight cards render in a 4-column grid on desktop, hover lifts work.
- [ ] Phase chains read with middle-dot separators (no trailing dot on the last phase).
- [ ] Slash-command chips are recognizable as commands (green tint, monospace).
- [ ] Footnote link `See the agents that drive them →` jumps to `#roster`.
- [ ] Navbar `Tracks` entry scrolls to the section.
- [ ] Mobile: cards collapse to single column without overflow; long phase chains wrap cleanly.
- [ ] No regressions in any other section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vv4h2vXXKT68UYR3AjrwrN)_