### PR TITLE
fix(scripts): tighten doctor hygiene checks

### DIFF
--- a/docs/how-to/run-doctor.md
+++ b/docs/how-to/run-doctor.md
@@ -16,14 +16,14 @@
    - **Node** — version satisfies the engines field (`>=20`).
    - **npm** — present on `PATH`.
    - **git** — present on `PATH`.
-   - **branch** — current branch and upstream.
+   - **branch** — current branch, upstream, and ahead/behind state.
    - **git status** — clean / dirty.
-   - **worktrees** — every entry under `.worktrees/` is registered with git.
+   - **worktrees** — registered worktrees, unregistered `.worktrees/` directories, and merged local branches that are ready for cleanup.
    - **dependencies** — `node_modules/` matches `package.json`.
    - **ADR index** — re-runs `check:adr-index`.
    - **command inventories** — re-runs `check:commands`.
    - **verify gate** — re-runs `npm run verify` end-to-end.
-3. For every `warn` line, read the `hint` to decide if it matters for your task. Many warns (e.g. dirty tree on a topic branch) are expected.
+3. For every `warn` line, read the `hint` to decide if it matters for your task. A stale integration branch usually means `git pull --ff-only`; a merged branch or unregistered worktree usually means cleanup after the related PR is confirmed merged.
 4. For every `fail` line, fix the underlying cause before continuing. The doctor exits non-zero on any failure.
 5. Re-run until the trailing line reads `doctor: ok`.
 

--- a/docs/scripts/lib/doctor/README.md
+++ b/docs/scripts/lib/doctor/README.md
@@ -14,10 +14,14 @@ entry_point: true
 
 ## Type Aliases
 
+- [BranchReadinessInput](type-aliases/BranchReadinessInput.md)
 - [CheckResult](type-aliases/CheckResult.md)
 - [CheckStatus](type-aliases/CheckStatus.md)
+- [WorktreeHygieneInput](type-aliases/WorktreeHygieneInput.md)
 
 ## Functions
 
+- [branchReadinessCheck](functions/branchReadinessCheck.md)
 - [dependencyReadinessCheck](functions/dependencyReadinessCheck.md)
 - [workflowReadinessChecks](functions/workflowReadinessChecks.md)
+- [worktreeHygieneCheck](functions/worktreeHygieneCheck.md)

--- a/docs/scripts/lib/doctor/functions/branchReadinessCheck.md
+++ b/docs/scripts/lib/doctor/functions/branchReadinessCheck.md
@@ -1,0 +1,25 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/doctor](../README.md) / branchReadinessCheck
+
+# Function: branchReadinessCheck()
+
+> **branchReadinessCheck**(`input`): [`CheckResult`](../type-aliases/CheckResult.md)
+
+Check whether the current branch is fresh enough to start or resume work.
+
+## Parameters
+
+### input
+
+[`BranchReadinessInput`](../type-aliases/BranchReadinessInput.md)
+
+Current branch, upstream, and ahead/behind counts.
+
+## Returns
+
+[`CheckResult`](../type-aliases/CheckResult.md)
+
+Branch readiness result.

--- a/docs/scripts/lib/doctor/functions/worktreeHygieneCheck.md
+++ b/docs/scripts/lib/doctor/functions/worktreeHygieneCheck.md
@@ -1,0 +1,25 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/doctor](../README.md) / worktreeHygieneCheck
+
+# Function: worktreeHygieneCheck()
+
+> **worktreeHygieneCheck**(`input`): [`CheckResult`](../type-aliases/CheckResult.md)
+
+Check whether .worktrees/ matches git's registered worktree state.
+
+## Parameters
+
+### input
+
+[`WorktreeHygieneInput`](../type-aliases/WorktreeHygieneInput.md)
+
+Registered worktrees, filesystem directories, and merged local branches.
+
+## Returns
+
+[`CheckResult`](../type-aliases/CheckResult.md)
+
+Worktree hygiene result.

--- a/docs/scripts/lib/doctor/type-aliases/BranchReadinessInput.md
+++ b/docs/scripts/lib/doctor/type-aliases/BranchReadinessInput.md
@@ -1,0 +1,33 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/doctor](../README.md) / BranchReadinessInput
+
+# Type Alias: BranchReadinessInput
+
+> **BranchReadinessInput** = `object`
+
+## Properties
+
+### ahead
+
+> **ahead**: `number`
+
+***
+
+### behind
+
+> **behind**: `number`
+
+***
+
+### branchName
+
+> **branchName**: `string`
+
+***
+
+### upstreamName
+
+> **upstreamName**: `string`

