### PR TITLE
docs(v06): plan productization and trust release

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,7 @@ Full version in [`memory/constitution.md`](memory/constitution.md).
 | v0.3 | Planned | [Worked end-to-end examples, artifact validation](specs/version-0-3-plan/tasks.md) |
 | v0.4 | Planned | [CI quality gates, metrics, maturity model](specs/version-0-4-plan/tasks.md) |
 | v0.5 | Planned | [Release workflow, branching strategy, GitHub Releases and Packages](specs/version-0-5-plan/tasks.md) |
+| v0.6 | Planned | [Productization, cross-tool adapters, live proof, hooks, and agentic security](specs/version-0-6-plan/tasks.md) |
 
 ---
 

--- a/specs/version-0-6-plan/design.md
+++ b/specs/version-0-6-plan/design.md
@@ -1,0 +1,121 @@
+---
+id: DESIGN-V06-001
+title: Version 0.6 productization and trust plan - Design
+stage: design
+feature: version-0-6-plan
+status: accepted
+owner: architect
+inputs:
+  - PRD-V06-001
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+# Design - Version 0.6 productization and trust plan
+
+## Product shape
+
+v0.6 has six connected slices:
+
+1. **Steering profile:** make this repository's own product steering concrete while preserving blank downstream templates.
+2. **Golden-path proof:** replace desk-only tutorial confidence with verified demo evidence.
+3. **Cross-tool adapters:** make Copilot, Codex, Cursor/Aider-style consumers first-class without fragmenting the source of truth.
+4. **Hook packs:** provide opt-in deterministic guardrails for worktree, branch, Markdown, secret, and risky-command checks.
+5. **Agentic security review:** add an OWASP-aligned review path for risks unique to autonomous tool-using agents.
+6. **Adoption and positioning:** add persona adoption profiles and evidence-first public messaging.
+
+## Steering model
+
+The current `docs/steering/*.md` files are blank adopter templates. v0.6 should avoid losing that template value while still documenting Specorator's own product reality.
+
+Recommended shape:
+
+| Surface | Purpose |
+|---|---|
+| `docs/steering/README.md` | Explain downstream steering and link to examples. |
+| `docs/steering/*.md` | Remain starter templates for adopters unless maintainers decide to move template copies elsewhere. |
+| `docs/specorator-product/` or equivalent | Hold Specorator's own product, UX, tech, quality, and operations steering profile. |
+| `AGENTS.md` / `CLAUDE.md` | Point agents to the right steering source for template improvements. |
+
+If the project chooses to repurpose `docs/steering/*.md` for Specorator itself, it should add blank templates elsewhere in the same change.
+
+## Golden-path model
+
+The golden path should prove one small workflow end to end without making contributors run a long interactive session on every PR.
+
+Recommended layers:
+
+| Layer | Behavior |
+|---|---|
+| Tutorial | Human-readable walkthrough, updated after live execution. |
+| Example artifacts | A complete or near-complete `examples/<slug>/` workflow showing accepted outputs. |
+| Deterministic check | Validates the example's state, traceability, links, and frontmatter. |
+| Evidence note | Records date, commit, commands, and caveats from the live run. |
+
+CI can initially validate the artifacts and evidence note. Fully automating the interactive tutorial can be a later promotion if the run stabilizes.
+
+## Cross-tool adapter model
+
+Adapters should be thin projections, not independent methodologies.
+
+| Tool surface | Candidate path | Role |
+|---|---|---|
+| GitHub Copilot | `.github/copilot-instructions.md`, `.github/agents/`, `.github/skills/` | GitHub-native instructions, agents, and skills. |
+| Codex | `.codex/`, `.agents/skills/`, plugin package | Codex-specific delivery mechanics and installable reusable workflows. |
+| Cursor / Aider / generic agents | `.cursor/rules/`, `.aider.conf.yml`, `AGENTS.md` references | Thin pointers to canonical rules and manual stage order. |
+| All tools | `AGENTS.md`, `docs/workflow-overview.md`, `templates/` | Canonical shared workflow and artifact contract. |
+
+The adapter docs should state what is authoritative and what is generated or maintained manually.
+
+## Hook pack model
+
+Hooks should start opt-in and advisory. Suggested packs:
+
+| Pack | Trigger class | Initial behavior |
+|---|---|---|
+| Worktree guard | session start / pre-tool use | Warn when working outside `.worktrees/<slug>` for non-trivial edits. |
+| Branch guard | pre-git operation | Warn or block direct commits/pushes to `main` or `develop`. |
+| Markdown guard | post-edit / stop | Run targeted frontmatter, link, spec-state, or product-page checks. |
+| Secret/risky command guard | pre-tool use | Warn on suspicious secrets, destructive commands, or release/publish operations. |
+| Handoff context | session start | Surface current workflow-state and open clarifications. |
+
+Blocking behavior should require explicit maintainer promotion after false positives are understood.
+
+## Agentic security review model
+
+The first version should be an optional workflow/checklist, not a claim of complete security. It can live as a dedicated doc, QA checklist extension, or skill. Minimum review categories:
+
+- Goal and instruction hijacking.
+- Tool misuse, unsafe permissions, and destructive operations.
+- Excessive agency and missing human authorization.
+- Memory, context, or artifact poisoning.
+- Secrets, credentials, and private data exposure.
+- Inter-agent handoff failures and unreviewed autonomous outputs.
+- Observability and audit trail for agent actions.
+
+The review should produce findings, mitigations, residual risk, and follow-up actions.
+
+## Adoption profile model
+
+Profiles should be short maps to existing surfaces:
+
+| Profile | Minimal path |
+|---|---|
+| Solo builder | Start with README, tutorial, `orchestrate`, local verify, one feature. |
+| Product team | Discovery, requirements, design, roadmap, review gates. |
+| Agency/client delivery | Sales, project manager track, lifecycle, QA review, release notes. |
+| Enterprise governance | Quality metrics, agentic security, hooks, ADRs, CI, release workflow. |
+| Brownfield migration | Project scaffolding, stock-taking, discovery, first tracer-bullet feature. |
+
+## ADR impact
+
+An ADR is likely required if v0.6 makes hooks mandatory, changes canonical steering ownership, or introduces a new formal workflow track. No ADR is required for docs-only adapter pointers, optional checklists, or non-blocking hook examples.
+
+## Risks and mitigations
+
+- RISK-V06-001: Keep adapters thin and verify source-of-truth references.
+- RISK-V06-002: Start hook packs in advisory mode and document disable paths.
+- RISK-V06-003: State security limits and avoid certification language.
+- RISK-V06-004: Validate golden-path artifacts before attempting full CI automation.
+- RISK-V06-005: Keep adoption profiles as maps, not duplicate manuals.
+- RISK-V06-006: Track ISO 9001:2026 without updating QA requirements before final publication.

