### PR TITLE
feat(specs): verify v0.3 release readiness (T-V03-008, T-V03-009)

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ Full version in [`memory/constitution.md`](memory/constitution.md).
 |---|---|---|
 | v0.1 | Done | Workflow definition, templates, agents, slash commands |
 | v0.2 | Done | Skills layer, operational bots, branching / verify / worktrees guides |
-| v0.3 | Planned | [Worked end-to-end examples, artifact validation](specs/version-0-3-plan/tasks.md) |
+| v0.3 | Done | [Worked end-to-end examples, artifact validation](specs/version-0-3-plan/release-notes.md) |
 | v0.4 | Planned | [CI quality gates, metrics, maturity model](specs/version-0-4-plan/tasks.md) |
 | v0.5 | Planned | [Release workflow, branching strategy, GitHub Releases and Packages](specs/version-0-5-plan/tasks.md) |
 | v0.6 | Planned | [Productization, cross-tool adapters, live proof, hooks, and agentic security](specs/version-0-6-plan/tasks.md) |

--- a/specs/version-0-3-plan/release-notes.md
+++ b/specs/version-0-3-plan/release-notes.md
@@ -4,7 +4,7 @@ title: Version 0.3 release plan — Release notes
 stage: release
 feature: version-0-3-plan
 version: v0.3.0
-status: draft
+status: complete
 owner: release-manager
 inputs:
   - PRD-V03-001

--- a/specs/version-0-3-plan/workflow-state.md
+++ b/specs/version-0-3-plan/workflow-state.md
@@ -1,7 +1,7 @@
 ---
 feature: version-0-3-plan
 area: V03
-current_stage: implementation
+current_stage: learning
 status: active
 last_updated: 2026-05-01
 last_agent: release-manager
@@ -12,12 +12,12 @@ artifacts:
   design.md: complete
   spec.md: complete
   tasks.md: complete
-  implementation-log.md: pending
-  test-plan.md: pending
-  test-report.md: pending
-  review.md: pending
-  traceability.md: pending
-  release-notes.md: in-progress
+  implementation-log.md: skipped
+  test-plan.md: skipped
+  test-report.md: skipped
+  review.md: skipped
+  traceability.md: skipped
+  release-notes.md: complete
   retrospective.md: pending
 ---
 
@@ -33,15 +33,23 @@ artifacts:
 | 4. Design | `design.md` | complete |
 | 5. Specification | `spec.md` | complete |
 | 6. Tasks | `tasks.md` | complete |
-| 7. Implementation | `implementation-log.md` + code | pending |
-| 8. Testing | `test-plan.md`, `test-report.md` | pending |
-| 9. Review | `review.md`, `traceability.md` | pending |
-| 10. Release | `release-notes.md` | in-progress |
+| 7. Implementation | `implementation-log.md` + code | skipped |
+| 8. Testing | `test-plan.md`, `test-report.md` | skipped |
+| 9. Review | `review.md`, `traceability.md` | skipped |
+| 10. Release | `release-notes.md` | complete |
 | 11. Learning | `retrospective.md` | pending |
 
 ## Skips
 