--- a/docs/scripts/lib/doctor/type-aliases/WorktreeHygieneInput.md
+++ b/docs/scripts/lib/doctor/type-aliases/WorktreeHygieneInput.md
@@ -1,0 +1,33 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/doctor](../README.md) / WorktreeHygieneInput
+
+# Type Alias: WorktreeHygieneInput
+
+> **WorktreeHygieneInput** = `object`
+
+## Properties
+
+### currentBranch
+
+> **currentBranch**: `string`
+
+***
+
+### mergedBranches
+
+> **mergedBranches**: `string`[]
+
+***
+
+### registeredWorktrees
+
+> **registeredWorktrees**: `string`[]
+
+***
+
+### worktreeDirectories
+
+> **worktreeDirectories**: `string`[]

--- a/docs/worktrees.md
+++ b/docs/worktrees.md
@@ -31,6 +31,7 @@ cd .worktrees/<slug>
 
 # 3. After the PR merges, clean up
 cd ../..                             # back to the main checkout
+git pull --ff-only                   # bring the integration branch to the merge commit
 git worktree remove .worktrees/<slug>
 git branch -d <prefix>/<slug>
 git worktree prune                   # if needed
@@ -54,6 +55,8 @@ For anything that touches code, runs tests, or is reviewed by an automated revie
 - **`git worktree add` against an existing branch.** Use `-b <new-branch>` to create + switch atomically. If the branch already exists, the prior fix is in flight; don't clobber it.
 - **`git pull` while inside the main checkout's integration branch with worktrees open.** Safe — the worktrees see the new commits the next time they `fetch`.
 - **Deleting a worktree directory with `rm -rf`.** Use `git worktree remove`. A bare `rm -rf` leaves a stale `.git/worktrees/<slug>` administrative entry; `git worktree prune` cleans that up after the fact.
+- **Empty directories left under `.worktrees/`.** `npm run doctor` warns when a directory exists under `.worktrees/` but is not registered as a git worktree. Confirm it is empty and unrelated to active work before deleting it.
+- **Merged local branches piling up.** `npm run doctor` warns when local topic branches are already merged into `origin/main`. Delete them after the PR merge is confirmed and the matching worktree is removed.
 
 ## Settings
 

--- a/scripts/doctor.ts
+++ b/scripts/doctor.ts
@@ -1,5 +1,13 @@
 import { SpawnSyncReturns, spawnSync } from "node:child_process";
-import { CheckResult, dependencyReadinessCheck, workflowReadinessChecks } from "./lib/doctor.js";
+import fs from "node:fs";
+import path from "node:path";
+import {
+  CheckResult,
+  branchReadinessCheck,
+  dependencyReadinessCheck,
+  workflowReadinessChecks,
+  worktreeHygieneCheck,
+} from "./lib/doctor.js";
 import { repoRoot } from "./lib/repo.js";
 
 type Check = {
@@ -70,8 +78,23 @@ function checkGitBranch(): Check {
       }
 
       const branchName = firstLine(branch.stdout);
-      const upstreamName = upstream.status === 0 ? firstLine(upstream.stdout) : "no upstream";
-      return { name: "branch", status: "pass", detail: `${branchName} -> ${upstreamName}` };
+      if (upstream.status !== 0) {
+        return { name: "branch", status: "pass", detail: `${branchName} -> no upstream` };
+      }
+
+      const upstreamName = firstLine(upstream.stdout);
+      const counts = run("git", ["rev-list", "--left-right", "--count", "HEAD...@{u}"]);
+      if (counts.status !== 0) {
+        return { name: "branch", status: "fail", detail: "could not compare branch with upstream" };
+      }
+
+      const [aheadText = "0", behindText = "0"] = firstLine(counts.stdout).split(/\s+/);
+      return branchReadinessCheck({
+        branchName,
+        upstreamName,
+        ahead: Number(aheadText),
+        behind: Number(behindText),
+      });
     },
   };
 }
@@ -102,8 +125,20 @@ function checkWorktrees(): Check {
       const result = run("git", ["worktree", "list", "--porcelain"]);
       if (result.status !== 0) return { name: "worktrees", status: "fail", detail: "git worktree list failed" };
 
-      const worktreeCount = result.stdout.split(/\r?\n/).filter((line) => line.startsWith("worktree ")).length;
-      return { name: "worktrees", status: "pass", detail: `${worktreeCount} registered` };
+      const registeredWorktrees = result.stdout
+        .split(/\r?\n/)
+        .filter((line) => line.startsWith("worktree "))
+        .map((line) => line.slice("worktree ".length));
+      const worktreeDirectories = worktreeDirectoryNames();
+      const mergedBranches = mergedLocalBranches();
+      const branch = run("git", ["branch", "--show-current"]);
+
+      return worktreeHygieneCheck({
+        registeredWorktrees,
+        worktreeDirectories,
+        mergedBranches,
+        currentBranch: branch.status === 0 ? firstLine(branch.stdout) : "",
+      });
     },
   };
 }