--- a/specs/version-0-6-plan/idea.md
+++ b/specs/version-0-6-plan/idea.md
@@ -1,0 +1,44 @@
+---
+id: IDEA-V06-001
+title: Version 0.6 productization and trust plan
+stage: idea
+feature: version-0-6-plan
+status: accepted
+owner: analyst
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+# Idea - Version 0.6 productization and trust plan
+
+## Problem
+
+Specorator has a strong workflow core, but adoption still depends on users reading a large repository, trusting unproven examples, and translating Claude-first artifacts into other agent surfaces by hand. The project also underplays its strongest market fit: verifiable, governed AI-assisted delivery in a period where teams are adding agentic coding tools faster than their verification, security, and process controls mature.
+
+## Target users
+
+- Maintainers who need a release after v0.5 that makes the template easier to install, prove, and explain.
+- First-time adopters who need a short path from clone or package install to a working, verified feature.
+- Teams using Codex, Copilot, Cursor, Aider, or other tools alongside Claude Code.
+- Security-conscious teams that need agentic AI risk controls, not only conventional code checks.
+- Product evaluators comparing Specorator with GitHub Spec Kit and lighter prompt libraries.
+
+## Desired outcome
+
+v0.6 should turn the released v0.5 distribution into an adoption-ready productization release: filled Specorator steering context, a live verified golden path, cross-tool adapter surfaces, deterministic hook packs, agentic security guidance, clearer adoption profiles, and public positioning that proves the workflow instead of only describing it.
+
+## Constraints
+
+- v0.6 builds on the v0.5 release/distribution mechanism; do not duplicate v0.5 publishing work.
+- Do not add a mandatory lifecycle stage.
+- Keep the core lifecycle small and make new surfaces opt-in.
+- Preserve Markdown portability and the single source of truth in `AGENTS.md`.
+- Treat security hooks and agent automation as guardrails that must be auditable and reversible.
+
+## Open questions
+
+- Which cross-tool adapters should be first-class in v0.6: Copilot, Codex, Cursor, Aider, or all of them?
+- Should agentic security live as a standalone optional workflow, a QA track extension, or a checklist pack consumed by both?
+- Should the golden-path demo execute in CI, or should CI only validate the canned artifacts and scripts?
+- Should public positioning explicitly compare Specorator against GitHub Spec Kit in README and the product page?
+- How much of the steering context should be filled for the template product itself versus left as blank downstream examples?

