### PR TITLE
feat(scripts): scaffold automation registry discovery

### DIFF
--- a/docs/scripts/README.md
+++ b/docs/scripts/README.md
@@ -61,6 +61,20 @@ npm run check:automation-registry
 
 Registry entries record the command or path, purpose, read-only status, local safety, JSON support, intended users, and rerun command. Add or update the registry in the same PR as any new package script, GitHub workflow, skill, or operational agent.
 
+When a check reports a missing surface, scaffold candidate entries with:
+
+```bash
+npm run automation:registry:discover
+```
+
+Use JSON when an agent or tool needs to consume the candidates:
+
+```bash
+npm run automation:registry:discover -- --json
+```
+
+Discovery output is intentionally not commit-ready: generated `purpose` values contain `TODO` markers, and `check:automation-registry` rejects those placeholders until a human or responsible agent writes the actual annotation.
+
 ## Agent Artifacts
 
 Validate lifecycle agents, reusable skills, and operational agent prompts as product artifacts:
@@ -165,6 +179,7 @@ In GitHub Actions, `verify` requests JSON diagnostics from supported check scrip
 | `npm run check:fast` | Run the fast local iteration gate. |
 | `npm run check:content` | Run content and generated documentation integrity checks. |
 | `npm run check:workflow` | Run workflow state, traceability, roadmap, and agent contract checks. |
+| `npm run automation:registry:discover` | Emit candidate registry entries for newly discovered automation surfaces. |
 | `npm run check:automation-registry` | Validate `tools/automation-registry.yml` against package scripts, workflows, skills, and operational agents. |
 | `npm run check:agents` | Validate lifecycle agents, skills, and operational agents as product artifacts. |
 | `npm run check:links` | Validate local Markdown links and anchors. |

--- a/docs/scripts/automation-registry-discover/README.md
+++ b/docs/scripts/automation-registry-discover/README.md
@@ -1,0 +1,13 @@
+---
+title: "automation-registry-discover"
+folder: "docs/scripts/automation-registry-discover"
+description: "Entry point for generated API reference for the automation-registry-discover script."
+entry_point: true
+---
+[**agentic-workflow**](../README.md)
+
+***
+
+[agentic-workflow](../modules.md) / automation-registry-discover
+
+# automation-registry-discover

--- a/docs/scripts/lib/automation-registry/README.md
+++ b/docs/scripts/lib/automation-registry/README.md
@@ -16,6 +16,7 @@ entry_point: true
 
 - [AutomationKind](type-aliases/AutomationKind.md)
 - [AutomationRegistry](type-aliases/AutomationRegistry.md)
+- [AutomationRegistryDiscovery](type-aliases/AutomationRegistryDiscovery.md)
 - [AutomationRegistryEntry](type-aliases/AutomationRegistryEntry.md)
 
 ## Variables
@@ -24,5 +25,6 @@ entry_point: true
 
 ## Functions
 
+- [discoverAutomationRegistryEntries](functions/discoverAutomationRegistryEntries.md)
 - [loadAutomationRegistry](functions/loadAutomationRegistry.md)
 - [validateAutomationRegistry](functions/validateAutomationRegistry.md)

--- a/docs/scripts/lib/automation-registry/functions/discoverAutomationRegistryEntries.md
+++ b/docs/scripts/lib/automation-registry/functions/discoverAutomationRegistryEntries.md
@@ -1,0 +1,36 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/automation-registry](../README.md) / discoverAutomationRegistryEntries
+
+# Function: discoverAutomationRegistryEntries()
+
+> **discoverAutomationRegistryEntries**(`registry`, `root?`): [`AutomationRegistryDiscovery`](../type-aliases/AutomationRegistryDiscovery.md)
+
+Discover registry entries for automation surfaces that are not yet registered.
+
+The returned entries are intentionally incomplete: their `purpose` values
+contain TODO markers that `validateAutomationRegistry` rejects. This makes
+the output useful as a scaffold without allowing generated placeholders to
+become accepted registry annotations.
+
+## Parameters
+
+### registry
+
+[`AutomationRegistry`](../type-aliases/AutomationRegistry.md)
+
+Parsed automation registry.
+
+### root?
+
+`string` = `repoRoot`
+
+Repository root.
+
+## Returns
+
+[`AutomationRegistryDiscovery`](../type-aliases/AutomationRegistryDiscovery.md)
+
+Missing registry entry candidates.

