### PR TITLE
feat(scripts): require examples subdirs to ship workflow-state.md (T-V03-003 slice 2)

### DIFF
--- a/docs/scripts/lib/spec-state/README.md
+++ b/docs/scripts/lib/spec-state/README.md
@@ -18,5 +18,6 @@ entry_point: true
 
 ## Functions
 
+- [examplesCoverageDiagnostics](functions/examplesCoverageDiagnostics.md)
 - [parseStageProgressTable](functions/parseStageProgressTable.md)
 - [specStateDiagnosticsForText](functions/specStateDiagnosticsForText.md)

--- a/docs/scripts/lib/spec-state/functions/examplesCoverageDiagnostics.md
+++ b/docs/scripts/lib/spec-state/functions/examplesCoverageDiagnostics.md
@@ -1,0 +1,29 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/spec-state](../README.md) / examplesCoverageDiagnostics
+
+# Function: examplesCoverageDiagnostics()
+
+> **examplesCoverageDiagnostics**(`missingSubdirs`): `string`[]
+
+Emit a diagnostic for each example subdirectory missing a workflow-state.md file.
+
+The function is pure: directory traversal is the caller's responsibility.
+Pass the repository-relative POSIX paths of the offending subdirectories and
+receive one diagnostic per path naming the missing artifact.
+
+## Parameters
+
+### missingSubdirs
+
+`string`[]
+
+Repository-relative paths of example subdirectories that lack workflow-state.md.
+
+## Returns
+
+`string`[]
+
+Diagnostic messages, one per missing path.

--- a/scripts/check-spec-state.ts
+++ b/scripts/check-spec-state.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
-import { failIfErrors, readText, relativeToRoot, walkFiles } from "./lib/repo.js";
-import { specStateDiagnosticsForText } from "./lib/spec-state.js";
+import { failIfErrors, readText, relativeToRoot, repoRoot, walkFiles } from "./lib/repo.js";
+import { examplesCoverageDiagnostics, specStateDiagnosticsForText } from "./lib/spec-state.js";
 
 const errors: string[] = [];
 
@@ -16,6 +16,8 @@ for (const filePath of workflowStateFiles()) {
   );
 }
 
+errors.push(...examplesCoverageDiagnostics(exampleSubdirsMissingWorkflowState()));
+
 failIfErrors(errors, "check:specs");
 
 function workflowStateFiles(): string[] {
@@ -24,6 +26,20 @@ function workflowStateFiles(): string[] {
 
 function isWorkflowState(filePath: string): boolean {
   return path.basename(filePath) === "workflow-state.md";
+}
+
+function exampleSubdirsMissingWorkflowState(): string[] {
+  const examplesRoot = path.join(repoRoot, "examples");
+  if (!fs.existsSync(examplesRoot)) return [];
+
+  const missing: string[] = [];
+  for (const entry of fs.readdirSync(examplesRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const subdir = path.join(examplesRoot, entry.name);
+    if (fs.existsSync(path.join(subdir, "workflow-state.md"))) continue;
+    missing.push(relativeToRoot(subdir));
+  }
+  return missing;
 }
 
 export { parseStageProgressTable } from "./lib/spec-state.js";

--- a/scripts/lib/spec-state.ts
+++ b/scripts/lib/spec-state.ts
@@ -54,6 +54,20 @@ export function specStateDiagnosticsForText(
 }
 
 /**
+ * Emit a diagnostic for each example subdirectory missing a workflow-state.md file.
+ *
+ * The function is pure: directory traversal is the caller's responsibility.
+ * Pass the repository-relative POSIX paths of the offending subdirectories and
+ * receive one diagnostic per path naming the missing artifact.
+ *
+ * @param missingSubdirs - Repository-relative paths of example subdirectories that lack workflow-state.md.
+ * @returns Diagnostic messages, one per missing path.
+ */
+export function examplesCoverageDiagnostics(missingSubdirs: string[]): string[] {
+  return missingSubdirs.map((subdir) => `${subdir} missing workflow-state.md`);
+}
+
+/**
  * Extract artifact-status pairs from the Stage progress Markdown table.
  *
  * @param body - Markdown body after the YAML frontmatter.

--- a/tests/scripts/spec-state.test.ts
+++ b/tests/scripts/spec-state.test.ts
@@ -1,6 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { parseStageProgressTable, specStateDiagnosticsForText } from "../../scripts/lib/spec-state.js";
+import {
+  examplesCoverageDiagnostics,
+  parseStageProgressTable,
+  specStateDiagnosticsForText,
+} from "../../scripts/lib/spec-state.js";
 
 const REL = "specs/feat/workflow-state.md";
 const FEATURE_DIR = "feat";
@@ -239,6 +243,20 @@ test("skipped artifact mentioned in Skips section passes the skip-doc check", ()
       message.includes("Skips section does not document"),
     ),
     false,
+  );
+});
+
+test("examplesCoverageDiagnostics passes when no example subdirs are missing workflow-state.md", () => {
+  assert.deepEqual(examplesCoverageDiagnostics([]), []);
+});
+
+test("examplesCoverageDiagnostics reports each example subdir missing workflow-state.md", () => {
+  assert.deepEqual(
+    examplesCoverageDiagnostics(["examples/foo", "examples/bar"]),
+    [
+      "examples/foo missing workflow-state.md",
+      "examples/bar missing workflow-state.md",
+    ],
   );
 });
 


### PR DESCRIPTION
## Summary

- Adds a deterministic check that every direct child folder of `examples/` contains a `workflow-state.md`. Subdirectories without one fail `check:specs` with a diagnostic naming the missing path.
- New pure helper `examplesCoverageDiagnostics` in `scripts/lib/spec-state.ts` emits one diagnostic per missing subdir; the script walker stays a thin wrapper.
- Second slice of T-V03-003 (skipped-stage docs shipped in #95). Third slice — every `TEST-*` references a `REQ-*`/`NFR-*` — follows in a separate PR per branch-per-concern.

## Trace

- Refs: `specs/version-0-3-plan/tasks.md` (T-V03-003), `specs/version-0-3-plan/workflow-state.md` (CLAR-V03-002)

## Test plan

- [x] `npx tsx --test tests/scripts/spec-state.test.ts` (24 pass; 2 new examples-coverage tests)
- [x] `npm run verify` green locally
- [x] Manual sanity check: induced `examples/__sanity/` (no workflow-state.md), check fails with `examples/__sanity missing workflow-state.md`; removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)