### PR TITLE
docs(examples): align cli traceability metrics

### DIFF
--- a/examples/cli-todo/spec.md
+++ b/examples/cli-todo/spec.md
@@ -329,7 +329,7 @@ This interface is the sole mutation entry point for the on-disk store, per ADR-C
 - **Post-conditions:** Returns a string. Does not touch the filesystem.
 - **Side effects:** None.
 - **Errors:** None — path resolution is a pure function of the environment.
-- **Satisfies:** REQ-CLI-009, REQ-CLI-007.
+- **Satisfies:** REQ-CLI-009, REQ-CLI-007, NFR-CLI-003.
 
 ---
 
@@ -659,6 +659,19 @@ Inherits from PRD NFR-CLI-001 with no tightening:
 - **Budget:** any subcommand against a data store containing up to 10,000 tasks completes in ≤ 1 second wall-clock on a 2015-era commodity laptop (e.g., 4-core x86-64, SSD, 8 GB RAM, no encryption-at-rest overhead).
 - **Implementation implication (informative):** the read-all-into-memory-then-rewrite strategy is acceptable at this scale. No caching, no incremental write, no in-memory database is needed. The dominant cost is file I/O (read + temp write + fsync + rename), all of which are well under 100 ms at 10,000 tasks on commodity hardware.
 - **No per-interface tighter budget** is set in v1.
+
+---
+
+### SPEC-CLI-010 — Non-functional acceptance constraints
+
+- **Kind:** Cross-cutting acceptance contract.
+- **Performance:** Any subcommand against a data store containing up to 10,000 tasks completes in ≤ 1 second wall-clock on the reference hardware named in NFR-CLI-001.
+- **Portability:** v1 supports Linux and macOS using the resolver behavior in SPEC-CLI-009. Windows remains undefined for v1.
+- **Privacy:** The CLI has no telemetry, analytics, remote backup, cloud sync, or other network path.
+- **Maintainability:** Source remains small enough to review in one sitting; the target is ≤ 500 source lines excluding tests and generated files.
+- **Installability:** The example is installable from source with one language-toolchain command and no external service dependency.
+- **Traceability:** Review must leave a requirement-to-code mapping in the RTM before the worked example is marked complete.
+- **Satisfies:** NFR-CLI-001, NFR-CLI-003, NFR-CLI-004, NFR-CLI-005, NFR-CLI-006, NFR-CLI-007.
 
 ---
 

--- a/examples/cli-todo/traceability.md
+++ b/examples/cli-todo/traceability.md
@@ -33,13 +33,13 @@ generated: 2026-04-29 00:00
 | REQ-CLI-011 | SPEC-CLI-004 | T-CLI-007, T-CLI-008 | `internal/cli/rm.go` | TEST-CLI-015 | pass |
 | REQ-CLI-012 | SPEC-CLI-005, SPEC-CLI-008 | T-CLI-002, T-CLI-003, T-CLI-004 | `internal/cli/help.go`, `internal/storage/load.go` | TEST-CLI-023, TEST-CLI-024, TEST-CLI-025, TEST-CLI-026, TEST-CLI-027 | pass |
 | REQ-CLI-013 | SPEC-CLI-001 | T-CLI-007, T-CLI-008 | `internal/cli/add.go` | TEST-CLI-012, TEST-CLI-013 | pass |
-| NFR-CLI-001 | SPECDOC-CLI-001 | T-CLI-007 | `tests/integration/performance_test.go` | TEST-CLI-031 | pass |
+| NFR-CLI-001 | SPEC-CLI-010 | T-CLI-007 | `tests/integration/performance_test.go` | TEST-CLI-031 | pass |
 | NFR-CLI-002 | SPEC-CLI-008 | T-CLI-005, T-CLI-006 | `internal/storage/save.go` | TEST-CLI-018, TEST-CLI-033 | pass |
-| NFR-CLI-003 | PRD-CLI-001 | T-CLI-009 | `README.md` scope note | TEST-CLI-019, TEST-CLI-020 | pass |
-| NFR-CLI-004 | DESIGN-CLI-001 | T-CLI-009 | no network code path | TEST-CLI-029 | pass |
-| NFR-CLI-005 | DESIGN-CLI-001 | T-CLI-009 | source layout review | REVIEW-CLI-001 | pass |
-| NFR-CLI-006 | PRD-CLI-001 | T-CLI-009 | install notes | RELEASE-CLI-001 | pass |
-| NFR-CLI-007 | RTM-CLI-001 | T-CLI-009 | this matrix | REVIEW-CLI-001 | pass |
+| NFR-CLI-003 | SPEC-CLI-009, SPEC-CLI-010 | T-CLI-009 | `README.md` scope note | TEST-CLI-019, TEST-CLI-020 | pass |
+| NFR-CLI-004 | SPEC-CLI-010 | T-CLI-009 | no network code path | TEST-CLI-029 | pass |
+| NFR-CLI-005 | SPEC-CLI-010 | T-CLI-009 | source layout review | REVIEW-CLI-001 | pass |
+| NFR-CLI-006 | SPEC-CLI-010 | T-CLI-009 | install notes | RELEASE-CLI-001 | pass |
+| NFR-CLI-007 | SPEC-CLI-010 | T-CLI-009 | this matrix | REVIEW-CLI-001 | pass |
 
 ## Reverse coverage check
 
@@ -59,9 +59,16 @@ generated: 2026-04-29 00:00
 
 | Bucket | Total | Covered | Percent |
 |---|---:|---:|---:|
-| Functional REQs | 13 | 13 | 100% |
-| NFRs | 7 | 7 | 100% |
+| Functional REQs with spec/task/test links | 13 | 13 | 100% |
+| NFRs with spec/task evidence | 7 | 7 | 100% |
+| NFRs with automated `TEST-*` evidence | 7 | 4 | 57% |
+| NFRs with review/release evidence instead of `TEST-*` | 7 | 3 | 43% |
+| All requirements with canonical `TEST-*` evidence | 20 | 17 | 85% |
 | Spec scenarios | 33 | 33 | 100% |
+
+The three non-test NFRs are deliberate artifact checks: NFR-CLI-005 is reviewed through `REVIEW-CLI-001`, NFR-CLI-006 through `RELEASE-CLI-001`, and NFR-CLI-007 through this RTM plus `REVIEW-CLI-001`. They are not counted as automated `TEST-*` evidence by `quality:metrics`.
+
+`quality:metrics` should report 100% requirement-to-spec coverage, 100% requirement-to-task coverage, 85% requirement-to-test coverage, and a 95% stage-aware traceability average for this completed example.
 
 ## Open items blocking review
 


### PR DESCRIPTION
## Summary
- add a `SPEC-CLI-010` non-functional acceptance contract for the CLI worked example
- point NFR rows at concrete `SPEC-CLI-*` links where the spec contains the contract
- make the RTM coverage summary match quality metrics: 20/20 spec links, 20/20 task links, 17/20 canonical test links, 95% stage-aware traceability

## Verification
- `npm run check:traceability`
- `npm run quality:metrics -- --feature cli-todo --json`
- `npm run check:links`
- `npm run verify`

## Notes
- NFR-CLI-005, NFR-CLI-006, and NFR-CLI-007 intentionally remain review/release artifact checks rather than automated `TEST-*` evidence.