### PR TITLE
docs: plan V08 content-driven product page

### DIFF
--- a/specs/version-0-8-plan/design.md
+++ b/specs/version-0-8-plan/design.md
@@ -1,0 +1,149 @@
+---
+id: DESIGN-V08-001
+title: Version 0.8 content-driven product page plan - Design
+stage: design
+feature: version-0-8-plan
+status: accepted
+owner: architect
+inputs:
+  - PRD-V08-001
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+# Design - Version 0.8 content-driven product page plan
+
+## Product shape
+
+v0.8 should turn the product page from a hand-authored static HTML file into a built static site:
+
+1. **Content model:** page-purpose Markdown files describe public sections, CTAs, feature groupings, proof points, and visual references.
+2. **Artifact readers:** build-time code reads selected canonical Markdown/frontmatter from the repo for facts and source links.
+3. **Static generator:** Astro is the recommended first implementation because it fits the existing Node toolchain and GitHub Pages static output.
+4. **Generated site:** the build emits static HTML/CSS/assets suitable for GitHub Pages.
+5. **Verification:** checks validate content schema, artifact references, links, assets, and the deploy workflow.
+6. **Workflow guidance:** product-page skills and agents tell maintainers to update content and canonical artifacts in the right place.
+
+## Recommended architecture
+
+```
+Repository Markdown sources
+├── README.md
+├── docs/
+├── specs/version-*/workflow-state.md
+├── quality/
+└── sites/content/product-page/
+        │
+        ▼
+Build-time loaders and schemas
+├── parse page-purpose content
+├── read selected canonical frontmatter
+├── validate required sections and source links
+└── expose typed data to page components
+        │
+        ▼
+Astro static site
+├── layouts
+├── components
+├── generated routes
+└── static assets
+        │
+        ▼
+GitHub Pages artifact
+└── static HTML/CSS/JS/assets
+```
+
+## Content model
+
+The first implementation should keep the content model small and explicit.
+
+| File | Purpose |
+|---|---|
+| `sites/content/product-page/home.md` | Hero copy, primary CTA, supporting CTA, and summary positioning. |
+| `sites/content/product-page/features.md` | Curated feature groups with source references. |
+| `sites/content/product-page/proof.md` | Evidence, verification, quality signals, and source links. |
+| `sites/content/product-page/get-started.md` | Installation, first steps, and adoption-profile links. |
+| `sites/content/product-page/navigation.md` | Header/footer links and public docs links. |
+
+Implementation may split these into one-file-per-section or a small collection, but it should avoid a single large HTML file and avoid scattering public copy across component code.
+
+## Canonical artifact inputs
+
+The first build should read a constrained set of canonical artifacts:
+
+| Artifact | Public use |
+|---|---|
+| `README.md` | Repository name, overview links, installation/getting-started anchors. |
+| `docs/specorator.md` | Workflow definition and lifecycle summary links. |
+| `specs/version-*/workflow-state.md` | Active and planned version cards. |
+| `docs/adr/*.md` | Architecture decision count/status or selected decision links. |
+| `docs/quality-framework.md` | Quality gate and verification positioning. |
+
+Artifact readers should extract frontmatter and stable headings, not scrape arbitrary marketing sentences from bodies. Page-purpose files decide which extracted facts are shown.
+
+## Generator decision
+
+Use Astro as the default unless implementation discovers a blocker.
+
+| Criterion | Astro | Jekyll | Hugo |
+|---|---|---|---|
+| Existing stack fit | Strong: Node-based | Weaker: Ruby | Weaker: Go/Hugo |
+| Markdown/frontmatter | Strong | Strong | Strong |
+| Typed content schema | Strong | Limited | Moderate |
+| GitHub Pages | Supported through Actions | Built-in Pages path | Supported through Actions |
+| Component layout | Strong | Theme/template-driven | Theme/template-driven |
+
+If an ADR is required during implementation, it should record Astro as the default generator and explain that canonical content remains plain Markdown so downstream projects can replace the generator.
+
+## Output strategy
+
+Two output options are acceptable:
+
+| Option | Behavior | Recommendation |
+|---|---|---|
+| Build-only output | CI builds and deploys `sites/dist/`; generated files are not committed. | Preferred if `sites/index.html` can become a source redirect or the direct-open contract is updated. |
+| Committed generated output | Build writes static HTML under `sites/` and commits it. | Use only if direct file opening without a build remains non-negotiable. |
+
+The implementation must make the contract explicit because the current skill says `sites/index.html` is directly openable. A generated site can preserve this by keeping a simple checked-in fallback that points maintainers to `npm run product-page:build`, or by committing generated `sites/index.html`.
+
+## Verification model
+
+The first implementation should add or update checks for:
+
+- page-purpose content schema,
+- required sections and CTAs,
+- source references to canonical artifacts,
+- local links and asset paths,
+- successful static build,
+- generated output presence,
+- GitHub Pages workflow path,
+- product-page accessibility smoke checks where practical.
+
+`npm run check:product-page` should evolve from checking hand-authored HTML into checking the content/build contract.
+
+## Agent and skill updates
+
+Update these surfaces in the same implementation PR:
+
+- `.claude/skills/product-page/SKILL.md`
+- `.claude/agents/product-page-designer.md`
+- `.claude/commands/product/page.md`
+- `sites/README.md`
+- `docs/sink.md`
+- `docs/scripts/check-product-page/README.md` after generated docs refresh, if script behavior changes.
+
+The guidance should tell maintainers:
+
+- edit canonical artifacts when facts change,
+- edit page-purpose content when presentation changes,
+- run the product-page build/check before PR,
+- record whether the page was updated or unaffected in PR summaries.
+
+## Risks and mitigations
+
+- RISK-V08-001: Require public claims to carry source references where practical.
+- RISK-V08-002: Keep the generated site minimal and document opt-in/downstream setup.
+- RISK-V08-003: Decide and document the `sites/index.html` contract before migration.
+- RISK-V08-004: Update `check:product-page` and wire any new build check into verify.
+- RISK-V08-005: Keep page-purpose content presentation-owned and source-linked.
+- RISK-V08-006: Keep canonical content plain Markdown so Jekyll/Hugo replacements remain possible.

