### PR TITLE
feat(sites): increment 7 — FAQ section with six honest answers for evaluators

### DIFF
--- a/sites/index.html
+++ b/sites/index.html
@@ -618,6 +618,39 @@ send a one-time link valid for 30 minutes.</pre>
         </div>
       </section>
 
+      <section class="section faq-section" id="faq" aria-labelledby="faq-title">
+        <div class="section-header">
+          <h2 id="faq-title">Questions you probably have.</h2>
+          <p class="section-kicker">Six honest answers for evaluators &mdash; positioning, prerequisites, scope, and friction.</p>
+        </div>
+        <div class="faq-grid">
+          <article class="faq-item">
+            <h3>How is this different from spec-kit, Aider, or Copilot Workspace?</h3>
+            <p>They're tools; Specorator is a <strong>process</strong> you can run on top of them. The 11-stage lifecycle, named specialist agents, quality gates, and trace IDs are the real differentiators. Claude Code gets first-class slash commands, but the workflow itself is described in <code>AGENTS.md</code> and works with Codex, Cursor, Aider, Copilot, and Gemini.</p>
+          </article>
+          <article class="faq-item">
+            <h3>Do I have to use Claude Code?</h3>
+            <p>No. Claude Code gets first-class commands and the skills layer is Claude-specific, but the workflow itself is described in <code>AGENTS.md</code> and runs with any agent that can read Markdown. The artifacts, IDs, and quality gates are tool-agnostic.</p>
+          </article>
+          <article class="faq-item">
+            <h3>Is this a library or a template?</h3>
+            <p>A template. Fork the repo, replace <code>docs/steering/</code> with your own product context, adapt <code>memory/constitution.md</code> to your team's principles, and start a feature. The default content is intentionally generic &mdash; every project will overwrite parts of it.</p>
+          </article>
+          <article class="faq-item">
+            <h3>Can I use it without GitHub?</h3>
+            <p>Yes for the lifecycle. Verify gate, agents, skills, and artifacts all run locally. Some optional bits lean on GitHub (Pages deploy, Actions for typos / spell-check / verify CI), but the core workflow doesn't depend on it. Local hooks deny direct <code>main</code> pushes the same way branch protection would.</p>
+          </article>
+          <article class="faq-item">
+            <h3>Is the 11-stage lifecycle overkill for a one-person project?</h3>
+            <p>For a throwaway script, yes. For anything you'll maintain past the first commit, no &mdash; stages move in minutes when there's no stakeholder cycle to run. Solo builders use the <code>orchestrate</code> skill and gate themselves between stages. The mandatory retrospective at the end is what compounds the value over time.</p>
+          </article>
+          <article class="faq-item">
+            <h3>Do I have to learn the slash commands?</h3>
+            <p>No. The conductor skills (<code>orchestrate</code>, <code>discovery-sprint</code>, <code>project-run</code>, etc.) auto-trigger on natural language. Slash commands are the manual escape hatch when you want precise control. Every entry point in the audience cards above shows the natural-language form.</p>
+          </article>
+        </div>
+      </section>
+
       <section class="section dark" id="start" aria-labelledby="start-title">
         <div class="section-header">
           <h2 id="start-title">Get started in one repository.</h2>

--- a/sites/styles.css
+++ b/sites/styles.css
@@ -948,6 +948,57 @@ h1 {
   background: #eef1ea;
 }
 