--- a/specs/version-0-6-plan/requirements.md
+++ b/specs/version-0-6-plan/requirements.md
@@ -1,0 +1,160 @@
+---
+id: PRD-V06-001
+title: Version 0.6 productization and trust plan
+stage: requirements
+feature: version-0-6-plan
+status: accepted
+owner: pm
+inputs:
+  - IDEA-V06-001
+  - RESEARCH-V06-001
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+# PRD - Version 0.6 productization and trust plan
+
+## Summary
+
+Plan v0.6 as the productization and trust release: improve first-run adoption, live proof, cross-tool compatibility, deterministic hooks, agentic security governance, and public positioning after v0.5 provides release and package distribution.
+
+## Goals
+
+- Make the template easier to adopt from a released distribution.
+- Provide a live, verified golden path that proves the lifecycle works.
+- Add first-class adapter surfaces for major AI coding agents.
+- Add opt-in deterministic hook packs for common workflow guardrails.
+- Add an agentic security review path aligned to current OWASP guidance.
+- Clarify product positioning with adoption profiles and evidence-first messaging.
+- Track ISO 9001:2026 impact without making premature compliance claims.
+
+## Non-goals
+
+- No Obsidian plugin implementation in v0.6.
+- No mandatory new lifecycle stage.
+- No replacement for v0.5 release and package publishing.
+- No claim of ISO certification, OWASP compliance, or complete agent security coverage.
+- No hosted telemetry, external analytics, or user behavior tracking.
+- No requirement that downstream projects use every adapter or hook.
+
+## Functional requirements (EARS)
+
+### REQ-V06-001 - Fill Specorator product steering
+
+- **Pattern:** ubiquitous
+- **Statement:** The repository shall distinguish Specorator's own product steering from blank downstream steering templates.
+- **Acceptance:** The docs explain which steering files describe this repository and where adopters find blank/template steering guidance.
+- **Priority:** must
+- **Satisfies:** IDEA-V06-001
+
+### REQ-V06-002 - Provide a live golden-path demo
+
+- **Pattern:** ubiquitous
+- **Statement:** The repository shall provide a verified golden-path demo that shows a first-time adopter what a successful Specorator run produces.
+- **Acceptance:** The demo has expected artifacts, verification steps, and a recorded evidence note replacing the current desk-validation caveat.
+- **Priority:** must
+- **Satisfies:** IDEA-V06-001, RESEARCH-V06-001
+
+### REQ-V06-003 - Add cross-tool adapter surfaces
+
+- **Pattern:** ubiquitous
+- **Statement:** The repository shall define first-class adapter surfaces for supported AI coding tools beyond Claude Code.
+- **Acceptance:** Copilot, Codex, and at least one editor-agent adapter path are documented or generated from the canonical instructions, with drift checks or clear maintenance rules.
+- **Priority:** must
+- **Satisfies:** RESEARCH-V06-001
+
+### REQ-V06-004 - Preserve AGENTS.md as source of truth
+
+- **Pattern:** unwanted behavior
+- **Statement:** When adapter files are added, the repository shall not let them become independent sources of truth for workflow rules.
+- **Acceptance:** Adapter docs point back to `AGENTS.md`, `.codex/`, `.claude/`, or generated inventories, and verification catches known drift where practical.
+- **Priority:** must
+- **Satisfies:** RESEARCH-V06-001
+
+### REQ-V06-005 - Add opt-in hook packs
+
+- **Pattern:** optional feature
+- **Statement:** Where maintainers enable workflow hooks, the repository shall provide opt-in hook packs for guardrails that must run deterministically.
+- **Acceptance:** Hook packs cover at least worktree/main-branch protection, Markdown artifact checks, and secrets/destructive-command guardrails in advisory or dry-run mode first.
+- **Priority:** should
+- **Satisfies:** RESEARCH-V06-001
+
+### REQ-V06-006 - Document hook safety and disable paths
+
+- **Pattern:** ubiquitous
+- **Statement:** The repository shall document hook scope, risk, dry-run behavior, and disable or bypass procedures.
+- **Acceptance:** Hook documentation explains authority boundaries, false-positive handling, local disable steps, and which hooks are safe to promote to blocking mode.
+- **Priority:** must
+- **Satisfies:** RESEARCH-V06-001
+
+### REQ-V06-007 - Add agentic security review path
+
+- **Pattern:** ubiquitous
+- **Statement:** The repository shall provide an agentic security review path aligned to OWASP Agentic Applications risk categories.
+- **Acceptance:** The path covers goal hijacking, tool misuse, excessive agency, memory or context poisoning, secrets exposure, and human authorization boundaries.
+- **Priority:** must
+- **Satisfies:** RESEARCH-V06-001
+
+### REQ-V06-008 - Avoid overstated security claims
+
+- **Pattern:** unwanted behavior
+- **Statement:** When the repository describes agentic security controls, it shall state limits and avoid implying certification or complete protection.
+- **Acceptance:** Public and workflow docs describe the controls as internal risk-reduction guidance, not external certification or guaranteed security.
+- **Priority:** must
+- **Satisfies:** RESEARCH-V06-001
+
+### REQ-V06-009 - Add adoption profiles
+
+- **Pattern:** ubiquitous
+- **Statement:** The repository shall provide adoption profiles that map common users to the smallest useful Specorator surface.
+- **Acceptance:** Profiles exist for solo builder, product team, agency/client delivery, enterprise governance, and brownfield migration, each linking to existing docs instead of duplicating them.
+- **Priority:** should
+- **Satisfies:** IDEA-V06-001
+
+### REQ-V06-010 - Sharpen public evidence-first positioning
+
+- **Pattern:** event-driven
+- **Statement:** When v0.6 adds live proof, adapters, hooks, and security guidance, the repository shall update public positioning to emphasize verification evidence and governed adoption.
+- **Acceptance:** README and product page language reflect proof, verification, cross-tool support, and clear comparison against lighter spec-driven or prompt-library alternatives.
+- **Priority:** should
+- **Satisfies:** RESEARCH-V06-001
+
+### REQ-V06-011 - Track ISO 9001:2026 impact
+
+- **Pattern:** event-driven
+- **Statement:** When ISO 9001:2026 is published or the project prepares v1.0, the repository shall review the QA track for required updates.
+- **Acceptance:** v0.6 adds a watch item or follow-up record that references the expected ISO/FDIS 9001 replacement timeline without changing QA requirements prematurely.
+- **Priority:** should
+- **Satisfies:** RESEARCH-V06-001
+
+### REQ-V06-012 - Keep v0.6 opt-in and reversible
+
+- **Pattern:** unwanted behavior
+- **Statement:** When v0.6 introduces adapters, hooks, or security workflows, the repository shall keep them opt-in unless a later ADR or release plan promotes them.
+- **Acceptance:** New surfaces document enablement and disablement, and no default workflow blocks contributors without explicit adoption.
+- **Priority:** must
+- **Satisfies:** IDEA-V06-001
+
+## Non-functional requirements
+
+| ID | Category | Requirement | Target |
+|---|---|---|---|
+| NFR-V06-001 | usability | First-run adoption must be understandable without reading the whole repository. | Golden path plus adoption profiles point to the minimum needed docs. |
+| NFR-V06-002 | maintainability | Adapter and hook surfaces must have clear ownership and drift checks where practical. | Generated inventories or validation docs identify source files and expected outputs. |
+| NFR-V06-003 | safety | Hooks and security review automation must start opt-in and reversible. | Dry-run/advisory defaults unless explicitly promoted. |
+| NFR-V06-004 | portability | New surfaces must preserve Markdown as the canonical artifact format. | No tool-specific data store replaces `specs/`, `docs/`, or `AGENTS.md`. |
+| NFR-V06-005 | credibility | Public claims must be backed by repository evidence. | Claims link to demo evidence, verification output, or source docs. |
+
+## Success metrics
+
+- A first-time adopter can identify the right adoption profile in under five minutes.
+- The first-feature tutorial no longer carries a "No live run yet" caveat after the demo is executed or replaced by verified evidence.
+- At least three non-Claude adapter surfaces are documented or generated with drift rules.
+- Hook packs can be enabled in advisory mode without changing the default contributor path.
+- Agentic security review guidance exists and states its limits clearly.
+
+## Quality gate
+
+- [x] Functional requirements use EARS and stable IDs.
+- [x] Acceptance criteria are testable.
+- [x] Non-goals keep v0.6 from absorbing v0.5 publishing or v2.0 plugin work.