--- a/specs/version-0-8-plan/idea.md
+++ b/specs/version-0-8-plan/idea.md
@@ -1,0 +1,55 @@
+---
+id: IDEA-V08-001
+title: Version 0.8 content-driven product page plan
+stage: idea
+feature: version-0-8-plan
+status: accepted
+owner: analyst
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+# Idea - Version 0.8 content-driven product page plan
+
+## Problem
+
+The repository already treats a public product page as a living artifact, but the implementation is still a hand-maintained static HTML page under `sites/index.html`. That keeps hosting simple, but it makes product-page updates fragile as the workflow grows: claims, feature lists, personas, proof points, release notes, roadmap signals, and getting-started paths can drift from the Markdown artifacts that already describe the project.
+
+Teams adopting the template need a better default: a product page that can be generated for GitHub Pages from repository-owned Markdown content, while still allowing dedicated marketing and page-composition files where the canonical workflow artifacts are not the right copy source.
+
+## Target users
+
+- Maintainers who need Specorator's public page to stay current with version plans, release evidence, and docs.
+- Product-page designers who need a structured content source instead of editing one large HTML file.
+- Downstream teams that want a ready-to-host GitHub Pages product page as part of the template.
+- Reviewers who need deterministic checks that the page builds, links resolve, and claims map back to repo artifacts.
+
+## Desired outcome
+
+v0.8 should introduce a Markdown-driven static product-page generator that can build and deploy a polished GitHub Pages site from:
+
+- curated page-purpose content files,
+- selected project steering fields,
+- release or version-plan summaries,
+- proof/evidence artifacts,
+- docs and getting-started links,
+- optional manually curated highlights.
+
+The implementation should keep the repo Markdown-native, make content ownership explicit, and preserve a directly accessible static output for GitHub Pages.
+
+## Constraints
+
+- The product page must remain hostable on GitHub Pages.
+- Markdown artifacts remain the source of product truth; generated pages must not become the source of truth.
+- Dedicated page content is allowed, but it must be clearly owned and reviewed like other artifacts.
+- The generator must not require a database, CMS, server runtime, or external SaaS.
+- The default path should be understandable to maintainers who are not frontend specialists.
+- Existing product-page checks and upkeep expectations should be adapted, not discarded.
+
+## Open questions
+
+- Should v0.8 choose Astro as the default static-site generator, or compare Astro, Jekyll, and Hugo and defer the stack decision to implementation?
+- Should generated HTML be committed under `sites/`, built only in GitHub Actions, or both?
+- Which repo artifacts should feed the first version automatically: steering docs, version plans, release notes, docs index, quality metrics, or all of them?
+- How should page-purpose copy be separated from workflow-source facts?
+- How much visual customization should downstream adopters get before the generator becomes a theme system?