+.faq-section {
+  background: var(--paper);
+}
+
+.faq-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(20px, 3vw, 32px);
+}
+
+.faq-item {
+  padding: clamp(22px, 3vw, 28px);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--surface);
+  transition: border-color 0.2s ease;
+}
+
+.faq-item:hover {
+  border-color: var(--ink);
+}
+
+.faq-item h3 {
+  margin: 0 0 12px;
+  font-size: 17px;
+  letter-spacing: -0.01em;
+  line-height: 1.3;
+}
+
+.faq-item p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14.5px;
+  line-height: 1.65;
+}
+
+.faq-item p code {
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: rgba(23, 32, 27, 0.06);
+  color: var(--ink);
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 12.5px;
+  font-weight: 700;
+}
+
+.faq-item p strong {
+  color: var(--ink);
+  font-weight: 800;
+}
+
 .artifact-chain {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -1230,7 +1281,8 @@ h1 {
   .repo-grid,
   .steps,
   .team-grid,
-  .track-grid {
+  .track-grid,
+  .faq-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
@@ -1279,7 +1331,8 @@ h1 {
   .repo-grid,
   .steps,
   .team-grid,
-  .track-grid {
+  .track-grid,
+  .faq-grid {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
## Summary

Adds a new `#faq` section between `#example` and `#start` with six honest answers for evaluators. Closes one of the most frequently-flagged gaps in the original page critique: serious evaluators' questions had no presence on the page.

No expand/collapse — answers are short enough to read inline, and search engines / accessibility tools see all six immediately.

## Six Q&As

| # | Question | Take |
|---|---|---|
| 1 | How is this different from spec-kit, Aider, or Copilot Workspace? | Process, not tool. Tool-agnostic via `AGENTS.md`. |
| 2 | Do I have to use Claude Code? | No. Any agent that reads Markdown works. |
| 3 | Is this a library or a template? | A template. Fork, replace steering, adapt constitution. |
| 4 | Can I use it without GitHub? | Yes for the lifecycle. GitHub-specific bits are optional. |
| 5 | Is the 11-stage lifecycle overkill for a one-person project? | Yes for a throwaway script. No for anything maintained. |
| 6 | Do I have to learn the slash commands? | No — conductor skills auto-trigger on natural language. |

## Phrasing notes — please flag if you want to redirect

- **Q1 (spec-kit comparison)** is the riskiest. I deliberately avoided saying competitors are *worse* and instead framed Specorator as the *process* layer that *runs on top of* tools. If you want a sharper or more competitive take, redirect on the PR.
- **Q4 ("can I use it without GitHub")** says "yes for the lifecycle" — the verify gate, agents, skills, and artifacts all run locally. Some optional bits (Pages deploy, GH Actions for typos / spell-check / verify CI) lean on GitHub. If you'd rather state it more flatly, redirect.
- **Q5 ("overkill for one-person")** is honest about throwaway scripts being a bad fit. The earlier `#fit` section already says this; the FAQ reinforces it. Some projects sell harder ("works at any scale!"), but I'd argue the candor lands better with the technical audience this page targets.

## Visual approach

- 2-column grid of always-visible Q/A pairs (`.faq-grid` → `repeat(2, minmax(0, 1fr))`).
- 980px breakpoint collapses to single column.
- Card body styling matches the rhythm of `.team-grid`, `.track-grid`, and the audience cards.
- No new color tokens — reuses existing `--line`, `--paper`, `--surface`, `--ink`, `--muted`, and the 6%-ink chip for inline `<code>` (same chip as `artifact-meta p code` and `track-cmd`).

## Page-flow rationale

```
#example → see proof (real artifact excerpts)
#faq     → answer concerns (six honest takes)
#start   → take action (terminal-chrome quickstart)
```

The visitor's reading order is now: prove it works → answer my doubts → tell me how to start.

## Verification

- `npm run verify` — green
- `npm run check:product-page` — green
- HTML well-formedness via `python3 html.parser` — no unclosed tags
- Responsive: 2 → 1 column at 980px
- Section anchors all resolve

## Test plan

- [ ] Reviewer opens `sites/index.html` and walks the new `#faq` section.
- [ ] Six Q&A pairs render in a 2-column grid on desktop, hover darkens border.
- [ ] Inline `<code>` (`AGENTS.md`, `docs/steering/`, `orchestrate`, etc.) renders as a tinted chip.
- [ ] Mobile: cards collapse to single column without overflow.
- [ ] No regressions in any other section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vv4h2vXXKT68UYR3AjrwrN)_