### PR TITLE
feat(sites): switch product page example to cli-todo (T-V03-007)

### DIFF
--- a/sites/index.html
+++ b/sites/index.html
@@ -603,14 +603,14 @@ task on its own line.</pre>
             </header>
 <pre class="artifact-source"><span class="md-h1"># Tasks: CLI todo app</span>
 
-<span class="md-id">T-CLI-001</span>  Dispatcher and help tests
-  owner: qa    &rarr; <span class="md-id">REQ-CLI-006</span>, <span class="md-id">REQ-CLI-012</span>
+<span class="md-id">T-CLI-007</span>  Command behavior tests
+  owner: qa    &rarr; <span class="md-id">REQ-CLI-001</span>, <span class="md-id">REQ-CLI-002</span>
 
-<span class="md-id">T-CLI-002</span>  Scaffold binary and dispatcher
-  owner: dev   &rarr; <span class="md-id">REQ-CLI-006</span>
+<span class="md-id">T-CLI-008</span>  Implement task commands
+  owner: dev   &rarr; <span class="md-id">REQ-CLI-001</span>, <span class="md-id">REQ-CLI-002</span>
 
-<span class="md-id">T-CLI-003</span>  Storage and path tests
-  owner: qa    &rarr; <span class="md-id">REQ-CLI-007</span>, <span class="md-id">REQ-CLI-009</span></pre>
+<span class="md-id">T-CLI-009</span>  Review and traceability
+  owner: dev   &rarr; <span class="md-id">REQ-CLI-001</span>, <span class="md-id">REQ-CLI-002</span></pre>
           </figure>
         </div>
         <div class="artifact-meta">

--- a/sites/index.html
+++ b/sites/index.html
@@ -553,65 +553,70 @@
       <section class="section example-section" id="example" aria-labelledby="example-title">
         <div class="section-header">
           <h2 id="example-title">From a one-line brief to working code.</h2>
-          <p class="section-kicker">A walk-through of one fabricated feature &mdash; password reset by email. Each stage produces a Markdown artifact with stable IDs that flow forward to the next.</p>
+          <p class="section-kicker">A walk-through of the worked CLI todo example &mdash; the smallest realistic feature you can read end to end. Each stage produces a Markdown artifact with stable IDs that flow forward to the next.</p>
         </div>
         <div class="artifact-chain" aria-label="Three example artifacts produced in sequence">
           <figure class="artifact-card">
             <header class="artifact-card-head">
               <span class="artifact-step">Stage 1 &middot; Idea</span>
-              <code class="artifact-path">specs/password-reset/idea.md</code>
+              <code class="artifact-path">examples/cli-todo/idea.md</code>
             </header>
-<pre class="artifact-source"><span class="md-h1"># Idea: Password reset</span>
+<pre class="artifact-source"><span class="md-h1"># Idea: CLI todo app</span>
 
 <span class="md-h2">## Brief</span>
-Users who forget their password should
-recover access without a support ticket.
+Solo engineers want to capture, list,
+and complete short-lived tasks without
+leaving the shell.
 
 <span class="md-h2">## User</span>
-Existing account holders, locked out.
+Terminal-native engineers; contributors
+reading this kit's worked example.
 
 <span class="md-h2">## Outcome</span>
-Self-service via a one-time link expiring
-in 30 minutes.</pre>
+A `todo` binary with add, list, done,
+rm. First add &rarr; list &rarr; done in
+under two minutes.</pre>
           </figure>
           <figure class="artifact-card">
             <header class="artifact-card-head">
               <span class="artifact-step">Stage 3 &middot; Requirements</span>
-              <code class="artifact-path">specs/password-reset/requirements.md</code>
+              <code class="artifact-path">examples/cli-todo/requirements.md</code>
             </header>
-<pre class="artifact-source"><span class="md-h1"># Requirements: Password reset</span>
+<pre class="artifact-source"><span class="md-h1"># Requirements: CLI todo app</span>
 
-<span class="md-id">REQ-AUTH-001</span>
-<span class="md-em">While</span> the user is signed out,
-<span class="md-em">when</span> they tap &ldquo;Forgot password,&rdquo;
-<span class="md-em">the system shall</span> open the email form.
+<span class="md-id">REQ-CLI-001</span>
+<span class="md-em">When</span> the user invokes `todo add`
+with a non-empty text argument,
+<span class="md-em">the CLI shall</span> create a new task
+with a unique sequential ID and persist
+it for later `todo list` calls.
 