--- a/specs/version-0-8-plan/requirements.md
+++ b/specs/version-0-8-plan/requirements.md
@@ -1,0 +1,142 @@
+---
+id: PRD-V08-001
+title: Version 0.8 content-driven product page plan
+stage: requirements
+feature: version-0-8-plan
+status: accepted
+owner: pm
+inputs:
+  - IDEA-V08-001
+  - RESEARCH-V08-001
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+# PRD - Version 0.8 content-driven product page plan
+
+## Summary
+
+Plan v0.8 as the content-driven product-page release: introduce a static-site generator that builds a GitHub Pages-ready product page from repository Markdown artifacts and dedicated page content, while preserving traceable product truth and deterministic verification.
+
+## Goals
+
+- Generate the public product page from Markdown and frontmatter rather than hand-maintained HTML.
+- Use repo-owned canonical artifacts for facts, evidence, and links.
+- Add dedicated page-purpose content files for public copy, section ordering, and CTAs.
+- Keep the site fully static and hostable on GitHub Pages.
+- Update product-page agents, skills, docs, and checks so the new workflow is maintainable.
+- Preserve a low-friction path for downstream projects that want a product page without adopting a full CMS.
+
+## Non-goals
+
+- No runtime CMS, database, server rendering, analytics platform, or external content service.
+- No multi-generator abstraction layer in v0.8.
+- No mandatory migration for downstream adopters unless explicitly accepted in a later release decision.
+- No automatic public claim generation from private or draft artifacts.
+- No replacement for the canonical workflow artifacts in `specs/`, `docs/`, `projects/`, `quality/`, or `roadmaps/`.
+
+## Functional requirements (EARS)
+
+### REQ-V08-001 - Select a default static-site generator
+
+- **Pattern:** ubiquitous
+- **Statement:** The repository shall select and document a default static-site generator for product-page builds.
+- **Acceptance:** The decision compares Astro, Jekyll, and Hugo, records the selected default, and explains replacement boundaries for downstream projects.
+- **Priority:** must
+- **Satisfies:** IDEA-V08-001, RESEARCH-V08-001
+
+### REQ-V08-002 - Build from Markdown content
+
+- **Pattern:** ubiquitous
+- **Statement:** The product-page system shall build public pages from Markdown and frontmatter content files.
+- **Acceptance:** Page content can be edited without editing generated HTML, and the build consumes the committed content files.
+- **Priority:** must
+- **Satisfies:** IDEA-V08-001
+
+### REQ-V08-003 - Consume canonical project artifacts
+
+- **Pattern:** ubiquitous
+- **Statement:** The product-page system shall consume selected canonical repository artifacts for product facts, evidence, and links.
+- **Acceptance:** At minimum, the build or content model can reference README/docs links, version-plan summaries, and proof or quality artifacts without duplicating their full body copy.
+- **Priority:** must
+- **Satisfies:** IDEA-V08-001
+
+### REQ-V08-004 - Separate page-purpose content from product truth
+
+- **Pattern:** unwanted behavior
+- **Statement:** When dedicated product-page content files are added, they shall not become an independent source of workflow truth.
+- **Acceptance:** Documentation states which files own public presentation and which artifacts own product facts; public claims link back to source artifacts where practical.
+- **Priority:** must
+- **Satisfies:** RESEARCH-V08-001
+
+### REQ-V08-005 - Generate GitHub Pages-ready output
+
+- **Pattern:** ubiquitous
+- **Statement:** The product-page build shall produce static output suitable for GitHub Pages hosting.
+- **Acceptance:** The repository includes a documented local build and a GitHub Pages workflow or workflow update that deploys the generated static output.
+- **Priority:** must
+- **Satisfies:** IDEA-V08-001
+
+### REQ-V08-006 - Preserve direct static access
+
+- **Pattern:** unwanted behavior
+- **Statement:** When the product page moves to generated output, the repository shall preserve a directly accessible static page or documented generated output path.
+- **Acceptance:** Users can still open a static `index.html` output locally after build, and the old `sites/index.html` contract is either preserved, redirected, or explicitly superseded.
+- **Priority:** must
+- **Satisfies:** RESEARCH-V08-001
+
+### REQ-V08-007 - Validate content schema and build output
+
+- **Pattern:** ubiquitous
+- **Statement:** The repository shall validate product-page content schema, local links, assets, and generated output.
+- **Acceptance:** `npm run verify` or a targeted check fails for malformed page content, missing required sections, unresolved local links, broken asset references, or missing Pages build output.
+- **Priority:** must
+- **Satisfies:** RESEARCH-V08-001
+
+### REQ-V08-008 - Update product-page workflow guidance
+
+- **Pattern:** event-driven
+- **Statement:** When the generator is introduced, product-page skills, agents, commands, and docs shall describe the new content and build workflow.
+- **Acceptance:** `product-page` guidance tells maintainers where to edit content, how to build/verify, and when to update canonical source artifacts instead of page copy.
+- **Priority:** must
+- **Satisfies:** IDEA-V08-001
+
+### REQ-V08-009 - Support downstream adoption
+
+- **Pattern:** ubiquitous
+- **Statement:** The product-page generator shall be usable by downstream projects adopting the template.
+- **Acceptance:** Docs explain how a downstream project fills product-page content, points it at its own artifacts, customizes branding, and deploys to GitHub Pages.
+- **Priority:** should
+- **Satisfies:** IDEA-V08-001
+
+### REQ-V08-010 - Keep generated pages static and dependency-light
+
+- **Pattern:** unwanted behavior
+- **Statement:** The product-page generator shall not require a runtime server, CMS, database, or external SaaS to render the hosted page.
+- **Acceptance:** The default deploy publishes static files only, and all required build dependencies are local development or CI dependencies.
+- **Priority:** must
+- **Satisfies:** RESEARCH-V08-001
+
+## Non-functional requirements
+
+| ID | Category | Requirement | Target |
+|---|---|---|---|
+| NFR-V08-001 | maintainability | Product-page content ownership must be obvious. | Public-page files and canonical artifact inputs have documented owners and review expectations. |
+| NFR-V08-002 | portability | Canonical product truth must remain plain Markdown/frontmatter. | No content lock-in to a database or SaaS. |
+| NFR-V08-003 | usability | A maintainer can update a product-page section without touching generated HTML. | Edit a Markdown content file, run build/check, and see output. |
+| NFR-V08-004 | accessibility | Generated pages must preserve the existing product-page accessibility bar. | Responsive layout, keyboard focus, semantic headings, and WCAG AA contrast expectations. |
+| NFR-V08-005 | verification | Build and content failures must be caught before PR review. | Targeted checks are wired into `npm run verify` or explicitly documented if deferred. |
+
+## Success metrics
+
+- A maintainer can change a public feature card by editing one Markdown file and running one documented check.
+- The product page build uses at least one canonical artifact source and one page-purpose content source.
+- GitHub Pages deploys generated static output without manual repository settings changes.
+- Product-page verification catches malformed content and missing generated output.
+- The product-page skill and designer agent no longer instruct maintainers to edit one large HTML page as the primary workflow.
+
+## Quality gate
+
+- [x] Functional requirements use EARS and stable IDs.
+- [x] Acceptance criteria are testable.
+- [x] Non-goals prevent v0.8 from becoming a CMS, analytics, or multi-generator framework release.

