### PR TITLE
feat(scripts): require Skips section to document skipped artifacts (T-V03-003)

### DIFF
--- a/scripts/lib/spec-state.ts
+++ b/scripts/lib/spec-state.ts
@@ -49,6 +49,7 @@ export function specStateDiagnosticsForText(
   validateArtifactMap(rel, data, artifactExists, errors);
   validateStageProgress(rel, frontmatter.body, data, errors);
   validateRequiredSections(rel, frontmatter.body, errors);
+  validateSkipsDocumentation(rel, frontmatter.body, data, errors);
   return errors;
 }
 
@@ -221,6 +222,36 @@ function validateRequiredSections(rel: string, body: string, errors: string[]): 
       errors.push(`${rel} missing section: ${heading}`);
     }
   }
+}
+
+function validateSkipsDocumentation(
+  rel: string,
+  body: string,
+  data: Record<string, unknown>,
+  errors: string[],
+): void {
+  const artifacts = data.artifacts;
+  if (!artifacts || typeof artifacts !== "object" || Array.isArray(artifacts)) return;
+
+  const skipsBody = extractSectionBody(body, "Skips");
+  if (skipsBody === null) return;
+
+  for (const [artifact, status] of Object.entries(artifacts as Record<string, unknown>)) {
+    if (status !== "skipped") continue;
+    if (!skipsBody.includes(artifact)) {
+      errors.push(`${rel} marks ${artifact} as skipped, but Skips section does not document it`);
+    }
+  }
+}
+
+function extractSectionBody(body: string, heading: string): string | null {
+  const headingPattern = new RegExp(`^##\\s+${escapeRegExp(heading)}\\s*$`, "m");
+  const match = headingPattern.exec(body);
+  if (!match) return null;
+
+  const start = match.index + match[0].length;
+  const nextHeading = body.slice(start).search(/^##\s+/m);
+  return nextHeading === -1 ? body.slice(start) : body.slice(start, start + nextHeading);
 }
 
 function escapeRegExp(value: string): string {

--- a/specs/version-0-3-plan/workflow-state.md
+++ b/specs/version-0-3-plan/workflow-state.md
@@ -54,4 +54,10 @@ artifacts:
 ## Open clarifications
 
 - [ ] CLAR-V03-001 — Confirm whether `examples/cli-todo` remains the selected complete example for v0.3 or whether a different example should replace it.
-- [ ] CLAR-V03-002 — Confirm which strengthened validation checks must fail `npm run verify` in v0.3 versus remain advisory until v0.4.
+- [x] CLAR-V03-002 — Confirm which strengthened validation checks must fail `npm run verify` in v0.3 versus remain advisory until v0.4.
+
+  **Resolved 2026-05-01 (human + claude):** Default is hard-fail; advisory only when format variability creates real false-positive risk. Concrete split for the new T-V03-003 / T-V03-004 checks:
+  - **Hard-fail (v0.3 verify gate):** skipped artifact must appear under `## Skips` section (T-V03-003); examples folders must have a `workflow-state.md` (T-V03-003); every `TEST-*` references back to a `REQ-*` or `NFR-*` (T-V03-004).
+  - **Advisory (deferred to v0.4):** every `REQ-*` / `NFR-*` has at least one covering `TEST-*` — test-plan formats are not yet locked, so a deterministic coverage check would block legitimate PRs. T-V03-009 records this as a v0.4 promotion candidate.
+
+  All previously-shipped checks (current-stage consistency, complete-artifact file presence, done-state rules, duplicate IDs, area mismatches, unknown references, invalid reference kinds, missing `Satisfies`) remain hard-fail and are now covered by regression tests (PR #93 for spec-state, PR #94 for traceability).

--- a/tests/scripts/spec-state.test.ts
+++ b/tests/scripts/spec-state.test.ts
@@ -210,6 +210,38 @@ test("missing required section is reported", () => {
   assert.ok(diagnostics.includes(`${REL} missing section: Skips`));
 });
 
+test("skipped artifact without mention in Skips section is reported", () => {
+  const text = cleanText
+    .replace("research.md: pending", "research.md: skipped")
+    .replace(
+      "| 2. Research | `research.md` | pending |",
+      "| 2. Research | `research.md` | skipped |",
+    );
+  const diagnostics = diagnose(text);
+  assert.ok(
+    diagnostics.includes(
+      `${REL} marks research.md as skipped, but Skips section does not document it`,
+    ),
+  );
+});
+
+test("skipped artifact mentioned in Skips section passes the skip-doc check", () => {
+  const text = cleanText
+    .replace("research.md: pending", "research.md: skipped")
+    .replace(
+      "| 2. Research | `research.md` | pending |",
+      "| 2. Research | `research.md` | skipped |",
+    )
+    .replace("## Skips\n\n> None.", "## Skips\n\n- `research.md` skipped because no upstream sources required.");
+  const diagnostics = diagnose(text);
+  assert.equal(
+    diagnostics.some((message) =>
+      message.includes("Skips section does not document"),
+    ),
+    false,
+  );
+});
+
 test("parseStageProgressTable extracts artifact-status pairs", () => {
   const table = parseStageProgressTable(`
 | Stage | Artifact | Status |


### PR DESCRIPTION
## Summary

- New deterministic check: when workflow-state frontmatter marks an artifact as `skipped`, the `## Skips` section body must mention the artifact filename. Catches silently-dropped stages.
- Resolves CLAR-V03-002 with the fail-vs-advisory split for v0.3 hardening.

## Why

First slice of **T-V03-003 — Harden artifact state validation**. Lands the smallest deterministic check now that the regression-test safety net (#93, #94) is in place. The skip-doc rule has near-zero false-positive risk in this repo (no existing skipped artifacts) so it ships as hard-fail.

## CLAR-V03-002 resolution

Default = hard-fail; advisory only when format variability creates real false-positive risk. Concrete split for the new T-V03-003 / T-V03-004 checks:

- **Hard-fail (v0.3 verify gate):**
  - skipped artifact must appear under `## Skips` section *(this PR)*
  - examples folders must have a `workflow-state.md` *(follow-up PR)*
  - every `TEST-*` references back to a `REQ-*` or `NFR-*` *(follow-up PR)*
- **Advisory (deferred to v0.4):**
  - every `REQ-*` / `NFR-*` has at least one covering `TEST-*` — test-plan formats are not yet locked, so a deterministic coverage check would block legitimate PRs. T-V03-009 will record this as a v0.4 promotion candidate.

All previously-shipped checks remain hard-fail and are now covered by the #93/#94 regression tests.

## Linked artifacts

- Plan: [`specs/version-0-3-plan/tasks.md`](https://github.com/Luis85/agentic-workflow/blob/main/specs/version-0-3-plan/tasks.md) — T-V03-003 (first slice)
- State: [`specs/version-0-3-plan/workflow-state.md`](https://github.com/Luis85/agentic-workflow/blob/main/specs/version-0-3-plan/workflow-state.md) — CLAR-V03-002 (resolved)
- Safety net: PR #93 (spec-state regression tests), PR #94 (traceability regression tests)

## Test plan

- [x] TDD: red bar (skip-doc test fails) → implement → green bar (100 tests pass, 2 new)
- [x] `npm run verify` → all 13 gates green; existing repo content has zero `skipped` artifacts so the new rule never fires today
- [x] Behaviour preservation: every other diagnostic unchanged

## Follow-ups

- T-V03-003 slice 2 — examples folders must have `workflow-state.md`
- T-V03-004 — every `TEST-*` references back to a `REQ-*` or `NFR-*`
- T-V03-009 — record advisory `REQ → TEST` coverage check as v0.4 promotion candidate

🤖 Generated with [Claude Code](https://claude.com/claude-code)