### PR TITLE
fix(scripts): gate unresolved done clarifications

### DIFF
--- a/docs/quality-metrics.md
+++ b/docs/quality-metrics.md
@@ -102,6 +102,8 @@ Stage score avoids false negatives while a workflow is legitimately in progress:
 
 The lifecycle artifact percentage remains visible so readers can still see total progress across all 11 stages.
 
+Open clarification signals count only unresolved checklist entries (`- [ ]`) under `## Open clarifications`. Resolved entries (`- [x]`) remain in the artifact history but do not count as active risks. Active workflows may carry unresolved clarifications as advisory signals; workflows marked `status: done` fail deterministic validation until all clarification checkboxes are resolved.
+
 ## Maturity model
 
 The maturity assessment is an adoption guide. It uses observable repository evidence and reports the highest level currently supported by that evidence.

--- a/scripts/lib/quality-metrics.ts
+++ b/scripts/lib/quality-metrics.ts
@@ -680,7 +680,7 @@ function readWorkflowMetric(statePath: string): WorkflowMetric | null {
     testCoverageExpected,
     earsCoverage,
     earsExpected,
-    openClarifications: sectionItemCount(text, "Open clarifications"),
+    openClarifications: unresolvedChecklistItemCount(text, "Open clarifications"),
     blockers: sectionItemCount(text, "Blocks"),
     counts: {
       artifactsExpected: artifactNames.length,
@@ -923,6 +923,16 @@ function sectionItemCount(text: string, heading: string): number {
     .split(/\r?\n/)
     .filter((line) => /^-\s+/.test(line.trim()))
     .filter((line) => !/^-\s+None\.?$/i.test(line.trim()))
+    .length;
+}
+
+function unresolvedChecklistItemCount(text: string, heading: string): number {
+  const pattern = new RegExp(`^## ${escapeRegExp(heading)}\\s*$([\\s\\S]*?)(?=^##\\s+|$(?![\\s\\S]))`, "im");
+  const match = text.match(pattern);
+  if (!match) return 0;
+  return match[1]
+    .split(/\r?\n/)
+    .filter((line) => /^-\s+\[\s\]\s+/.test(line.trim()))
     .length;
 }
 

--- a/scripts/lib/spec-state.ts
+++ b/scripts/lib/spec-state.ts
@@ -50,6 +50,7 @@ export function specStateDiagnosticsForText(
   validateStageProgress(rel, frontmatter.body, data, errors);
   validateRequiredSections(rel, frontmatter.body, errors);
   validateSkipsDocumentation(rel, frontmatter.body, data, errors);
+  validateDoneClarifications(rel, frontmatter.body, data.status, errors);
   return errors;
 }
 
@@ -241,6 +242,25 @@ function validateSkipsDocumentation(
     if (!skipsBody.includes(artifact)) {
       errors.push(`${rel} marks ${artifact} as skipped, but Skips section does not document it`);
     }
+  }
+}
+
+function validateDoneClarifications(
+  rel: string,
+  body: string,
+  workflowStatus: unknown,
+  errors: string[],
+): void {
+  if (workflowStatus !== "done") return;
+  const clarificationsBody = extractSectionBody(body, "Open clarifications");
+  if (clarificationsBody === null) return;
+
+  const unresolvedCount = clarificationsBody
+    .split(/\r?\n/)
+    .filter((line) => /^-\s+\[\s\]\s+/.test(line.trim()))
+    .length;
+  if (unresolvedCount > 0) {
+    errors.push(`${rel} status is done, but Open clarifications has ${unresolvedCount} unresolved item(s)`);
   }
 }
 

--- a/templates/workflow-state-template.md
+++ b/templates/workflow-state-template.md
@@ -66,6 +66,7 @@ Free-form. What does the next agent / human need to know? Where did the previous
 ## Open clarifications
 
 > Add and resolve as they come up. Unresolved clarifications block stage transitions.
+> A workflow cannot be marked `status: done` while any `- [ ]` clarification remains. Active workflows may carry unresolved clarifications as visible advisory signals.
 
 - [ ] CLAR-001 — …
 - [x] CLAR-002 — …  *(resolved YYYY-MM-DD: …)*

--- a/tests/scripts/quality-metrics.test.ts
+++ b/tests/scripts/quality-metrics.test.ts
@@ -49,6 +49,16 @@ test("collectQualityMetrics scores active workflows by current stage", () => {
   assert.equal(workflow.stageScore > workflow.artifactCompletion, true);
 });
 
+test("collectQualityMetrics ignores resolved clarification checklist items", () => {
+  const metrics = collectQualityMetrics({ feature: "cli-todo" });
+  const workflow = metrics.workflows[0];
+  assert.equal(workflow.openClarifications, 0);
+  assert.equal(
+    metrics.signals.openClarifications.some((signal) => signal.includes("cli-todo")),
+    false,
+  );
+});
+
 test("completeCanonicalArtifacts ignores non-lifecycle workflow-state keys", () => {
   assert.equal(
     completeCanonicalArtifacts({

--- a/tests/scripts/spec-state.test.ts
+++ b/tests/scripts/spec-state.test.ts
@@ -176,6 +176,29 @@ test("done status with non-complete artifact is reported", () => {
   );
 });
 
+test("done status with unresolved clarifications is reported", () => {
+  const text = completeWorkflowText().replace(
+    "## Open clarifications\n\n> None.",
+    "## Open clarifications\n\n- [ ] CLAR-FEAT-001 — Resolve before completion.",
+  );
+  const diagnostics = diagnose(text);
+  assert.ok(
+    diagnostics.includes(`${REL} status is done, but Open clarifications has 1 unresolved item(s)`),
+  );
+});
+
+test("done status with only resolved clarifications passes the clarification gate", () => {
+  const text = completeWorkflowText().replace(
+    "## Open clarifications\n\n> None.",
+    "## Open clarifications\n\n- [x] CLAR-FEAT-001 — resolved 2026-05-01.",
+  );
+  const diagnostics = diagnose(text);
+  assert.equal(
+    diagnostics.some((message) => message.includes("Open clarifications has")),
+    false,
+  );
+});
+
 test("missing Stage progress artifact table is reported", () => {
   const text = cleanText.replace(/\| Stage \| Artifact \| Status \|[\s\S]*?Learning \| `retrospective.md` \| pending \|\n/m, "");
   const diagnostics = diagnose(text);
@@ -253,3 +276,13 @@ test("parseStageProgressTable extracts artifact-status pairs", () => {
   assert.equal(table.get("test-plan.md"), "pending");
   assert.equal(table.get("test-report.md"), "pending");
 });
+
+function completeWorkflowText(): string {
+  return cleanText
+    .replace("current_stage: idea", "current_stage: learning")
+    .replace("status: active", "status: done")
+    .replace("idea.md: in-progress", "idea.md: complete")
+    .replaceAll(": pending", ": complete")
+    .replace("| 1. Idea | `idea.md` | in-progress |", "| 1. Idea | `idea.md` | complete |")
+    .replaceAll("| pending |", "| complete |");
+}


### PR DESCRIPTION
## Summary
- count only unresolved `- [ ]` clarification checklist items in quality metrics
- fail workflow-state validation when `status: done` still has unresolved clarifications
- document that active workflows keep unresolved clarifications as advisory signals

## Verification
- `npm run test:scripts`
- `npm run check:specs`
- `npm run quality:metrics -- --json`
- `npm run check:script-docs`
- `npm run verify`

## Notes
- Active v0.3/v0.4/v0.5/v0.6 workflow clarifications remain advisory and do not fail verify.
- Resolved `[x]` clarification history remains in artifacts but no longer appears as an active quality signal.