--- a/specs/version-0-8-plan/research.md
+++ b/specs/version-0-8-plan/research.md
@@ -1,0 +1,101 @@
+---
+id: RESEARCH-V08-001
+title: Version 0.8 content-driven product page plan - Research
+stage: research
+feature: version-0-8-plan
+status: accepted
+owner: analyst
+inputs:
+  - IDEA-V08-001
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+# Research - Version 0.8 content-driven product page plan
+
+## Context
+
+Specorator already has a product-page skill, a `product-page-designer` agent, a `sites/index.html` public page, a GitHub Pages workflow expectation, and a deterministic product-page check. The gap is not whether the page exists; it is that the page is a manually edited presentation artifact instead of a built output from the Markdown content model that defines the product.
+
+The relevant source material is already in the repo:
+
+- `README.md` and `docs/steering/*` for positioning and audience.
+- `docs/specorator.md` for workflow definition.
+- `specs/version-*` for version-level requirements and release plans.
+- `docs/adr/` for architectural decisions.
+- `docs/quality-framework.md` and quality artifacts for trust signals.
+- Dedicated product-page content can live under a new content directory when workflow artifacts are too detailed or too operational for public copy.
+
+## Static generator options
+
+### Astro
+
+Astro is a strong fit for a content-driven product page because it supports static output by default, Markdown pages, content collections with typed frontmatter, and official GitHub Pages deployment guidance through the `withastro/action`. It also lets the implementation keep most of the site static while using small components for repeated sections such as features, proof points, release cards, and CTAs.
+
+**Fit:** high.
+
+**Tradeoff:** adds a Node-based frontend build stack and generated output path that the repo must document and verify.
+
+### Jekyll
+
+Jekyll has the simplest GitHub Pages story because GitHub Pages has built-in Jekyll support. It can consume Markdown and frontmatter directly and works well for conventional docs/blog style sites.
+
+**Fit:** medium.
+
+**Tradeoff:** Ruby dependency and theme/plugin constraints may feel less aligned with the repository's existing Node/TypeScript verification stack.
+
+### Hugo
+
+Hugo is fast, mature, Markdown-first, and strong for content-heavy static sites. It is a good option if build speed, multilingual content, or theme ecosystem maturity dominate.
+
+**Fit:** medium.
+
+**Tradeoff:** introduces a Go/Hugo toolchain that is separate from the repo's current Node-based checks.
+
+## Recommendation
+
+Choose Astro as the default v0.8 generator unless implementation discovers a blocking dependency or hosting constraint. Astro aligns with the existing Node toolchain, supports Markdown and content collections, can generate a fully static GitHub Pages site, and gives enough component structure to create a polished product page without turning the repo into a web app.
+
+Keep the architecture generator-aware rather than generator-abstract. v0.8 should not design a multi-generator adapter layer for Astro, Jekyll, and Hugo. It should document why Astro was selected and leave room for downstream projects to replace the generator when their stack requires Jekyll or Hugo.
+
+## Content model findings
+
+The page needs two kinds of content:
+
+| Source | Purpose | Example |
+|---|---|---|
+| Canonical workflow artifacts | Facts that should not be rewritten as marketing claims | active version plans, release evidence, docs links, ADR status |
+| Page-purpose content | Curated copy and layout choices written for public reading | hero copy, CTA labels, feature grouping, proof-point summaries |
+
+The build should merge both. Canonical artifacts provide facts and links; page-purpose files decide what to expose and how to say it.
+
+## Recommended paths
+
+| Path | Purpose |
+|---|---|
+| `sites/content/product-page/*.md` | Dedicated public-page copy and curated section data. |
+| `sites/src/` | Astro source components, layouts, pages, and content loaders. |
+| `sites/public/` | Static assets copied into the built page. |
+| `sites/dist/` | Generated static output, ignored locally unless the project decides to commit it. |
+| `.github/workflows/pages.yml` | Build and deploy generated output to GitHub Pages. |
+
+The exact paths can change during implementation, but the ownership split should remain clear: Markdown content is authored; HTML is generated.
+
+## Risks
+
+| ID | Risk | Severity | Mitigation |
+|---|---|---|
+| RISK-V08-001 | Generated public copy drifts from source artifacts. | high | Require source links or evidence references for claims surfaced from canonical artifacts. |
+| RISK-V08-002 | Static-site tooling makes the template feel heavier. | medium | Keep generator opt-in for downstream projects or make the default scaffold minimal. |
+| RISK-V08-003 | `sites/index.html` direct-open expectation conflicts with generated output. | medium | Decide whether to commit generated output or keep a static fallback/redirect with documented build workflow. |
+| RISK-V08-004 | Product-page checks only validate old static HTML. | high | Update checks to validate content schema, build output, asset references, and Pages workflow. |
+| RISK-V08-005 | Page-purpose content becomes a second product truth. | high | Document that dedicated files own public presentation, not workflow facts. |
+| RISK-V08-006 | Generator-specific design locks out Jekyll/Hugo users. | low | Document replacement boundaries and keep canonical content in plain Markdown/frontmatter. |
+
+## Sources
+
+- Astro deploy docs, including GitHub Pages deployment: <https://docs.astro.build/en/guides/deploy/>
+- Astro pages and Markdown docs: <https://docs.astro.build/en/basics/astro-pages/>
+- Astro content collections docs: <https://docs.astro.build/en/guides/content-collections/>
+- GitHub Pages Jekyll docs: <https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll>
+- Hugo content formats docs: <https://gohugo.io/content-management/formats/>