--- a/specs/version-0-6-plan/research.md
+++ b/specs/version-0-6-plan/research.md
@@ -1,0 +1,82 @@
+---
+id: RESEARCH-V06-001
+title: Version 0.6 productization and trust plan - Research
+stage: research
+feature: version-0-6-plan
+status: accepted
+owner: analyst
+inputs:
+  - IDEA-V06-001
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+# Research - Version 0.6 productization and trust plan
+
+## Context
+
+The repository already has the pieces of a credible product: AGENTS.md as cross-tool context, Claude agents and skills, Codex delivery instructions, quality metrics, worktree discipline, CI/security workflows, an Obsidian UI layer, and a public product page. The remaining gap is that users must infer how these pieces become an adoption path. Several steering docs still contain placeholder copy, the first-feature tutorial is desk-validated rather than live-run, and cross-tool support is described more as portability than as installable adapter surfaces.
+
+## Market and platform signals
+
+- Anthropic's Claude Code best practices emphasize verification, exploring before planning and coding, keeping `CLAUDE.md` concise, using skills for on-demand workflows, using subagents for isolated investigation, and using hooks for actions that must happen every time. Source: <https://code.claude.com/docs/en/best-practices>.
+- OpenAI Codex documents `AGENTS.md`, skills, hooks, plugins, subagents, and the Codex GitHub Action as first-class customization and automation surfaces. Sources: <https://developers.openai.com/codex/guides/agents-md>, <https://developers.openai.com/codex/skills>, <https://developers.openai.com/codex/hooks>, <https://developers.openai.com/codex/github-action>.
+- GitHub Copilot customization now includes custom instructions, prompt files, custom agents, agent skills, hooks, and MCP servers, with project skills accepted under `.github/skills/`, `.claude/skills/`, or `.agents/skills/`. Source: <https://docs.github.com/en/copilot/reference/customization-cheat-sheet>.
+- GitHub Spec Kit has a clear install and init story, supported AI coding agent integrations, extension catalogs, presets, and community examples. Source: <https://github.com/github/spec-kit>.
+- Sonar's 2026 State of Code survey reports that AI-generated code is a large and growing share of committed code, while many developers do not always verify it before committing. Source: <https://www.sonarsource.com/blog/state-of-code-developer-survey-report-the-current-reality-of-ai-coding>.
+- OWASP's Top 10 for Agentic Applications 2026 provides a peer-reviewed operational starting point for autonomous-agent risks. Source: <https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/>.
+- ISO lists ISO/FDIS 9001 as expected to replace ISO 9001:2015 in September 2026. Source: <https://www.iso.org/standard/88464.html>.
+
+## Alternatives
+
+### Alternative A - Productization and trust release
+
+Use v0.6 to improve adoption proof, cross-tool compatibility, deterministic hooks, and agentic security governance.
+
+**Pros:** Directly addresses adoption, trust, and current market needs without changing the lifecycle.
+
+**Cons:** Touches several docs/tooling surfaces and needs careful scoping to avoid becoming a broad cleanup release.
+
+### Alternative B - Obsidian plugin acceleration
+
+Move directly into the v2.0 Obsidian plugin direction after v0.5.
+
+**Pros:** Strong user-facing interface story and aligns with issue #96.
+
+**Cons:** Depends on released packages and stable installation/update semantics that v0.6 should prove first.
+
+### Alternative C - v1.0 stabilization only
+
+Skip v0.6 and focus all effort on the v1.0 release readiness checklist.
+
+**Pros:** Reduces version sprawl and keeps attention on stable release mechanics.
+
+**Cons:** Leaves productization, cross-tool adapters, live proof, and agentic security gaps unresolved before v1.0.
+
+## Recommendation
+
+Choose Alternative A. v0.6 should be a productization and trust release that bridges v0.5 distribution to v1.0 stability and v2.0 Obsidian UX. It should not add a mandatory stage or a plugin. It should make the existing workflow easier to adopt, easier to verify, easier to run across agent tools, and easier to defend from agent-specific risk.
+
+## Risks
+
+| ID | Risk | Severity | Mitigation |
+|---|---|---|---|
+| RISK-V06-001 | Cross-tool adapters drift from the canonical `AGENTS.md` and Claude surfaces. | high | Generate or validate adapter inventories from a source-of-truth map and document ownership. |
+| RISK-V06-002 | Hook packs become too aggressive and block legitimate local work. | high | Ship hooks as opt-in profiles first, with dry-run/advisory mode and documented disable paths. |
+| RISK-V06-003 | Agentic security claims overstate protection. | high | Align to OWASP risk categories, state limits clearly, and avoid certification claims. |
+| RISK-V06-004 | Golden-path demo is brittle or too slow for CI. | medium | Start with deterministic artifact validation and promote to CI execution only after a stable dry run. |
+| RISK-V06-005 | Adoption profiles duplicate docs and add maintenance overhead. | medium | Keep profiles as short entry-point maps linking to existing docs, not parallel manuals. |
+| RISK-V06-006 | ISO 9001:2026 references become stale before final publication. | medium | Add a watch item and avoid updating QA requirements until the published standard is final. |
+
+## Sources
+
+- Claude Code best practices: <https://code.claude.com/docs/en/best-practices>
+- OpenAI Codex AGENTS.md guide: <https://developers.openai.com/codex/guides/agents-md>
+- OpenAI Codex skills: <https://developers.openai.com/codex/skills>
+- OpenAI Codex hooks: <https://developers.openai.com/codex/hooks>
+- OpenAI Codex GitHub Action: <https://developers.openai.com/codex/github-action>
+- GitHub Copilot customization cheat sheet: <https://docs.github.com/en/copilot/reference/customization-cheat-sheet>
+- GitHub Spec Kit: <https://github.com/github/spec-kit>
+- OWASP Top 10 for Agentic Applications 2026: <https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/>
+- Sonar 2026 State of Code survey: <https://www.sonarsource.com/blog/state-of-code-developer-survey-report-the-current-reality-of-ai-coding>
+- ISO/FDIS 9001: <https://www.iso.org/standard/88464.html>