-<span class="md-id">REQ-AUTH-002</span>
-<span class="md-em">When</span> an email matching a known account
-is submitted, <span class="md-em">the system shall</span>
-send a one-time link valid for 30 minutes.</pre>
+<span class="md-id">REQ-CLI-002</span>
+<span class="md-em">When</span> the user invokes `todo list`,
+<span class="md-em">the CLI shall</span> display every open
+task on its own line.</pre>
           </figure>
           <figure class="artifact-card">
             <header class="artifact-card-head">
               <span class="artifact-step">Stage 6 &middot; Tasks</span>
-              <code class="artifact-path">specs/password-reset/tasks.md</code>
+              <code class="artifact-path">examples/cli-todo/tasks.md</code>
             </header>
-<pre class="artifact-source"><span class="md-h1"># Tasks: Password reset</span>
+<pre class="artifact-source"><span class="md-h1"># Tasks: CLI todo app</span>
 
-<span class="md-id">T-AUTH-014</span>  Email-entry form
-  owner: dev   &rarr; <span class="md-id">REQ-AUTH-001</span>
+<span class="md-id">T-CLI-001</span>  Dispatcher and help tests
+  owner: qa    &rarr; <span class="md-id">REQ-CLI-006</span>, <span class="md-id">REQ-CLI-012</span>
 
-<span class="md-id">T-AUTH-015</span>  One-time token issuer
-  owner: dev   &rarr; <span class="md-id">REQ-AUTH-002</span>
+<span class="md-id">T-CLI-002</span>  Scaffold binary and dispatcher
+  owner: dev   &rarr; <span class="md-id">REQ-CLI-006</span>
 
-<span class="md-id">T-AUTH-016</span>  Tests for above
-  owner: qa    &rarr; <span class="md-id">TEST-AUTH-014..15</span></pre>
+<span class="md-id">T-CLI-003</span>  Storage and path tests
+  owner: qa    &rarr; <span class="md-id">REQ-CLI-007</span>, <span class="md-id">REQ-CLI-009</span></pre>
           </figure>
         </div>
         <div class="artifact-meta">
           <p>Every requirement carries a stable ID that flows forward &mdash; <code>REQ</code> to <code>T</code> to <code>TEST</code>. The traceability matrix is regenerable from the artifacts; nothing ships without a chain.</p>
           <ul class="artifact-list">
-            <li><a href="https://github.com/Luis85/agentic-workflow/tree/main/examples/cli-todo">Real example feature &rarr;</a></li>
+            <li><a href="https://github.com/Luis85/agentic-workflow/tree/main/examples/cli-todo">Browse every cli-todo artifact &rarr;</a></li>
             <li><a href="https://github.com/Luis85/agentic-workflow/blob/main/docs/workflow-overview.md">Workflow cheat sheet &rarr;</a></li>
             <li><a href="https://github.com/Luis85/agentic-workflow/blob/main/docs/quality-framework.md">Quality gates &rarr;</a></li>
           </ul>


### PR DESCRIPTION
## Summary

Updates the "From a one-line brief to working code" section of `sites/index.html` to reference the real worked example (`examples/cli-todo/`) shipping with v0.3 instead of the fictional `specs/password-reset/` snippets.

- Section kicker rewritten to point at cli-todo.
- Stage 1 / Stage 3 / Stage 6 cards swapped:
  - Idea: cli-todo brief (capture / list / complete; under two minutes)
  - Requirements: REQ-CLI-001 (Add a task), REQ-CLI-002 (List open tasks) — actual EARS pulled from `examples/cli-todo/requirements.md`
  - Tasks: T-CLI-001..003 (dispatcher tests, dispatcher impl, storage tests) — actual entries pulled from `examples/cli-todo/tasks.md`
- Footer link relabelled "Real example feature" → "Browse every cli-todo artifact" (same target, clearer now that the snippets match).
- Path prefix `examples/cli-todo/` everywhere (cli-todo lives under `examples/`, not `specs/`).

No CSS, structure, or styling changes — only string content and `<code class="artifact-path">` values inside the existing markup.

## Trace

- Refs: `specs/version-0-3-plan/tasks.md` (T-V03-007), `specs/version-0-3-plan/requirements.md` (REQ-V03-006)
- Resolves: issue #88 progress item T-V03-007.

## Test plan

- [x] `grep -n "password-reset\|REQ-AUTH\|T-AUTH\|TEST-AUTH" sites/index.html` returns nothing — no stale refs left.
- [x] `npm run verify` green locally (link check, frontmatter check, product-page check, etc.).
- [ ] Visual eyeball of GitHub Pages once deploy lands; the three artifact cards should render at the same height as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)