--- a/specs/version-0-8-plan/spec.md
+++ b/specs/version-0-8-plan/spec.md
@@ -1,0 +1,65 @@
+---
+id: SPECDOC-V08-001
+title: Version 0.8 content-driven product page plan - Specification
+stage: specification
+feature: version-0-8-plan
+status: accepted
+owner: architect
+inputs:
+  - DESIGN-V08-001
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+# Specification - Version 0.8 content-driven product page plan
+
+### SPEC-V08-001 - Generator decision record
+
+- **Satisfies:** REQ-V08-001
+- **Behavior:** The repository records the selected default static-site generator and the rationale comparing Astro, Jekyll, and Hugo.
+- **Acceptance:** A maintainer can identify the default generator, the replacement boundaries, and whether an ADR was required.
+
+### SPEC-V08-002 - Page-purpose content collection
+
+- **Satisfies:** REQ-V08-002, REQ-V08-004, NFR-V08-001, NFR-V08-003
+- **Behavior:** Product-page copy, section ordering, feature cards, proof summaries, and CTAs live in dedicated Markdown/frontmatter content files.
+- **Acceptance:** A page-purpose content edit changes the built product page without requiring direct edits to generated HTML or component code.
+
+### SPEC-V08-003 - Canonical artifact reader
+
+- **Satisfies:** REQ-V08-003, REQ-V08-004, NFR-V08-002
+- **Behavior:** Build-time code reads selected canonical repository artifacts for source facts, status, and links.
+- **Acceptance:** The generated page can show at least version-plan or workflow evidence sourced from canonical Markdown/frontmatter, with links back to source artifacts.
+
+### SPEC-V08-004 - Static GitHub Pages build
+
+- **Satisfies:** REQ-V08-005, REQ-V08-006, REQ-V08-010
+- **Behavior:** The product-page build emits static output and the GitHub Pages workflow deploys that output.
+- **Acceptance:** The deployed artifact requires no server runtime, CMS, database, or external SaaS, and local maintainers can open a generated static `index.html` after build.
+
+### SPEC-V08-005 - Product-page verification
+
+- **Satisfies:** REQ-V08-007, NFR-V08-004, NFR-V08-005
+- **Behavior:** Product-page checks validate content schema, required sections, source references, local links, assets, generated output, and Pages workflow configuration.
+- **Acceptance:** Malformed content, missing required public sections, broken local references, or failed static builds fail local verification.
+
+### SPEC-V08-006 - Workflow guidance update
+
+- **Satisfies:** REQ-V08-008, REQ-V08-009
+- **Behavior:** Product-page agent, skill, command, site docs, and sink ownership docs describe the content-driven build workflow.
+- **Acceptance:** A downstream adopter can find where to edit page content, where to update canonical facts, how to customize branding, and how to deploy to GitHub Pages.
+
+## Test scenarios
+
+| ID | Requirement | Scenario | Expected result |
+|---|---|---|---|
+| TEST-V08-001 | REQ-V08-001 | A maintainer asks which generator v0.8 uses. | The selected default and Astro/Jekyll/Hugo comparison are documented. |
+| TEST-V08-002 | REQ-V08-002 | A maintainer edits a feature card content file. | The static build updates the feature card without hand-editing generated HTML. |
+| TEST-V08-003 | REQ-V08-003 | The page renders a version or proof signal. | The signal is sourced from a canonical artifact or includes a source link. |
+| TEST-V08-004 | REQ-V08-004 | Page-purpose copy contradicts a source artifact. | Review guidance or validation surfaces the source-of-truth boundary. |
+| TEST-V08-005 | REQ-V08-005 | GitHub Actions runs the Pages workflow. | The generated static output is uploaded as the Pages artifact. |
+| TEST-V08-006 | REQ-V08-006 | A maintainer builds locally and opens the output. | A static `index.html` is available after build or the old contract is explicitly superseded. |
+| TEST-V08-007 | REQ-V08-007 | Required content frontmatter is missing. | Product-page verification fails with an actionable error. |
+| TEST-V08-008 | REQ-V08-008 | The product-page designer agent is invoked after v0.8. | It points to content files and build checks instead of editing one HTML file first. |
+| TEST-V08-009 | REQ-V08-009 | A downstream project adopts the template. | Docs explain how to fill content, map artifact inputs, customize branding, and deploy. |
+| TEST-V08-010 | REQ-V08-010 | The site is deployed. | The hosted page is static and has no runtime service dependency. |