--- a/specs/version-0-6-plan/spec.md
+++ b/specs/version-0-6-plan/spec.md
@@ -1,0 +1,79 @@
+---
+id: SPECDOC-V06-001
+title: Version 0.6 productization and trust plan - Specification
+stage: specification
+feature: version-0-6-plan
+status: accepted
+owner: architect
+inputs:
+  - DESIGN-V06-001
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+# Specification - Version 0.6 productization and trust plan
+
+### SPEC-V06-001 - Specorator steering profile
+
+- **Satisfies:** REQ-V06-001, NFR-V06-001
+- **Behavior:** Repository docs distinguish downstream steering templates from Specorator's own product steering and explain which agents should read which source.
+- **Acceptance:** A contributor can identify the steering context for template improvements without overwriting adopter-facing template guidance.
+
+### SPEC-V06-002 - Golden-path proof package
+
+- **Satisfies:** REQ-V06-002, NFR-V06-005
+- **Behavior:** A verified demo package includes tutorial updates, example artifacts, deterministic validation, and an evidence note with date, commit, commands, and caveats.
+- **Acceptance:** The first-feature tutorial no longer relies only on desk validation.
+
+### SPEC-V06-003 - Cross-tool adapter inventory
+
+- **Satisfies:** REQ-V06-003, REQ-V06-004, NFR-V06-002, NFR-V06-004
+- **Behavior:** Adapter surfaces for Copilot, Codex, and at least one editor-agent path are documented or generated from canonical workflow sources.
+- **Acceptance:** Adapter files point back to `AGENTS.md` and the owning tool-specific directories, and drift ownership is explicit.
+
+### SPEC-V06-004 - Hook pack contract
+
+- **Satisfies:** REQ-V06-005, REQ-V06-006, REQ-V06-012, NFR-V06-003
+- **Behavior:** Hook packs are opt-in and start in dry-run or advisory mode, with documented scope, false-positive handling, and disable paths.
+- **Acceptance:** Enabling hooks does not silently add irreversible or blocking behavior.
+
+### SPEC-V06-005 - Agentic security review
+
+- **Satisfies:** REQ-V06-007, REQ-V06-008, NFR-V06-003, NFR-V06-005
+- **Behavior:** The repository provides an OWASP-aligned review path for autonomous-agent risks and records findings, mitigations, residual risks, and follow-ups.
+- **Acceptance:** Security docs describe risk reduction and limits without implying external certification or complete protection.
+
+### SPEC-V06-006 - Adoption profiles
+
+- **Satisfies:** REQ-V06-009, NFR-V06-001
+- **Behavior:** Persona adoption profiles route users to the smallest useful Specorator surfaces for their situation.
+- **Acceptance:** Profiles link to existing docs and do not duplicate the full method.
+
+### SPEC-V06-007 - Evidence-first public positioning
+
+- **Satisfies:** REQ-V06-010, NFR-V06-005
+- **Behavior:** Public docs and product page emphasize verification evidence, live proof, cross-tool support, and governed adoption.
+- **Acceptance:** Claims are backed by links to artifacts, checks, examples, or source documentation.
+
+### SPEC-V06-008 - ISO 9001:2026 watch item
+
+- **Satisfies:** REQ-V06-011
+- **Behavior:** The repository records a follow-up to review the Quality Assurance Track when ISO 9001:2026 is published or during v1.0 readiness.
+- **Acceptance:** QA docs avoid premature requirement changes while preserving a clear review trigger.
+
+## Test scenarios
+
+| ID | Requirement | Scenario | Expected result |
+|---|---|---|---|
+| TEST-V06-001 | REQ-V06-001 | A contributor searches for Specorator's own product steering. | The correct steering source is explicit and does not erase adopter templates. |
+| TEST-V06-002 | REQ-V06-002 | A first-time user follows the golden-path docs. | The docs point to verified artifacts and evidence from a live or deterministic run. |
+| TEST-V06-003 | REQ-V06-003 | A Copilot or Codex user looks for native setup files. | The adapter path exists and points to canonical workflow rules. |
+| TEST-V06-004 | REQ-V06-004 | Adapter content is compared with canonical instructions. | Drift is prevented by generation, validation, or documented ownership. |
+| TEST-V06-005 | REQ-V06-005 | A maintainer enables hook packs in advisory mode. | Hooks report guardrail findings without silently blocking unrelated work. |
+| TEST-V06-006 | REQ-V06-006 | A hook false positive occurs. | Docs explain disable, bypass, or remediation steps. |
+| TEST-V06-007 | REQ-V06-007 | A reviewer runs the agentic security review path. | Findings cover OWASP-aligned agent risks and human authorization boundaries. |
+| TEST-V06-008 | REQ-V06-008 | Public docs describe security controls. | Claims are limited to internal risk reduction and avoid certification language. |
+| TEST-V06-009 | REQ-V06-009 | A solo builder or enterprise evaluator chooses a profile. | The profile routes them to a minimal, concrete starting path. |
+| TEST-V06-010 | REQ-V06-010 | README and product page are reviewed after v0.6 implementation. | Positioning emphasizes verification, proof, and cross-tool adoption accurately. |
+| TEST-V06-011 | REQ-V06-011 | ISO 9001:2026 publication status changes. | A tracked follow-up prompts QA track review before v1.0 or the next QA release. |
+| TEST-V06-012 | REQ-V06-012 | A default contributor runs normal verification after v0.6. | New adapters, hooks, and security docs do not impose mandatory opt-in behavior. |