@@ -148,6 +183,24 @@ function run(command: string, args: string[]): SpawnSyncReturns<string> {
     encoding: "utf8",
     windowsHide: true,
   });
+}
+
+function worktreeDirectoryNames(): string[] {
+  const worktreesPath = path.join(repoRoot, ".worktrees");
+  if (!fs.existsSync(worktreesPath)) return [];
+  return fs
+    .readdirSync(worktreesPath, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name);
+}
+
+function mergedLocalBranches(): string[] {
+  const result = run("git", ["branch", "--merged", "origin/main", "--format=%(refname:short)"]);
+  if (result.status !== 0) return [];
+  return result.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
 }
 
 function commandInvocation(command: string, args: string[]): { command: string; args: string[] } {

--- a/scripts/lib/doctor.ts
+++ b/scripts/lib/doctor.ts
@@ -10,6 +10,20 @@ export type CheckResult = {
   hint?: string;
 };
 
+export type BranchReadinessInput = {
+  branchName: string;
+  upstreamName: string;
+  ahead: number;
+  behind: number;
+};
+
+export type WorktreeHygieneInput = {
+  registeredWorktrees: string[];
+  worktreeDirectories: string[];
+  mergedBranches: string[];
+  currentBranch: string;
+};
+
 type PackageJson = {
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
@@ -101,6 +115,77 @@ export function workflowReadinessChecks(root: string): CheckResult[] {
   return workflowContracts.map((contract) => workflowReadinessCheck(root, contract));
 }
 
+/**
+ * Check whether the current branch is fresh enough to start or resume work.
+ *
+ * @param input - Current branch, upstream, and ahead/behind counts.
+ * @returns Branch readiness result.
+ */
+export function branchReadinessCheck(input: BranchReadinessInput): CheckResult {
+  const { branchName, upstreamName, ahead, behind } = input;
+  const detail = `${branchName} -> ${upstreamName}`;
+  const integrationBranch = branchName === "main" || branchName === "develop";
+
+  if (integrationBranch && ahead > 0) {
+    return {
+      name: "branch",
+      status: "fail",
+      detail: `${detail}; ahead ${ahead}`,
+      hint: `preserve any work on a topic branch, then reset ${branchName} only after confirming it is safe`,
+    };
+  }
+
+  if (behind > 0) {
+    return {
+      name: "branch",
+      status: "warn",
+      detail: `${detail}; behind ${behind}`,
+      hint: integrationBranch ? `run git pull --ff-only` : `merge or recreate from ${upstreamName} before depending on latest changes`,
+    };
+  }
+
+  if (ahead > 0) {
+    return {
+      name: "branch",
+      status: "warn",
+      detail: `${detail}; ahead ${ahead}`,
+      hint: "push or review local commits before handing off the branch",
+    };
+  }
+
+  return { name: "branch", status: "pass", detail };
+}
+
+/**
+ * Check whether .worktrees/ matches git's registered worktree state.
+ *
+ * @param input - Registered worktrees, filesystem directories, and merged local branches.
+ * @returns Worktree hygiene result.
+ */
+export function worktreeHygieneCheck(input: WorktreeHygieneInput): CheckResult {
+  const registeredNames = new Set(input.registeredWorktrees.map((entry) => normalizeWorktreeName(entry)).filter(Boolean));
+  const unregisteredDirectories = input.worktreeDirectories.filter((directory) => !registeredNames.has(directory));
+  const staleBranches = input.mergedBranches.filter(
+    (branch) => branch !== input.currentBranch && branch !== "main" && branch !== "develop",
+  );
+
+  const warnings = [
+    ...unregisteredDirectories.map((directory) => `.worktrees/${directory} is not registered`),
+    ...staleBranches.map((branch) => `${branch} is already merged into origin/main`),
+  ];
+
+  if (warnings.length > 0) {
+    return {
+      name: "worktrees",
+      status: "warn",
+      detail: `${input.registeredWorktrees.length} registered; ${warnings.length} hygiene warning(s)`,
+      hint: `${warnings.join("; ")}. After merged PRs are confirmed, remove stale worktrees/branches with the cleanup workflow.`,
+    };
+  }
+
+  return { name: "worktrees", status: "pass", detail: `${input.registeredWorktrees.length} registered` };
+}
+
 function workflowReadinessCheck(root: string, contract: WorkflowContract): CheckResult {
   const absolutePath = path.join(root, contract.filePath);
   if (!fs.existsSync(absolutePath)) {
@@ -128,4 +213,8 @@ function workflowReadinessCheck(root: string, contract: WorkflowContract): Check
     status: "pass",
     detail: `${contract.filePath} ready`,
   };
+}
+
+function normalizeWorktreeName(worktreePath: string): string {
+  return path.basename(worktreePath.replace(/[/\\]$/, ""));
 }

--- a/tests/scripts/doctor.test.ts
+++ b/tests/scripts/doctor.test.ts
@@ -3,7 +3,12 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
-import { dependencyReadinessCheck, workflowReadinessChecks } from "../../scripts/lib/doctor.js";
+import {
+  branchReadinessCheck,
+  dependencyReadinessCheck,
+  workflowReadinessChecks,
+  worktreeHygieneCheck,
+} from "../../scripts/lib/doctor.js";
 
 test("dependencyReadinessCheck points lockfile installs at npm ci", () => {
   const root = tempRepo();
@@ -152,6 +157,82 @@ test("workflowReadinessChecks requires checkout before uploading Pages artifacts
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
+});
+
+test("branchReadinessCheck passes a clean tracked branch", () => {
+  assert.deepEqual(
+    branchReadinessCheck({
+      branchName: "feat/example",
+      upstreamName: "origin/feat/example",
+      ahead: 0,
+      behind: 0,
+    }),
+    {
+      name: "branch",
+      status: "pass",
+      detail: "feat/example -> origin/feat/example",
+    },
+  );
+});
+
+test("branchReadinessCheck warns when a branch is behind upstream", () => {
+  assert.deepEqual(
+    branchReadinessCheck({
+      branchName: "main",
+      upstreamName: "origin/main",
+      ahead: 0,
+      behind: 3,
+    }),
+    {
+      name: "branch",
+      status: "warn",
+      detail: "main -> origin/main; behind 3",
+      hint: "run git pull --ff-only",
+    },
+  );
+});
+
+test("branchReadinessCheck fails when an integration branch is ahead", () => {
+  assert.deepEqual(
+    branchReadinessCheck({
+      branchName: "develop",
+      upstreamName: "origin/develop",
+      ahead: 1,
+      behind: 0,
+    }),
+    {
+      name: "branch",
+      status: "fail",
+      detail: "develop -> origin/develop; ahead 1",
+      hint: "preserve any work on a topic branch, then reset develop only after confirming it is safe",
+    },
+  );
+});
+
+test("worktreeHygieneCheck warns for unregistered .worktrees directories", () => {
+  const result = worktreeHygieneCheck({
+    registeredWorktrees: ["/repo", "/repo/.worktrees/active"],
+    worktreeDirectories: ["active", "stale-empty"],
+    mergedBranches: ["main"],
+    currentBranch: "feat/current",
+  });
+
+  assert.equal(result.status, "warn");
+  assert.equal(result.detail, "2 registered; 1 hygiene warning(s)");
+  assert.match(result.hint || "", /\.worktrees\/stale-empty is not registered/);
+});
+
+test("worktreeHygieneCheck warns for merged local branches", () => {
+  const result = worktreeHygieneCheck({
+    registeredWorktrees: ["/repo"],
+    worktreeDirectories: [],
+    mergedBranches: ["main", "feat/old", "feat/current"],
+    currentBranch: "feat/current",
+  });
+
+  assert.equal(result.status, "warn");
+  assert.equal(result.detail, "1 registered; 1 hygiene warning(s)");
+  assert.match(result.hint || "", /feat\/old is already merged into origin\/main/);
 });
 
 function tempRepo(): string {


### PR DESCRIPTION
## Summary
- warn when branches are stale or topic branches are ahead of upstream, and fail when integration branches contain local-only commits
- warn about unregistered `.worktrees/` directories and local branches already merged into `origin/main`
- document the stronger doctor/worktree hygiene expectations and regenerate script API docs

## Verification
- `npm run test:scripts`
- `npm run doctor`
- `npm run verify`

## Notes
- Doctor warnings are advisory except for local-only commits on `main`/`develop`.
- Existing local cleanup is intentionally left for a post-merge maintenance step.