--- a/specs/version-0-8-plan/tasks.md
+++ b/specs/version-0-8-plan/tasks.md
@@ -1,0 +1,118 @@
+---
+id: TASKS-V08-001
+title: Version 0.8 content-driven product page plan - Tasks
+stage: tasks
+feature: version-0-8-plan
+status: complete
+owner: planner
+inputs:
+  - PRD-V08-001
+  - SPECDOC-V08-001
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+# Tasks - Version 0.8 content-driven product page plan
+
+### T-V08-001 - Decide product-page generator
+
+- **Description:** Confirm Astro as the default static-site generator or record an alternate decision after comparing Astro, Jekyll, and Hugo; add an ADR if the decision changes repository architecture or the `sites/index.html` contract.
+- **Satisfies:** REQ-V08-001, SPEC-V08-001
+- **Owner:** architect
+- **Estimate:** M
+
+### T-V08-002 - Define the product-page content schema
+
+- **Description:** Define required page-purpose content files, frontmatter fields, section IDs, CTA fields, proof/source references, and validation errors.
+- **Satisfies:** REQ-V08-002, REQ-V08-004, NFR-V08-001, NFR-V08-003, SPEC-V08-002
+- **Depends on:** T-V08-001
+- **Owner:** pm
+- **Estimate:** M
+
+### T-V08-003 - Define canonical artifact inputs
+
+- **Description:** Choose the initial canonical artifact readers for README/docs links, version-plan summaries, quality/proof references, and ADR or workflow status signals.
+- **Satisfies:** REQ-V08-003, REQ-V08-004, NFR-V08-002, SPEC-V08-003
+- **Depends on:** T-V08-002
+- **Owner:** architect
+- **Estimate:** M
+
+### T-V08-004 - Scaffold the static site build
+
+- **Description:** Add the selected generator configuration, source layout, scripts, dependencies, and local build command for the product page.
+- **Satisfies:** REQ-V08-002, REQ-V08-005, REQ-V08-010, SPEC-V08-004
+- **Depends on:** T-V08-001
+- **Owner:** dev
+- **Estimate:** L
+
+### T-V08-005 - Migrate current product-page content
+
+- **Description:** Move the current public page copy into page-purpose Markdown/frontmatter content files and implement components/layouts that render an equivalent or improved public page.
+- **Satisfies:** REQ-V08-002, REQ-V08-004, NFR-V08-003, NFR-V08-004, SPEC-V08-002
+- **Depends on:** T-V08-002, T-V08-004
+- **Owner:** product-page-designer
+- **Estimate:** L
+
+### T-V08-006 - Implement artifact readers
+
+- **Description:** Add build-time loaders that read selected canonical Markdown/frontmatter, expose stable data to page components, and preserve source links for public claims.
+- **Satisfies:** REQ-V08-003, REQ-V08-004, NFR-V08-002, SPEC-V08-003
+- **Depends on:** T-V08-003, T-V08-004
+- **Owner:** dev
+- **Estimate:** L
+
+### T-V08-007 - Update GitHub Pages deployment
+
+- **Description:** Update or replace the Pages workflow so it builds the product page and deploys generated static output from the selected output directory.
+- **Satisfies:** REQ-V08-005, REQ-V08-006, REQ-V08-010, SPEC-V08-004
+- **Depends on:** T-V08-004
+- **Owner:** dev
+- **Estimate:** M
+
+### T-V08-008 - Resolve the direct static access contract
+
+- **Description:** Decide whether generated output is committed, built locally only, or paired with a checked-in fallback/redirect; update `sites/README.md` and product-page guidance accordingly.
+- **Satisfies:** REQ-V08-006, SPEC-V08-004
+- **Depends on:** T-V08-004, T-V08-007
+- **Owner:** architect
+- **Estimate:** M
+
+### T-V08-009 - Update product-page checks
+
+- **Description:** Extend `check:product-page` or add companion checks for content schema, required sections, source references, local links, assets, static build, generated output, and Pages workflow path.
+- **Satisfies:** REQ-V08-007, NFR-V08-004, NFR-V08-005, SPEC-V08-005
+- **Depends on:** T-V08-002, T-V08-004, T-V08-006, T-V08-007
+- **Owner:** qa
+- **Estimate:** L
+
+### T-V08-010 - Update product-page skill, agent, and command
+
+- **Description:** Update `.claude/skills/product-page/SKILL.md`, `.claude/agents/product-page-designer.md`, and `.claude/commands/product/page.md` for the content-driven workflow.
+- **Satisfies:** REQ-V08-008, REQ-V08-009, SPEC-V08-006
+- **Depends on:** T-V08-002, T-V08-008, T-V08-009
+- **Owner:** product-page-designer
+- **Estimate:** M
+
+### T-V08-011 - Update repository docs and ownership map
+
+- **Description:** Update `sites/README.md`, `docs/sink.md`, README links if needed, and generated script docs after behavior changes.
+- **Satisfies:** REQ-V08-008, REQ-V08-009, SPEC-V08-006
+- **Depends on:** T-V08-008, T-V08-009, T-V08-010
+- **Owner:** release-manager
+- **Estimate:** M
+
+### T-V08-012 - Document downstream customization
+
+- **Description:** Add a downstream adoption guide for filling content, mapping source artifacts, customizing branding, replacing the generator if needed, and deploying to GitHub Pages.
+- **Satisfies:** REQ-V08-001, REQ-V08-009, REQ-V08-010, SPEC-V08-006
+- **Depends on:** T-V08-010, T-V08-011
+- **Owner:** pm
+- **Estimate:** M
+
+### T-V08-013 - Verify v0.8 release readiness
+
+- **Description:** Run content checks, build checks, link/product-page checks, relevant tests, and `npm run verify`; record any skipped browser/accessibility checks and remaining risks in implementation/test artifacts.
+- **Satisfies:** REQ-V08-001, REQ-V08-002, REQ-V08-003, REQ-V08-004, REQ-V08-005, REQ-V08-006, REQ-V08-007, REQ-V08-008, REQ-V08-009, REQ-V08-010, SPEC-V08-001, SPEC-V08-002, SPEC-V08-003, SPEC-V08-004, SPEC-V08-005, SPEC-V08-006
+- **Depends on:** T-V08-009, T-V08-011, T-V08-012
+- **Owner:** qa
+- **Estimate:** S