--- a/specs/version-0-6-plan/tasks.md
+++ b/specs/version-0-6-plan/tasks.md
@@ -1,0 +1,120 @@
+---
+id: TASKS-V06-001
+title: Version 0.6 productization and trust plan - Tasks
+stage: tasks
+feature: version-0-6-plan
+status: complete
+owner: planner
+inputs:
+  - PRD-V06-001
+  - SPECDOC-V06-001
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+# Tasks - Version 0.6 productization and trust plan
+
+### T-V06-001 - Decide steering profile location
+
+- **Description:** Decide whether Specorator's own steering lives in `docs/steering/`, a new product-specific folder, or another documented location; add an ADR if ownership semantics change.
+- **Satisfies:** REQ-V06-001, NFR-V06-001, SPEC-V06-001
+- **Owner:** architect
+- **Estimate:** M
+
+### T-V06-002 - Fill Specorator product steering
+
+- **Description:** Add or update product, UX, tech, quality, and operations steering for this template repository while preserving blank downstream guidance.
+- **Satisfies:** REQ-V06-001, NFR-V06-001, SPEC-V06-001
+- **Depends on:** T-V06-001
+- **Owner:** pm
+- **Estimate:** M
+
+### T-V06-003 - Define golden-path demo contract
+
+- **Description:** Define the demo subject, expected artifacts, evidence note format, validation scope, and success criteria for the first verified adopter path.
+- **Satisfies:** REQ-V06-002, NFR-V06-005, SPEC-V06-002
+- **Owner:** analyst
+- **Estimate:** M
+
+### T-V06-004 - Execute and record golden-path evidence
+
+- **Description:** Run or deterministically validate the golden-path demo, record date/commit/commands/caveats, and update the tutorial to remove desk-only caveats when justified.
+- **Satisfies:** REQ-V06-002, NFR-V06-005, SPEC-V06-002
+- **Depends on:** T-V06-003
+- **Owner:** qa
+- **Estimate:** L
+
+### T-V06-005 - Design cross-tool adapter inventory
+
+- **Description:** Map canonical source files to Copilot, Codex, Cursor/Aider, and generic agent adapter surfaces, including ownership and drift policy.
+- **Satisfies:** REQ-V06-003, REQ-V06-004, NFR-V06-002, NFR-V06-004, SPEC-V06-003
+- **Owner:** architect
+- **Estimate:** M
+
+### T-V06-006 - Add first cross-tool adapters
+
+- **Description:** Add or document first-class adapter paths for Copilot, Codex, and at least one editor-agent surface without duplicating workflow authority.
+- **Satisfies:** REQ-V06-003, REQ-V06-004, NFR-V06-002, NFR-V06-004, SPEC-V06-003
+- **Depends on:** T-V06-005
+- **Owner:** dev
+- **Estimate:** L
+
+### T-V06-007 - Add adapter drift checks or maintenance docs
+
+- **Description:** Add deterministic checks where practical, or explicit maintenance docs where generation is not yet stable, so adapter surfaces do not silently drift.
+- **Satisfies:** REQ-V06-004, NFR-V06-002, SPEC-V06-003
+- **Depends on:** T-V06-006
+- **Owner:** dev
+- **Estimate:** M
+
+### T-V06-008 - Design opt-in hook packs
+
+- **Description:** Define hook packs for worktree, branch, Markdown, secrets/risky commands, and handoff context, including dry-run behavior and promotion criteria.
+- **Satisfies:** REQ-V06-005, REQ-V06-006, REQ-V06-012, NFR-V06-003, SPEC-V06-004
+- **Owner:** architect
+- **Estimate:** M
+
+### T-V06-009 - Implement advisory hook examples
+
+- **Description:** Add opt-in hook examples and docs in advisory or dry-run mode, with disable and false-positive procedures.
+- **Satisfies:** REQ-V06-005, REQ-V06-006, REQ-V06-012, NFR-V06-003, SPEC-V06-004
+- **Depends on:** T-V06-008
+- **Owner:** dev
+- **Estimate:** L
+
+### T-V06-010 - Add agentic security review path
+
+- **Description:** Add an OWASP-aligned agentic security review doc, checklist, or skill covering goal hijacking, tool misuse, excessive agency, memory/context poisoning, secrets exposure, and human authorization boundaries.
+- **Satisfies:** REQ-V06-007, REQ-V06-008, NFR-V06-003, NFR-V06-005, SPEC-V06-005
+- **Owner:** reviewer
+- **Estimate:** L
+
+### T-V06-011 - Add adoption profiles
+
+- **Description:** Add concise persona profiles for solo builder, product team, agency/client delivery, enterprise governance, and brownfield migration.
+- **Satisfies:** REQ-V06-009, NFR-V06-001, SPEC-V06-006
+- **Owner:** pm
+- **Estimate:** M
+
+### T-V06-012 - Update evidence-first public positioning
+
+- **Description:** Update README and product page language for live proof, cross-tool adapters, hook guardrails, agentic security, and comparison against lighter spec-driven or prompt-library alternatives.
+- **Satisfies:** REQ-V06-010, NFR-V06-005, SPEC-V06-007
+- **Depends on:** T-V06-004, T-V06-006, T-V06-009, T-V06-010, T-V06-011
+- **Owner:** release-manager
+- **Estimate:** M
+
+### T-V06-013 - Add ISO 9001:2026 follow-up
+
+- **Description:** Record a watch item or follow-up issue for QA track review after ISO 9001:2026 publication or during v1.0 readiness.
+- **Satisfies:** REQ-V06-011, SPEC-V06-008
+- **Owner:** qa
+- **Estimate:** S
+
+### T-V06-014 - Verify v0.6 release readiness
+
+- **Description:** Run targeted checks, adapter/hook/security validation, link checks, product page checks, quality metrics, and `npm run verify`; document skipped automation and remaining risks.
+- **Satisfies:** REQ-V06-001, REQ-V06-002, REQ-V06-003, REQ-V06-004, REQ-V06-005, REQ-V06-006, REQ-V06-007, REQ-V06-008, REQ-V06-009, REQ-V06-010, REQ-V06-011, REQ-V06-012, SPEC-V06-001, SPEC-V06-002, SPEC-V06-003, SPEC-V06-004, SPEC-V06-005, SPEC-V06-006, SPEC-V06-007, SPEC-V06-008
+- **Depends on:** T-V06-012, T-V06-013
+- **Owner:** qa
+- **Estimate:** S