--- a/docs/scripts/lib/automation-registry/type-aliases/AutomationRegistryDiscovery.md
+++ b/docs/scripts/lib/automation-registry/type-aliases/AutomationRegistryDiscovery.md
@@ -1,0 +1,15 @@
+[**agentic-workflow**](../../../README.md)
+
+***
+
+[agentic-workflow](../../../modules.md) / [lib/automation-registry](../README.md) / AutomationRegistryDiscovery
+
+# Type Alias: AutomationRegistryDiscovery
+
+> **AutomationRegistryDiscovery** = `object`
+
+## Properties
+
+### missing
+
+> **missing**: [`AutomationRegistryEntry`](AutomationRegistryEntry.md)[]

--- a/docs/scripts/modules.md
+++ b/docs/scripts/modules.md
@@ -6,6 +6,7 @@
 
 ## Modules
 
+- [automation-registry-discover](automation-registry-discover/README.md)
 - [check-adr-index](check-adr-index/README.md)
 - [check-agents](check-agents/README.md)
 - [check-automation-registry](check-automation-registry/README.md)

--- a/docs/verify-gate.md
+++ b/docs/verify-gate.md
@@ -49,7 +49,7 @@ For narrower local iteration, the template exposes tiered read-only gates:
 | `npm run verify:changed` | Changed-file gate that selects the smallest mapped read-only checks relative to `origin/main`. |
 | `npm run verify:json` | Full gate with machine-readable aggregate diagnostics and rerun commands. |
 
-The automation inventory that backs these commands lives in `tools/automation-registry.yml`; `npm run check:automation-registry` verifies that package scripts, GitHub workflows, skills, and operational agents remain registered.
+The automation inventory that backs these commands lives in `tools/automation-registry.yml`; `npm run check:automation-registry` verifies that package scripts, GitHub workflows, skills, and operational agents remain registered. When a surface is missing, `npm run automation:registry:discover` emits candidate entries for humans or agents to annotate before committing.
 
 ## Reporting
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "verify": "tsx scripts/verify.ts",
     "verify:json": "tsx scripts/verify-json.ts",
     "verify:changed": "tsx scripts/verify-changed.ts",
+    "automation:registry:discover": "tsx scripts/automation-registry-discover.ts",
     "quality:metrics": "tsx scripts/quality-metrics.ts",
     "roadmap:digest": "tsx scripts/roadmap-digest.ts",
     "roadmap:evidence": "tsx scripts/roadmap-evidence.ts",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -57,6 +57,20 @@ npm run check:automation-registry
 
 Registry entries record the command or path, purpose, read-only status, local safety, JSON support, intended users, and rerun command. Add or update the registry in the same PR as any new package script, GitHub workflow, skill, or operational agent.
 
+When a check reports a missing surface, scaffold candidate entries with:
+
+```bash
+npm run automation:registry:discover
+```
+
+Use JSON when an agent or tool needs to consume the candidates:
+
+```bash
+npm run automation:registry:discover -- --json
+```
+
+Discovery output is intentionally not commit-ready: generated `purpose` values contain `TODO` markers, and `check:automation-registry` rejects those placeholders until a human or responsible agent writes the actual annotation.
+
 ## Agent Artifacts
 
 Validate lifecycle agents, reusable skills, and operational agent prompts as product artifacts:
@@ -161,6 +175,7 @@ In GitHub Actions, `verify` requests JSON diagnostics from supported check scrip
 | `npm run check:fast` | Run the fast local iteration gate. |
 | `npm run check:content` | Run content and generated documentation integrity checks. |
 | `npm run check:workflow` | Run workflow state, traceability, roadmap, and agent contract checks. |
+| `npm run automation:registry:discover` | Emit candidate registry entries for newly discovered automation surfaces. |
 | `npm run check:automation-registry` | Validate `tools/automation-registry.yml` against package scripts, workflows, skills, and operational agents. |
 | `npm run check:agents` | Validate lifecycle agents, skills, and operational agents as product artifacts. |
 | `npm run check:links` | Validate local Markdown links and anchors. |

--- a/scripts/automation-registry-discover.ts
+++ b/scripts/automation-registry-discover.ts
@@ -1,0 +1,18 @@
+import YAML from "yaml";
+import {
+  discoverAutomationRegistryEntries,
+  loadAutomationRegistry,
+} from "./lib/automation-registry.js";
+
+const discovery = discoverAutomationRegistryEntries(loadAutomationRegistry());
+const wantsJson = process.argv.includes("--json");
+
+if (wantsJson) {
+  console.log(JSON.stringify(discovery, null, 2));
+} else if (discovery.missing.length === 0) {
+  console.log("automation-registry: no missing entries");
+} else {
+  console.log("# Candidate entries for tools/automation-registry.yml");
+  console.log("# Replace TODO purpose text before committing; check:automation-registry rejects placeholders.");
+  console.log(YAML.stringify(discovery.missing));
+}