--- a/specs/version-0-8-plan/workflow-state.md
+++ b/specs/version-0-8-plan/workflow-state.md
@@ -1,0 +1,58 @@
+---
+feature: version-0-8-plan
+area: V08
+current_stage: implementation
+status: active
+last_updated: 2026-05-01
+last_agent: planner
+artifacts:
+  idea.md: complete
+  research.md: complete
+  requirements.md: complete
+  design.md: complete
+  spec.md: complete
+  tasks.md: complete
+  implementation-log.md: pending
+  test-plan.md: pending
+  test-report.md: pending
+  review.md: pending
+  traceability.md: pending
+  release-notes.md: pending
+  retrospective.md: pending
+---
+
+# Workflow state - version-0-8-plan
+
+## Stage progress
+
+| Stage | Artifact | Status |
+|---|---|---|
+| 1. Idea | `idea.md` | complete |
+| 2. Research | `research.md` | complete |
+| 3. Requirements | `requirements.md` | complete |
+| 4. Design | `design.md` | complete |
+| 5. Specification | `spec.md` | complete |
+| 6. Tasks | `tasks.md` | complete |
+| 7. Implementation | `implementation-log.md` + code/docs | pending |
+| 8. Testing | `test-plan.md`, `test-report.md` | pending |
+| 9. Review | `review.md`, `traceability.md` | pending |
+| 10. Release | `release-notes.md` | pending |
+| 11. Learning | `retrospective.md` | pending |
+
+## Skips
+
+- None.
+
+## Blocks
+
+- None.
+
+## Hand-off notes
+
+- 2026-05-01 (codex): Planned v0.8 through Stage 6 from the request for better product page creation. Recommended implementation order is decide the generator stack, define the content model, scaffold the static-site app, migrate the current product page into content files, add GitHub Pages deployment, add deterministic checks and docs, then update product-page agent/skill guidance.
+
+## Open clarifications
+
+- [ ] CLAR-V08-001 - Confirm whether v0.8 should adopt Astro as the default generator or keep a generator-neutral adapter with Astro as the first implementation.
+- [ ] CLAR-V08-002 - Confirm whether the generated site must preserve `sites/index.html` as the canonical source file or may make it a generated artifact committed or built by CI.
+- [ ] CLAR-V08-003 - Confirm whether downstream adopters should get the product-page generator by default or as an opt-in scaffold.


### PR DESCRIPTION
## Summary

Adds a Stage 1-6 v0.8 plan for content-driven product page creation.

The plan covers:

- a Markdown/frontmatter content model for public product-page copy
- build-time use of canonical repo artifacts for facts, evidence, and links
- Astro as the recommended default static-site generator, with Jekyll and Hugo compared
- GitHub Pages-ready static output and deployment expectations
- updates needed for product-page checks, skills, agents, commands, and downstream adoption docs

Implementation tracker: #106

## Verification

- `npm run check:frontmatter`
- `npm run check:specs`
- `npm run check:links`
- `npm run verify`

Note: the first `npm run verify` attempt failed in the fresh worktree because `typedoc` was not installed there. I ran `npm ci` in the worktree and reran `npm run verify`; the full gate passed.

## Product page

product page unaffected: this PR creates the v0.8 plan only and does not ship the generator or change public positioning yet.

## Known limitations

- Implementation remains pending in `specs/version-0-8-plan/workflow-state.md`.
- Open clarifications remain for the final generator decision, the `sites/index.html` contract, and whether downstream projects receive the generator by default.