-- None.
+The v0.3 plan is a meta-feature: each sub-task (T-V03-001 through T-V03-009) shipped as its own PR, with implementation, tests, review, and traceability scoped to the artifact each PR touched. The plan itself does not have a separate implementation source tree, test plan, or review artifact, so the canonical Stage 7–9 artifacts are skipped here.
+
+- `implementation-log.md` skipped — implementation evidence lives in the per-task PRs (#68, #93, #94, #95, #101, #107, #108, #110) and their commit messages, not in a single log under this folder.
+- `test-plan.md` skipped — testing strategy is documented per PR (each validator change shipped with characterization tests under `tests/scripts/`).
+- `test-report.md` skipped — test results live with the per-PR CI runs and the local `npm run test:scripts` output captured in PR descriptions.
+- `review.md` skipped — review findings landed inline on each PR (notably the Codex P1 in PR #94 and Codex P2 reviews in PR #107 / PR #108 / PR #110).
+- `traceability.md` skipped — the v0.3 trace chain is the per-task `Refs:` block in each PR plus `tasks.md` `Satisfies:` fields, not a separate matrix.
+
+The Stage 11 retrospective (`retrospective.md`) remains pending and is the only outstanding artifact for the v0.3 plan.
 
 ## Blocks
 
@@ -51,10 +59,13 @@ artifacts:
 
 - 2026-04-28 (codex): Planned v0.3 through Stage 6. Recommended implementation order is example completion, validation hardening, validator tests, documentation, product-page review, release readiness verification, then explicit v0.4 validation handoff.
 - 2026-05-01 (claude): T-V03-001/002/003/005/007 shipped. Drafted `release-notes.md` for T-V03-006. T-V03-004 satisfied by existing checks plus T-V03-003 slice 3. T-V03-008 (release readiness) and T-V03-009 (v0.4 handoff) remain.
+- 2026-05-01 (claude, T-V03-008 + T-V03-009): Verified release readiness. `npm run check:links`, `npm run check:specs`, `npm run check:traceability`, `npm run test:scripts` (131 tests), and `npm run verify` all green on `origin/main` at `ef015d3`. README §Roadmap row v0.3 flipped from "Planned" to "Done" with link to `release-notes.md`. `release-notes.md` frontmatter `status: draft` → `complete`. Stage 7–9 artifacts marked `skipped` with rationale under §Skips (meta-feature: per-task PRs ship their own implementation, tests, review, and trace evidence). T-V03-009 (v0.4 validation handoff) is satisfied in-place by §Validation baseline for v0.4 in `release-notes.md`. Only `retrospective.md` (Stage 11) remains; `current_stage` advanced to `learning`.
 
 ## Open clarifications
 
-- [ ] CLAR-V03-001 — Confirm whether `examples/cli-todo` remains the selected complete example for v0.3 or whether a different example should replace it.
+- [x] CLAR-V03-001 — Confirm whether `examples/cli-todo` remains the selected complete example for v0.3 or whether a different example should replace it.
+
+  **Resolved 2026-05-01 (claude, T-V03-008):** Retained. `examples/cli-todo/` shipped end-to-end via PR #68 and is now the worked example referenced from `examples/README.md`, `sites/index.html` (via PR #108), and `release-notes.md`. No replacement candidate emerged.
 - [x] CLAR-V03-002 — Confirm which strengthened validation checks must fail `npm run verify` in v0.3 versus remain advisory until v0.4.
 
   **Resolved 2026-05-01 (human + claude):** Default is hard-fail; advisory only when format variability creates real false-positive risk. Concrete split for the new T-V03-003 / T-V03-004 checks:


### PR DESCRIPTION
## Summary

Closes the v0.3 release loop. T-V03-008 + T-V03-009.

**Validation pass** on \`origin/main\` at \`ef015d3\`:

| Check | Result |
|---|---|
| \`npm run check:links\` | ok |
| \`npm run check:specs\` | ok |
| \`npm run check:traceability\` | ok |
| \`npm run test:scripts\` | 131 pass |
| \`npm run verify\` | ok |

**Changes**

- README.md §Roadmap: v0.3 row "Planned" → "Done"; link target moved from \`tasks.md\` to \`release-notes.md\`.
- \`specs/version-0-3-plan/release-notes.md\`: frontmatter \`status: draft\` → \`status: complete\`.
- \`specs/version-0-3-plan/workflow-state.md\`:
  - \`release-notes.md\` in-progress → complete; \`current_stage\` implementation → learning.
  - Stage 7-9 artifacts marked **skipped** with rationale under §Skips. The v0.3 plan is a meta-feature; each sub-task shipped its own PR with implementation, tests, review, and trace evidence scoped to that PR. The plan itself has no separate Stage 7-9 artifact.
  - CLAR-V03-001 resolved (cli-todo retained).
  - Hand-off note appended.
- T-V03-009 satisfied in-place: §Validation baseline for v0.4 inside \`release-notes.md\` already lists hard-fail validators, the deferred advisory item, false-positive risks, and CI promotion candidates.

Only \`retrospective.md\` (Stage 11) remains for the v0.3 plan; tracked as the next slice.

## Trace

- Refs: \`specs/version-0-3-plan/tasks.md\` (T-V03-008, T-V03-009), \`spec.md\` (SPEC-V03-005, SPEC-V03-006), \`release-notes.md\`.
- Resolves: issue #88 progress items T-V03-008, T-V03-009.

## Test plan

- [x] All five validation commands listed in the §Summary table run green locally on origin/main and on this branch.
- [x] \`npm run verify\` green after the workflow-state §Skips entries land (skipped artifacts must appear under §Skips per the T-V03-003 slice 1 check — verified by the same validator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)