--- a/scripts/lib/automation-registry.ts
+++ b/scripts/lib/automation-registry.ts
@@ -41,6 +41,10 @@ export type AutomationRegistry = {
   entries: AutomationRegistryEntry[];
 };
 
+export type AutomationRegistryDiscovery = {
+  missing: AutomationRegistryEntry[];
+};
+
 type PackageJson = {
   scripts?: Record<string, string>;
 };
@@ -114,6 +118,7 @@ export function validateAutomationRegistry(
     validateRequiredBoolean(entry, "read_only", registryPath, errors);
     validateRequiredBoolean(entry, "safe_to_run_locally", registryPath, errors);
     validateRequiredBoolean(entry, "emits_json", registryPath, errors);
+    validateHumanAnnotation(entry, registryPath, errors);
 
     if (!Array.isArray(entry.used_by) || entry.used_by.length === 0) {
       errors.push({
@@ -203,6 +208,52 @@ export function validateAutomationRegistry(
   return errors;
 }
 
+/**
+ * Discover registry entries for automation surfaces that are not yet registered.
+ *
+ * The returned entries are intentionally incomplete: their `purpose` values
+ * contain TODO markers that `validateAutomationRegistry` rejects. This makes
+ * the output useful as a scaffold without allowing generated placeholders to
+ * become accepted registry annotations.
+ *
+ * @param {AutomationRegistry} registry - Parsed automation registry.
+ * @param {string} [root=repoRoot] - Repository root.
+ * @returns {AutomationRegistryDiscovery} Missing registry entry candidates.
+ */
+export function discoverAutomationRegistryEntries(
+  registry: AutomationRegistry,
+  root = repoRoot,
+): AutomationRegistryDiscovery {
+  const entries = registry && Array.isArray(registry.entries) ? registry.entries : [];
+  const commands = new Set(
+    entries.map((entry) => entry.command).filter((command): command is string => typeof command === "string"),
+  );
+  const paths = new Set(
+    entries.map((entry) => entry.path).filter((entryPath): entryPath is string => typeof entryPath === "string"),
+  );
+  const missing: AutomationRegistryEntry[] = [];
+
+  for (const script of packageScripts(root)) {
+    const command = `npm run ${script}`;
+    if (!commands.has(command)) missing.push(discoveredPackageScriptEntry(script, root));
+  }
+
+  for (const workflow of listedFiles(".github/workflows", root, ".yml", ".yaml")) {
+    if (!paths.has(workflow)) missing.push(discoveredWorkflowEntry(workflow));
+  }
+
+  for (const skill of listedFiles(".claude/skills", root, "SKILL.md")) {
+    if (!paths.has(skill)) missing.push(discoveredSkillEntry(skill));
+  }
+
+  for (const operationalAgent of listedFiles("agents/operational", root, "PROMPT.md")) {
+    const directory = operationalAgent.replace(/\/PROMPT\.md$/, "");
+    if (!paths.has(directory)) missing.push(discoveredOperationalAgentEntry(directory));
+  }
+
+  return { missing };
+}
+
 function validateRequiredString(
   entry: AutomationRegistryEntry,
   key: "purpose" | "rerun_command",
@@ -233,12 +284,114 @@ function validateRequiredBoolean(
   }
 }
 
+function validateHumanAnnotation(
+  entry: AutomationRegistryEntry,
+  registryPath: string,
+  errors: Diagnostic[],
+): void {
+  if (typeof entry.purpose === "string" && /\bTODO\b/i.test(entry.purpose)) {
+    errors.push({
+      path: registryPath,
+      code: "AUTO_ANNOTATION",
+      message: `${entry.id || "entry"} purpose must be human-authored before registration`,
+    });
+  }
+}
+
 function packageScripts(root: string): string[] {
   const packageJson = JSON.parse(readText(path.join(root, "package.json"))) as PackageJson;
   if (!packageJson.scripts || typeof packageJson.scripts !== "object" || Array.isArray(packageJson.scripts)) {
     return [];
   }
   return Object.keys(packageJson.scripts).sort();
+}
+
+function discoveredPackageScriptEntry(script: string, root: string): AutomationRegistryEntry {
+  const scriptCommand = packageScriptCommand(root, script);
+  const discoveredPath = scriptPath(scriptCommand);
+  return {
+    id: discoveredPackageScriptId(script),
+    kind: packageScriptKind(script),
+    command: `npm run ${script}`,
+    ...(discoveredPath ? { path: discoveredPath } : {}),
+    purpose: `TODO: describe npm script ${script}.`,
+    read_only: !(script === "fix" || script.startsWith("fix:") || script.startsWith("docs:")),
+    safe_to_run_locally: true,
+    emits_json: script.endsWith(":json"),
+    used_by: ["human", "agent"],
+    rerun_command: `npm run ${script}`,
+  };
+}
+
+function discoveredWorkflowEntry(workflow: string): AutomationRegistryEntry {
+  const name = path.basename(workflow).replace(/\.(ya?ml)$/i, "");
+  return {
+    id: `workflow:${name}`,
+    kind: "workflow",
+    path: workflow,
+    purpose: `TODO: describe GitHub workflow ${workflow}.`,
+    read_only: workflow !== ".github/workflows/pages.yml",
+    safe_to_run_locally: false,
+    emits_json: false,
+    used_by: ["ci"],
+    rerun_command: `gh run list --workflow ${path.basename(workflow)}`,
+  };
+}
+
+function discoveredSkillEntry(skill: string): AutomationRegistryEntry {
+  const name = skill.replace(/^\.claude\/skills\//, "").replace(/\/SKILL\.md$/, "");
+  return {
+    id: `skill:${name}`,
+    kind: "skill",
+    path: skill,
+    purpose: `TODO: describe agent-facing skill ${name}.`,
+    read_only: true,
+    safe_to_run_locally: true,
+    emits_json: false,
+    used_by: ["agent"],
+    rerun_command: `open ${skill}`,
+  };
+}
+
+function discoveredOperationalAgentEntry(directory: string): AutomationRegistryEntry {
+  const name = directory.replace(/^agents\/operational\//, "");
+  return {
+    id: `operational-agent:${name}`,
+    kind: "operational-agent",
+    path: directory,
+    purpose: `TODO: describe operational agent ${name}.`,
+    read_only: true,
+    safe_to_run_locally: false,
+    emits_json: false,
+    used_by: ["agent", "human"],
+    rerun_command: `open ${directory}/PROMPT.md`,
+  };
+}
+
+function discoveredPackageScriptId(script: string): string {
+  if (script.startsWith("check:")) return script;
+  if (script === "fix") return "fix:generated";
+  if (script.startsWith("fix:")) return script;
+  if (script === "docs:scripts") return script;
+  return `script:${script.replace(/:/g, "-")}`;
+}
+
+function packageScriptKind(script: string): AutomationKind {
+  if (script.startsWith("check:")) return "check";
+  if (script === "fix" || script.startsWith("fix:")) return "fix";
+  return "script";
+}
+
+function packageScriptCommand(root: string, script: string): string {
+  const packageJson = JSON.parse(readText(path.join(root, "package.json"))) as PackageJson;
+  return packageJson.scripts?.[script] || "";
+}
+
+function scriptPath(command: string): string | undefined {
+  const match =
+    command.match(/\btsx\s+(scripts\/[^\s]+\.ts)\b/) ||
+    command.match(/\bnode\s+(scripts\/[^\s]+\.js)\b/);
+  return match?.[1];
 }
 
 function listedFiles(startDir: string, root: string, ...suffixes: string[]): string[] {

--- a/scripts/lib/automation-registry.ts
+++ b/scripts/lib/automation-registry.ts
@@ -289,7 +289,7 @@ function validateHumanAnnotation(
   registryPath: string,
   errors: Diagnostic[],
 ): void {
-  if (typeof entry.purpose === "string" && /\bTODO\b/i.test(entry.purpose)) {
+  if (typeof entry.purpose === "string" && /^TODO:\s+describe\b/i.test(entry.purpose)) {
     errors.push({
       path: registryPath,
       code: "AUTO_ANNOTATION",

--- a/tests/scripts/automation-registry.test.ts
+++ b/tests/scripts/automation-registry.test.ts
@@ -3,7 +3,11 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
-import { loadAutomationRegistry, validateAutomationRegistry } from "../../scripts/lib/automation-registry.js";
+import {
+  discoverAutomationRegistryEntries,
+  loadAutomationRegistry,
+  validateAutomationRegistry,
+} from "../../scripts/lib/automation-registry.js";
 
 test("repository automation registry validates current automation surfaces", () => {
   const errors = validateAutomationRegistry(loadAutomationRegistry());
@@ -100,4 +104,62 @@ test("automation registry reports non-object registry input without throwing", (
       message: "registry must be an object",
     },
   ]);
+});
+
+test("automation registry discovery scaffolds missing entries", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "agentic-workflow-registry-discovery-test-"));
+  try {
+    fs.mkdirSync(path.join(root, "scripts"), { recursive: true });
+    fs.mkdirSync(path.join(root, ".github", "workflows"), { recursive: true });
+    fs.mkdirSync(path.join(root, ".claude", "skills", "sample"), { recursive: true });
+    fs.mkdirSync(path.join(root, "agents", "operational", "sample-bot"), { recursive: true });
+    fs.writeFileSync(path.join(root, "scripts", "sample.ts"), "", "utf8");
+    fs.writeFileSync(path.join(root, ".github", "workflows", "verify.yml"), "name: Verify\n", "utf8");
+    fs.writeFileSync(path.join(root, ".claude", "skills", "sample", "SKILL.md"), "# Sample\n", "utf8");
+    fs.writeFileSync(path.join(root, "agents", "operational", "sample-bot", "PROMPT.md"), "# Sample\n", "utf8");
+    fs.writeFileSync(
+      path.join(root, "package.json"),
+      JSON.stringify({ scripts: { "check:sample": "tsx scripts/sample.ts" } }),
+      "utf8",
+    );
+
+    const discovery = discoverAutomationRegistryEntries({ version: 1, entries: [] }, root);
+    assert.deepEqual(
+      discovery.missing.map((entry) => entry.id),
+      ["check:sample", "workflow:verify", "skill:sample", "operational-agent:sample-bot"],
+    );
+    assert.equal(discovery.missing[0].path, "scripts/sample.ts");
+    assert.equal(discovery.missing.every((entry) => entry.purpose.startsWith("TODO:")), true);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("automation registry rejects generated placeholder annotations", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "agentic-workflow-registry-annotation-test-"));
+  try {
+    fs.writeFileSync(path.join(root, "package.json"), JSON.stringify({ scripts: {} }), "utf8");
+    const errors = validateAutomationRegistry(
+      {
+        version: 1,
+        entries: [
+          {
+            id: "script:placeholder",
+            kind: "script",
+            command: "npm run placeholder",
+            purpose: "TODO: describe this script.",
+            read_only: true,
+            safe_to_run_locally: true,
+            emits_json: false,
+            used_by: ["agent"],
+            rerun_command: "npm run placeholder",
+          },
+        ],
+      },
+      root,
+    );
+    assert.equal(errors.some((error) => typeof error !== "string" && error.code === "AUTO_ANNOTATION"), true);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 });

--- a/tests/scripts/automation-registry.test.ts
+++ b/tests/scripts/automation-registry.test.ts
@@ -163,3 +163,32 @@ test("automation registry rejects generated placeholder annotations", () => {
     fs.rmSync(root, { recursive: true, force: true });
   }
 });
+
+test("automation registry allows human-authored purposes that mention TODO", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "agentic-workflow-registry-todo-purpose-test-"));
+  try {
+    fs.writeFileSync(path.join(root, "package.json"), JSON.stringify({ scripts: {} }), "utf8");
+    const errors = validateAutomationRegistry(
+      {
+        version: 1,
+        entries: [
+          {
+            id: "script:todo-scan",
+            kind: "script",
+            command: "npm run todo-scan",
+            purpose: "Scan source for TODO comments before release review.",
+            read_only: true,
+            safe_to_run_locally: true,
+            emits_json: false,
+            used_by: ["agent"],
+            rerun_command: "npm run todo-scan",
+          },
+        ],
+      },
+      root,
+    );
+    assert.deepEqual(errors, []);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tools/automation-registry.yml
+++ b/tools/automation-registry.yml
@@ -40,6 +40,16 @@ entries:
     emits_json: false
     used_by: [human, agent]
     rerun_command: npm run verify:changed
+  - id: script:automation-registry-discover
+    kind: script
+    command: npm run automation:registry:discover
+    path: scripts/automation-registry-discover.ts
+    purpose: Emit candidate registry entries for newly discovered automation surfaces.
+    read_only: true
+    safe_to_run_locally: true
+    emits_json: true
+    used_by: [human, agent]
+    rerun_command: npm run automation:registry:discover
   - id: script:quality-metrics
     kind: script
     command: npm run quality:metrics


### PR DESCRIPTION
## Summary

- Adds `npm run automation:registry:discover` to emit candidate registry entries for missing package scripts, workflows, skills, and operational agents.
- Marks generated candidate purposes with `TODO` placeholders and rejects those placeholders in `check:automation-registry` so discovered entries require human annotation before they can pass.
- Registers and documents the new discovery command, including JSON output for agents and generated TypeDoc references.

## Verification

- `npm run automation:registry:discover -- --json`
- `npm run verify:changed`
- `npm run verify`

## Chunk

This is chunk 2 of the automation hardening follow-up series after PR #109. It focuses on registry discovery and annotation safety; agent stale-reference checks remain a separate chunk.