--- a/specs/version-0-6-plan/workflow-state.md
+++ b/specs/version-0-6-plan/workflow-state.md
@@ -1,0 +1,58 @@
+---
+feature: version-0-6-plan
+area: V06
+current_stage: implementation
+status: active
+last_updated: 2026-05-01
+last_agent: planner
+artifacts:
+  idea.md: complete
+  research.md: complete
+  requirements.md: complete
+  design.md: complete
+  spec.md: complete
+  tasks.md: complete
+  implementation-log.md: pending
+  test-plan.md: pending
+  test-report.md: pending
+  review.md: pending
+  traceability.md: pending
+  release-notes.md: pending
+  retrospective.md: pending
+---
+
+# Workflow state - version-0-6-plan
+
+## Stage progress
+
+| Stage | Artifact | Status |
+|---|---|---|
+| 1. Idea | `idea.md` | complete |
+| 2. Research | `research.md` | complete |
+| 3. Requirements | `requirements.md` | complete |
+| 4. Design | `design.md` | complete |
+| 5. Specification | `spec.md` | complete |
+| 6. Tasks | `tasks.md` | complete |
+| 7. Implementation | `implementation-log.md` + code/docs | pending |
+| 8. Testing | `test-plan.md`, `test-report.md` | pending |
+| 9. Review | `review.md`, `traceability.md` | pending |
+| 10. Release | `release-notes.md` | pending |
+| 11. Learning | `retrospective.md` | pending |
+
+## Skips
+
+- None.
+
+## Blocks
+
+- None.
+
+## Hand-off notes
+
+- 2026-05-01 (codex): Planned v0.6 through Stage 6 from the product research pass. Recommended implementation order is steering profile, live golden-path demo, cross-tool adapters, hook pack, agentic security workflow, proof-first public positioning, adoption profiles, ISO 9001:2026 watch item, then release readiness verification.
+
+## Open clarifications
+
+- [ ] CLAR-V06-001 - Confirm whether v0.6 should implement the full cross-tool adapter set or start with Claude Code, Codex, and Copilot only.
+- [ ] CLAR-V06-002 - Confirm whether the agentic security review is a new optional track, a QA checklist extension, or both.
+- [ ] CLAR-V06-003 - Confirm whether the golden-path demo should be fully automated in CI or documented as a maintainer-run release evidence check first.


### PR DESCRIPTION
## Summary

- Adds the v0.6 lifecycle planning artifacts through Stage 6 under `specs/version-0-6-plan/`.
- Frames v0.6 as the productization and trust release: steering profile, golden-path proof, cross-tool adapters, opt-in hooks, agentic security review, adoption profiles, evidence-first public positioning, and ISO 9001:2026 watch item.
- Adds the v0.6 row to the README roadmap.

## Linked issue

- Updates #91 from placeholder scope to concrete v0.6 planning scope.

## Verification

- `npm run check:specs`
- `npm run check:traceability`
- `npm run check:frontmatter`
- `npm run check:links`
- `npm run quality:metrics -- --feature version-0-6-plan`
- `npm run verify`

## Notes

- `npm run verify` initially failed in the fresh worktree because `typedoc` was not installed there; `npm ci` fixed the worktree dependencies and the full verify gate then passed.
- v0.6 remains an active implementation-stage plan with three open clarifications recorded in `workflow-state.md`.