### PR TITLE
chore(tokens): dedupe always-loaded context

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -1,32 +1,27 @@
 # Project memory — index
 
-Opinionated TOC for `.claude/memory/`. Read first.
-See [`README.md`](./README.md) for what belongs + how update.
+One-line pointers into `.claude/memory/`. Read first. See [`README.md`](./README.md) for the contract.
 
 ## Project state
 
-> What project currently *is* — facts that change over time.
-
-- *(Add `project_*.md` when repo has releases, integrations, in-flight roadmaps. Examples: `project_release_status.md`, `project_integrations.md`, `project_active_plan.md`.)*
+- *(Add `project_*.md` for releases, integrations, in-flight roadmaps as needed.)*
 
 ## Workflow rules
 
-> How we work — conventions every contributor (human/agent) follows.
-
-- **Discovery before idea** — no brief, run Discovery Track first (`/discovery:start` → … → `/discovery:handoff`). Track produces `chosen-brief.md` seeding `/spec:idea`. Skip discovery on blank page violates Article II (Separation of Concerns). See [`docs/discovery-track.md`](../../docs/discovery-track.md) + [ADR-0005](../../docs/adr/0005-add-discovery-track-before-stage-1.md).
-- **Project Manager Track for service-provider work** — delivering for client with contract, scope, stakeholders → run Project Manager Track alongside feature work (`/project:start` → `/project:initiate` → `/project:weekly` (recurring) → `/project:close`). Based on P3.Express. State lives in `projects/<slug>/project-state.md`. **Opt-in**; skip for internal product work with no contract boundary. See [`docs/project-track.md`](../../docs/project-track.md) + [ADR-0008](../../docs/adr/0008-add-project-manager-track.md).
-- **Portfolio track for multi-project work** — managing multiple parallel features or service provider → use opt-in Portfolio Track (`/portfolio:start` → cycles `/portfolio:y` monthly, `/portfolio:x` 6-monthly, `/portfolio:z` daily). `portfolio-manager` agent reads `specs/*/workflow-state.md` for health signals but **never modifies spec artifacts**. Portfolio Sponsor (always human) owns all strategic decisions (stop/start/pivot). See [`docs/portfolio-track.md`](../../docs/portfolio-track.md) + [ADR-0009](../../docs/adr/0009-add-portfolio-manager-role.md).
-- **Branch per concern** — one PR, one concern. Cut every topic branch fresh from integration branch; never stack. See [`feedback_pr_hygiene.md`](./feedback_pr_hygiene.md).
-- **No direct commits on main / develop** — every change (code, docs, memory, planning artifact) lands via topic branch + merged PR. Push deny on `main` / `develop` is backstop, not gate; commits should never reach integration branch locally either. See [`feedback_no_main_commits.md`](./feedback_no_main_commits.md).
-- **Verify before push** — project verify gate (formatter + linter + types + tests + build) must be green locally before opening PR. Never `--no-verify`. See [`feedback_verify_gate.md`](./feedback_verify_gate.md) + [`docs/verify-gate.md`](../../docs/verify-gate.md).
-- **Worktrees for parallel work** — every topic branch lives under `.worktrees/<slug>/` so multiple agents run parallel without trashing each other's caches. See [`feedback_worktrees_required.md`](./feedback_worktrees_required.md) + [`docs/worktrees.md`](../../docs/worktrees.md).
-- **Independent‑PRs + batch + multi‑pass review** — open every independent PR before draining review feedback. One implementation pass + one sweep pass beats N serial round‑trips. See [`feedback_pr_workflow.md`](./feedback_pr_workflow.md).
-- **PR Codex review loop** — every PR runs bounded author↔Codex loop. Trigger: `ready_for_review`. Author re-requests fresh Codex review **after every push**; CI failures + merge conflicts in-loop work; soft cap 3 rounds. Approval must come from latest round. See [`feedback_pr_review_loop.md`](./feedback_pr_review_loop.md) + [ADR-0015](../../docs/adr/0015-codify-codex-pr-review-loop.md).
-- **Docs and plan updates ride with their PR** — every user‑visible change updates relevant doc, plan row, steering file in *same* PR. No "I'll update docs after." See [`feedback_docs_with_pr.md`](./feedback_docs_with_pr.md).
-- **Parallel PRs use merge, not rebase** — two PRs both update same plan/RTM table → resolve via `git merge origin/<integration-branch>`. Rebase breaks reviewer line anchors. See [`feedback_parallel_pr_conflicts.md`](./feedback_parallel_pr_conflicts.md).
-- **Autonomous merge after green review + clean state** — agent‑driven runs, self‑merge allowed *only* after reviewer signal green AND CI green AND PR clean mergeable. See [`feedback_autonomous_merge.md`](./feedback_autonomous_merge.md).
-- **Memory edits are docs‑only** — changes to this directory don't need changeset/version bump; never bundle with code changes. See [`feedback_memory_edits.md`](./feedback_memory_edits.md).
+- **Discovery before idea** — no brief → run Discovery Track, get `chosen-brief.md`. See [`docs/discovery-track.md`](../../docs/discovery-track.md).
+- **Project Manager Track** — opt-in for client engagements (P3.Express). See [`docs/project-track.md`](../../docs/project-track.md).
+- **Portfolio Track** — opt-in for multi-feature/program work; never modifies `specs/`. See [`docs/portfolio-track.md`](../../docs/portfolio-track.md).
+- **Branch per concern** — one PR, one concern; cut fresh from integration. See [`feedback_pr_hygiene.md`](./feedback_pr_hygiene.md).
+- **No direct commits on `main` / `develop`** — every change via topic branch + merged PR. See [`feedback_no_main_commits.md`](./feedback_no_main_commits.md).
+- **Verify before push** — gate green locally; never `--no-verify`. See [`feedback_verify_gate.md`](./feedback_verify_gate.md).
+- **Worktrees for parallel work** — topic branches under `.worktrees/<slug>/`. See [`feedback_worktrees_required.md`](./feedback_worktrees_required.md).
+- **Independent PRs + batch review** — open all independent PRs before draining feedback. See [`feedback_pr_workflow.md`](./feedback_pr_workflow.md).
+- **PR Codex review loop** — bounded author↔Codex loop; re-request after every push. See [`feedback_pr_review_loop.md`](./feedback_pr_review_loop.md).
+- **Docs ride with their PR** — user-visible change updates the doc in the same PR. See [`feedback_docs_with_pr.md`](./feedback_docs_with_pr.md).
+- **Parallel PRs: merge not rebase** — preserves reviewer line anchors. See [`feedback_parallel_pr_conflicts.md`](./feedback_parallel_pr_conflicts.md).
+- **Autonomous merge** — only after green review + green CI + clean mergeable. See [`feedback_autonomous_merge.md`](./feedback_autonomous_merge.md).
+- **Memory edits are docs-only** — no changeset, no bundling with code. See [`feedback_memory_edits.md`](./feedback_memory_edits.md).
 
 ## How this index is maintained
 
-Add `feedback_*.md` or `project_*.md` → add one‑line bullet here pointing at it. Delete one → delete bullet. Index is contract; rest is detail.
+Add `feedback_*.md` or `project_*.md` → add one-line bullet here. Delete file → delete bullet. Index is the contract; rest is detail.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,73 +1,69 @@
 # AGENTS.md
 
-Cross-tool root context for AI coding agents (Claude Code, Codex, Cursor, Aider, Copilot, Gemini, etc.). Tool-specific files and folders (`CLAUDE.md`, `.codex/`, `.cursor/rules/`, `.aider.conf.yml`) should `@import` or reference this file, not duplicate.
+Cross-tool root context for AI coding agents (Claude Code, Codex, Cursor, Aider, Copilot, Gemini, etc.). Tool-specific files (`CLAUDE.md`, `.codex/`, `.cursor/rules/`, `.aider.conf.yml`) `@import` this file rather than duplicate.
 
 > **One source of truth, many tools.** Change project conventions here.
 
 ## Project
 
-Repo = **template for spec-driven, agentic software development**. No product build — defines workflow, artifacts, roles for building products. Workflow itself = deliverable.
-
-In project *using* template, replace this section with product overview.
+Repo = **template for spec-driven, agentic software development**. Defines workflow, artifacts, roles for building products. Workflow itself = the deliverable. Replace this section with a product overview when a project *uses* the template.
 
 ## Read these first
-
-Before non-trivial work, read:
 
 1. **`memory/constitution.md`** — governing principles. Override only with explicit human approval.
 2. **`.claude/memory/MEMORY.md`** — operational memory: workflow rules + project state, indexed.
 3. **`docs/specorator.md`** — full workflow definition.
-4. **`docs/steering/`** — scoped context (product, tech, ux, quality, operations). Load only relevant to task.
-5. **Current feature's `specs/<feature>/workflow-state.md`** — shows active stage + what produced.
+4. **`docs/steering/`** — scoped context (product, tech, ux, quality, ops). Load only what's relevant.
+5. **Current feature's `specs/<feature>/workflow-state.md`** — active stage + what's already produced.
 
 ## Operating rules
 
-- **Stay in scope.** Each agent role has defined responsibility (see `.claude/agents/`). No code in research phase. No requirement changes during implementation.
-- **Specs = source of truth.** Implementation reveals missing requirement → escalate, no silent invent. Update spec first, then code.
-- **Respect quality gates.** Every stage has acceptance criteria in `docs/quality-framework.md`. No stage complete unless pass.
-- **Trace everything.** Every requirement, task, test has ID (see `docs/traceability.md`). Reference IDs in commits, PRs, artifacts.
-- **EARS for requirements.** Functional requirements use EARS notation (see `docs/ears-notation.md`) — map 1:1 to tests.
-- **ADRs for irreversible decisions.** Architecturally load-bearing → ADR in `docs/adr/`. Use template `templates/adr-template.md`.
-- **Update workflow state.** Finish or hand off stage → update `specs/<feature>/workflow-state.md` so next agent resume.
-- **Keep product page alive.** Every new project/product gets public product page with directly accessible `sites/index.html`. Prefer GitHub Pages via GitHub Actions when available. Update page in same PR as user-visible product or positioning changes.
-- **Escalate ambiguity.** No guess. Ask human or open `clarifications` block in active artifact.
-- **No direct commits on `main` / `develop`.** Every change — code, docs, ADRs, glossary, memory, brainstorm output, plans, generated docs — lands via topic branch + merged PR. Push deny = backstop, not gate; commits never reach integration branch locally either. See `.claude/memory/feedback_no_main_commits.md`.
-- **Branch per concern; verify before push.** Topic branches live in `.worktrees/<slug>/`; one concern per PR; `verify` green locally before opening PR. Never `--no-verify`. See `docs/branching.md`, `docs/worktrees.md`, `docs/verify-gate.md`.
-- **Codex opens PR.** For non-trivial repo changes, Codex creates own worktree, commits, pushes, opens pull request, reports PR URL/status, asks human for next step. See `.codex/README.md`.
-- **Memory edits = docs‑only.** Updates to `.claude/memory/` ride own PR with no changeset, no version bump. See `.claude/memory/feedback_memory_edits.md`.
+- **Stay in scope.** Each agent role has a defined responsibility (see `.claude/agents/`). No code in research; no requirement changes during implementation.
+- **Specs = source of truth.** Implementation reveals a missing requirement → escalate, no silent invent. Update spec first, then code.
+- **Respect quality gates.** Acceptance criteria in `docs/quality-framework.md` are non-negotiable.
+- **Trace everything.** `REQ-<AREA>-NNN`, `T-<AREA>-NNN`, `TEST-<AREA>-NNN`, `ADR-NNNN`. Reference IDs in commits, PRs, artifacts. See [`docs/traceability.md`](docs/traceability.md).
+- **EARS for requirements.** Functional requirements use EARS notation — map 1:1 to tests. See [`docs/ears-notation.md`](docs/ears-notation.md).
+- **ADRs for irreversible decisions.** Architecturally load-bearing → ADR in `docs/adr/`. Use `templates/adr-template.md`. ADR bodies are immutable; supersede to change.
+- **Update workflow state.** Hand off a stage → update `specs/<feature>/workflow-state.md`.
+- **Keep a product page alive.** Public page at `sites/index.html`; prefer GitHub Pages. Update in the same PR as user-visible changes.
+- **Escalate ambiguity.** No guessing. Ask the human or open a `clarifications` block.
+- **No direct commits on `main` / `develop`.** Every change lands via topic branch + merged PR. Push deny is the backstop, not the gate. See [`.claude/memory/feedback_no_main_commits.md`](.claude/memory/feedback_no_main_commits.md).
+- **Branch per concern; verify before push.** One concern per PR; `verify` green locally; never `--no-verify`. See [`docs/branching.md`](docs/branching.md), [`docs/worktrees.md`](docs/worktrees.md), [`docs/verify-gate.md`](docs/verify-gate.md).
+- **Codex opens its PR.** Non-trivial changes via Codex own worktree → commit → push → open PR → report URL. See [`.codex/README.md`](.codex/README.md).
+- **Memory edits are docs-only.** Updates to `.claude/memory/` ride own PR with no changeset. See [`.claude/memory/feedback_memory_edits.md`](.claude/memory/feedback_memory_edits.md).
 
 ## Repo conventions
 
-- Markdown for all artifacts. Keep concise; precision over completeness in early iterations.
+- Markdown for all artifacts. Concise; precision over completeness in early iterations.
 - File names = kebab-case. Per-feature work under `specs/<feature-slug>/`.
-- Each folder may have at most one `README.md`. Below repo root → folder entry point for GitHub-style Markdown browsing. Must start with YAML frontmatter: `title`, `folder`, `description`, `entry_point: true`. `folder` value = repo-relative directory path. Root `README.md` = public repo entry point, exempt from frontmatter rule.
-- IDs stable: `REQ-<AREA>-NNN`, `T-<AREA>-NNN`, `TEST-<AREA>-NNN`, `ADR-NNNN`.
-- ADR bodies immutable. Change decision → supersede; predecessor's `status` and `superseded-by` pointers = only fields updateable.
-- Glossary terms live one-per-file under `docs/glossary/<slug>.md`. Define term with `/glossary:new "<term>"`. Directory listing = index — no `README.md` index to maintain. See [ADR-0010](docs/adr/0010-shard-glossary-into-one-file-per-term.md). Legacy `docs/UBIQUITOUS_LANGUAGE.md` single-file model deprecated.
-- Commit messages: imperative mood, reference IDs (`feat(auth): add T-AUTH-014 password reset`).
+- One `README.md` per folder max. Folders below the repo root start with frontmatter (`title`, `folder`, `description`, `entry_point: true`); root `README.md` is exempt.
+- Glossary terms one-per-file under `docs/glossary/<slug>.md` via `/glossary:new "<term>"`. Legacy single-file `docs/UBIQUITOUS_LANGUAGE.md` deprecated by [ADR-0010](docs/adr/0010-shard-glossary-into-one-file-per-term.md).
+- Commit messages: imperative, reference IDs (`feat(auth): add T-AUTH-014 password reset`).
 
-## When the harness gets in your way
+## Agent classes
 
-Repo **process-light by design**, but now has local + CI quality signals: `npm run verify`, PR-title checks, spell check, Pages deployment, workflow/security scans, dependency bump automation. Branch protection may still be intentionally light for early template adoption; if fighting tooling, fix process over working around it.
+| Class | Location | Purpose | Methodology |
+|---|---|---|---|
+| **Lifecycle (Stage 1–11 specialists)** | `.claude/agents/` | Build one feature: analyst, pm, ux/ui-designer, architect, planner, dev, qa, reviewer, release-manager, sre, retrospective. | [`docs/specorator.md`](docs/specorator.md) |
+| **Discovery specialists** *(opt-in)* | `.claude/agents/` | Pre-Stage 1 ideation: facilitator + product-strategist, user-researcher, game-designer, divergent-thinker, critic, prototyper. Produces `chosen-brief.md`. | [`docs/discovery-track.md`](docs/discovery-track.md) ([ADR-0005](docs/adr/0005-add-discovery-track-before-stage-1.md)) |
+| **Stock-taking** *(opt-in, brownfield)* | `.claude/agents/legacy-auditor.md` | Inventory existing systems before new work. Produces `stock-taking-inventory.md`. | [`docs/stock-taking-track.md`](docs/stock-taking-track.md) ([ADR-0007](docs/adr/0007-add-stock-taking-track-for-legacy-projects.md)) |
+| **Sales** *(opt-in, service provider)* | `.claude/agents/` | Pre-contract: `sales-qualifier`, `scoping-facilitator`, `estimator`, `proposal-writer`. Produces `order.md`. | [`docs/sales-cycle.md`](docs/sales-cycle.md) ([ADR-0006](docs/adr/0006-add-sales-cycle-track-before-discovery.md)) |
+| **Project manager** *(opt-in)* | `.claude/agents/project-manager.md` | Client-engagement governance based on P3.Express. State lives `projects/<slug>/`. Never edits `specs/`. | [`docs/project-track.md`](docs/project-track.md) ([ADR-0008](docs/adr/0008-add-project-manager-track.md)) |
+| **Roadmap manager** *(opt-in)* | `.claude/agents/roadmap-manager.md` | Outcome roadmaps, stakeholder maps, comms log under `roadmaps/<slug>/`. Read-only on `specs/`. | [`docs/roadmap-management-track.md`](docs/roadmap-management-track.md) ([ADR-0012](docs/adr/0012-add-roadmap-management-track.md)) |
+| **Portfolio** *(opt-in)* | `.claude/agents/portfolio-manager.md` | P5 Express X/Y/Z cycles. Reads `specs/*/workflow-state.md`; never modifies spec artifacts. | [`docs/portfolio-track.md`](docs/portfolio-track.md) ([ADR-0009](docs/adr/0009-add-portfolio-manager-role.md)) |
+| **Project scaffolder** *(opt-in)* | `.claude/agents/project-scaffolder.md` | Source-led onboarding from collected docs/folders. State lives `scaffolding/<slug>/`. | [`docs/project-scaffolding-track.md`](docs/project-scaffolding-track.md) ([ADR-0011](docs/adr/0011-add-project-scaffolding-track.md)) |
+| **Quality assurance** *(opt-in)* | `.claude/skills/quality-assurance/SKILL.md` | ISO 9001-aligned readiness review. State lives `quality/<slug>/`. | [`docs/quality-assurance-track.md`](docs/quality-assurance-track.md) |
+| **Operational bots** | `agents/operational/` | Scheduled routines (review-bot, docs-review-bot, plan-recon-bot, dep-triage-bot, actions-bump-bot). `PROMPT.md` + `README.md` per bot. | — |
 
-## Four classes of agent
-
-- **Lifecycle agents** (`.claude/agents/`) — build one feature across Stages 1–11. `orchestrator` routes between them. Three sub-classes:
-  - **Stage 1–11 specialists** — analyst, pm, ux-designer, ui-designer, architect, planner, dev, qa, reviewer, release-manager, sre, retrospective.
-  - **Discovery specialists** *(pre-stage 1, opt-in — see [ADR-0005](docs/adr/0005-add-discovery-track-before-stage-1.md))* — facilitator + product-strategist, user-researcher, game-designer, divergent-thinker, critic, prototyper. For ideation / design-sprint / concept-validation work producing `chosen-brief.md` before `/spec:idea`. Discovery-track methodology at [`docs/discovery-track.md`](docs/discovery-track.md).
-  - **Stock-taking specialist** *(pre-Discovery or pre-Stage 1, opt-in for legacy/brownfield projects — see [ADR-0007](docs/adr/0007-add-stock-taking-track-for-legacy-projects.md))* — `legacy-auditor`. Inventories existing systems (processes, use-cases, integrations, data, technical debt) before ideation or feature work. Produces `stock-taking-inventory.md` feeding Discovery Track or `/spec:idea`. Stock-taking methodology at [`docs/stock-taking-track.md`](docs/stock-taking-track.md).
-- **Project manager** (`.claude/agents/project-manager.md`) *(opt-in, service-provider context — see [ADR-0008](docs/adr/0008-add-project-manager-track.md))* — owns all project-level governance for client engagements: scope, stakeholders, risk/issue/change tracking, weekly cadence, status reports, project closure. Based on P3.Express. State lives `projects/<slug>/`. Links to but never edits `specs/` or `discovery/` artifacts. Project-manager methodology at [`docs/project-track.md`](docs/project-track.md).
-- **Roadmap manager** (`.claude/agents/roadmap-manager.md`) *(opt-in, product + project planning context — see [ADR-0012](docs/adr/0012-add-roadmap-management-track.md))* — owns outcome roadmaps, delivery-plan signals, stakeholder maps, communication logs, roadmap decisions under `roadmaps/<slug>/`. Reads linked `specs/`, `projects/`, `portfolio/` artifacts but never edits. Methodology at [`docs/roadmap-management-track.md`](docs/roadmap-management-track.md).
-- **Portfolio agent** (`.claude/agents/portfolio-manager.md`) *(opt-in, above Stage 1–11 — see [ADR-0009](docs/adr/0009-add-portfolio-manager-role.md))* — manages portfolios of programs and projects using P5 Express methodology (X/Y/Z cycles). Invoked by `/portfolio:x`, `/portfolio:y`, `/portfolio:z`. Reads `specs/*/workflow-state.md` for health signals; never modifies spec artifacts. Portfolio artifacts live under `portfolio/<slug>/`. Methodology at [`docs/portfolio-track.md`](docs/portfolio-track.md).
-- **Project scaffolder** (`.claude/agents/project-scaffolder.md`) *(opt-in, source-led adoption — see [ADR-0011](docs/adr/0011-add-project-scaffolding-track.md))* — inventories folders or Markdown files collected before template adoption, extracts evidence-backed project context, assembles reviewable starter drafts, hands off to Discovery, Specorator, Project Manager Track, or Stock-taking. State lives `scaffolding/<slug>/`. Methodology at [`docs/project-scaffolding-track.md`](docs/project-scaffolding-track.md).
-- **Quality assurance workflow** (`.claude/skills/quality-assurance/SKILL.md`) *(opt-in, ISO 9001-aligned readiness review)* — creates evidence-backed QA plans, checklists, readiness reviews, corrective actions for projects, portfolios, releases, suppliers, active features. State lives `quality/<slug>/`. Methodology at [`docs/quality-assurance-track.md`](docs/quality-assurance-track.md).
-- **Operational agents** (`agents/operational/`) — always-on, scheduled routines acting against live repo (review-bot, docs-review-bot, plan-recon-bot, dep-triage-bot, actions-bump-bot). Each = `PROMPT.md` + `README.md`.
-
-Skills (`.claude/skills/`) = reusable how-tos any agent invokes (`verify`, `new-adr`, `review-fix`). Ten workflow-conductor skills (`orchestrate`, `project-scaffolding`, `discovery-sprint`, `stock-taking`, `sales-cycle`, `project-run`, `roadmap-management`, `portfolio-track`, `quality-assurance`, `specorator-improvement`) = conversational entry points.
+Skills (`.claude/skills/`) = reusable how-tos any agent invokes (`verify`, `new-adr`, `review-fix`). Ten workflow-conductor skills (`orchestrate`, `project-scaffolding`, `discovery-sprint`, `stock-taking`, `sales-cycle`, `project-run`, `roadmap-management`, `portfolio-track`, `quality-assurance`, `specorator-improvement`) are the conversational entry points.
 
 ## Tool-specific notes
 
-- **Claude Code.** Subagents at `.claude/agents/`, slash commands at `.claude/commands/`, skills at `.claude/skills/`, operational memory at `.claude/memory/`, permission baseline at `.claude/settings.json`. `CLAUDE.md` imports this file plus constitution and memory index.
-- **Codex.** This file = primary context. Codex-specific instructions and workflows live in [`.codex/`](.codex/README.md): create worktree, verify, push, open PR, ask for next steps.
-- **Cursor / Aider.** This file = primary context. Cursor users: `.cursor/rules/` may be added later if needed.
-- **All tools.** Templates in `templates/` = framework-agnostic Markdown.
+- **Claude Code.** Subagents at `.claude/agents/`, slash commands at `.claude/commands/`, skills at `.claude/skills/`, memory at `.claude/memory/`, permissions at `.claude/settings.json`. `CLAUDE.md` imports this file plus constitution + memory index.
+- **Codex.** Primary context = this file. Codex specifics in [`.codex/`](.codex/README.md).
+- **Cursor / Aider.** Primary context = this file. `.cursor/rules/` optional.
+- **All tools.** Templates in `templates/` are framework-agnostic Markdown.
+
+## When the harness gets in your way
+
+Process-light by design, but with local + CI quality signals (`npm run verify`, PR-title checks, spell check, Pages deployment, security scans, dep automation). Branch protection is intentionally light for early template adoption. Fighting tooling? Fix the process, don't work around it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-Entry point for Claude Code in repo.
+Entry point for Claude Code in this repository.
 
 ## Primary context
 
@@ -10,64 +10,44 @@ Entry point for Claude Code in repo.
 
 ## What this repo is
 
-Template for **spec-driven, agentic software development**. Workflow itself = deliverable. See `docs/specorator.md` for full definition, `README.md` for file map.
+Template for **spec-driven, agentic software development**. The workflow itself is the deliverable. See [`docs/specorator.md`](docs/specorator.md) for the full definition and [`README.md`](README.md) for the file map.
 
 ## How to work here
 
-Two equivalent entry points for **lifecycle workflow** (Stages 1–11):
+The **lifecycle workflow** (Stages 1–11) has two equivalent entry points:
 
-- **Conversational (recommended):** say "let's start a feature" or "drive this end-to-end" and [`orchestrate`](.claude/skills/orchestrate/SKILL.md) skill guide you. Gates with `AskUserQuestion`, dispatches right `/spec:*` command per stage.
-- **Manual:** drive slash commands yourself in stage order: `/spec:start`, `/spec:idea`, `/spec:research`, `/spec:requirements`, `/spec:design`, `/spec:specify`, `/spec:tasks`, `/spec:implement`, `/spec:test`, `/spec:review`, `/spec:release`, `/spec:retro`. Optional gates: `/spec:clarify`, `/spec:analyze`.
+- **Conversational (recommended):** say "let's start a feature" or "drive this end-to-end" — the [`orchestrate`](.claude/skills/orchestrate/SKILL.md) skill gates with `AskUserQuestion` and dispatches the right `/spec:*` command per stage.
+- **Manual:** drive the slash commands in stage order — `/spec:start`, `/spec:idea`, `/spec:research`, `/spec:requirements`, `/spec:design`, `/spec:specify`, `/spec:tasks`, `/spec:implement`, `/spec:test`, `/spec:review`, `/spec:release`, `/spec:retro`. Optional gates: `/spec:clarify`, `/spec:analyze`.
 
-When **building on or replacing existing system** + need understand what's there before planning — run **Stock-taking Track first** (pre-Discovery, pre-Stage 1, opt-in for legacy/brownfield):
+State lives in `specs/<feature-slug>/workflow-state.md`. Each `/spec:*` command spawns its specialist subagent from `.claude/agents/` — don't bypass; agent scoping is intentional. Slash commands update `workflow-state.md` on stage completion — don't edit by hand mid-workflow.
 
-- **Conversational:** say "we're building on legacy system", "let's inventory what we have", or "stock-taking" and [`stock-taking`](.claude/skills/stock-taking/SKILL.md) skill guide through Scope → Audit → Synthesize → Handoff. Handoff writes `stock-taking-inventory.md` which feeds Discovery Track or `/spec:idea`.
-- **Manual:** `/stock:start`, `/stock:scope`, `/stock:audit`, `/stock:synthesize`, `/stock:handoff`. See [`docs/stock-taking-track.md`](docs/stock-taking-track.md) and [ADR-0007](docs/adr/0007-add-stock-taking-track-for-legacy-projects.md).
+### Other tracks (opt-in)
 
-When **service provider** needs win project before build — new lead, RFP response, SOW needed — run **Sales Cycle Track first** (pre-Discovery, service-provider opt-in):
+| Track | When to use | Conductor skill | Manual entry | Reference |
+|---|---|---|---|---|
+| **Discovery** | blank-page ideation, no brief | [`discovery-sprint`](.claude/skills/discovery-sprint/SKILL.md) | `/discovery:start` | [`docs/discovery-track.md`](docs/discovery-track.md) ([ADR-0005](docs/adr/0005-add-discovery-track-before-stage-1.md)) |
+| **Stock-taking** | brownfield, inventory existing system | [`stock-taking`](.claude/skills/stock-taking/SKILL.md) | `/stock:start` | [`docs/stock-taking-track.md`](docs/stock-taking-track.md) ([ADR-0007](docs/adr/0007-add-stock-taking-track-for-legacy-projects.md)) |
+| **Sales** | service provider, pre-contract (RFP / SOW) | [`sales-cycle`](.claude/skills/sales-cycle/SKILL.md) | `/sales:start` | [`docs/sales-cycle.md`](docs/sales-cycle.md) ([ADR-0006](docs/adr/0006-add-sales-cycle-track-before-discovery.md)) |
+| **Project Manager** | client engagement governance (P3.Express) | [`project-run`](.claude/skills/project-run/SKILL.md) | `/project:start` | [`docs/project-track.md`](docs/project-track.md) ([ADR-0008](docs/adr/0008-add-project-manager-track.md)) |
+| **Portfolio** | multi-feature / multi-program (P5 Express) | [`portfolio-track`](.claude/skills/portfolio-track/SKILL.md) | `/portfolio:start` | [`docs/portfolio-track.md`](docs/portfolio-track.md) ([ADR-0009](docs/adr/0009-add-portfolio-manager-role.md)) |
 
-- **Conversational (recommended):** say "we have new lead", "we need write proposal", "we got RFP", or "let's run sales cycle" and [`sales-cycle`](.claude/skills/sales-cycle/SKILL.md) skill guide through Qualify → Scope → Estimate → Propose → Order. Order writes `order.md` (Project Kickoff Brief) which feeds downstream delivery workflow.
-- **Manual:** `/sales:start`, `/sales:qualify`, `/sales:scope`, `/sales:estimate`, `/sales:propose`, `/sales:order`. See [`docs/sales-cycle.md`](docs/sales-cycle.md) and [ADR-0006](docs/adr/0006-add-sales-cycle-track-before-discovery.md).
-- **Skip when** signed mandate already — go straight to Discovery Track or `/spec:start`.
-- Deal artifacts live under `sales/<deal-slug>/`. `order.md` Project Kickoff Brief = canonical handoff to delivery workflow, read as mandatory input by analyst (Stage 1) or discovery facilitator (Frame phase).
-
-When no brief yet — blank page, multiple candidate ideas, no clear winner — run **Discovery Track first** (pre-Stage 1, opt-in):
-
-- **Conversational:** say "let's run design sprint", "let's brainstorm new product ideas", or "we have blank page" and [`discovery-sprint`](.claude/skills/discovery-sprint/SKILL.md) skill guide through Frame → Diverge → Converge → Prototype → Validate → Handoff. Handoff writes `chosen-brief.md` which feeds `/spec:idea`.
-- **Manual:** `/discovery:start`, `/discovery:frame`, `/discovery:diverge`, `/discovery:converge`, `/discovery:prototype`, `/discovery:validate`, `/discovery:handoff`. See [`docs/discovery-track.md`](docs/discovery-track.md) and [ADR-0005](docs/adr/0005-add-discovery-track-before-stage-1.md).
-
-When working **service-provider context** — delivering for clients, tracking scope/schedule/budget, sending status reports — run **Project Manager Track** (opt-in, wraps one+ feature deliveries):
-
-- **Conversational:** say "let's start client project", "set up service engagement", or "I have client brief" and [`project-run`](.claude/skills/project-run/SKILL.md) skill guide through Initiation → Execution → Closure. Based on [P3.Express](https://p3.express/).
-- **Manual:** `/project:start`, `/project:initiate`, `/project:weekly`, `/project:change`, `/project:report`, `/project:close`, `/project:post`. See [`docs/project-track.md`](docs/project-track.md) and [ADR-0008](docs/adr/0008-add-project-manager-track.md).
-
-Both modes:
-
-1. State lives in `specs/<feature-slug>/workflow-state.md` — read to learn where feature is.
-2. Each `/spec:*` command spawns specialist subagent from `.claude/agents/`. Don't bypass — agent scoping intentional.
-3. Finish stage → slash command updates `workflow-state.md`. Don't edit by hand mid-workflow.
-
-When managing **multiple parallel features** or **service provider** across client portfolios, run **Portfolio Track** (opt-in, above Specorator):
-
-- **Conversational:** say "run portfolio review", "update portfolio", or "check portfolio health" and [`portfolio-track`](.claude/skills/portfolio-track/SKILL.md) skill detect active portfolio + dispatch right cycle.
-- **Manual:** `/portfolio:start <slug>` (bootstrap), then `/portfolio:x` (6-monthly strategy), `/portfolio:y` (monthly review), `/portfolio:z` (daily ops). See [`docs/portfolio-track.md`](docs/portfolio-track.md) and [ADR-0009](docs/adr/0009-add-portfolio-manager-role.md).
-- Portfolio artifacts live under `portfolio/<portfolio-slug>/`. Track read-only on `specs/` side — never modifies feature artifacts.
+Each track produces a handoff artifact that feeds the next: `chosen-brief.md`, `stock-taking-inventory.md`, `order.md`. See the per-track methodology doc for details.
 
 ## Conventions specific to Claude Code
 
-- Subagents project-scoped (`.claude/agents/`). Tool lists intentionally narrow — missing tool = feature, not bug. Six classes ship: **lifecycle** agents (one per Stage 1–11), **discovery** agents (one facilitator + six specialists for Discovery Track), **stock-taking** agents (one `legacy-auditor` for brownfield inventory), **sales** agents (four specialists for pre-project commercial track: `sales-qualifier`, `scoping-facilitator`, `estimator`, `proposal-writer`), one **project-manager** agent for service-provider engagements, and **portfolio-manager** agent (opt-in, portfolio-level management).
-- Skills live in `.claude/skills/` — see [`.claude/skills/README.md`](.claude/skills/README.md). Auto-trigger from natural language, invoke explicit via `/<skill-name>`. Catalog spans six workflow conductors (`orchestrate`, `discovery-sprint`, `stock-taking`, `sales-cycle`, `project-run`, `portfolio-track`), mattpocock-style practice skills (`grill`, `design-twice`, `tracer-bullet`, `tdd-cycle`), cross-cutting sink skills (`domain-context`, `new-glossary-entry`; `ubiquitous-language` deprecated by [ADR-0010](docs/adr/0010-shard-glossary-into-one-file-per-term.md)), operational skills (`verify`, `new-adr`, `review-fix`).
-- Operational bots live under `agents/operational/`. Each = `PROMPT.md` + `README.md` pair; prompt = source of truth scheduled run loads.
-- Permission rules live in `.claude/settings.json`. Pushes to `main` / `develop` denied by default; `--no-verify` denied. See `docs/branching.md`.
-- Topic branches live in worktrees under `.worktrees/<slug>/`. See `docs/worktrees.md`.
-- Run verify gate before opening PR. See `docs/verify-gate.md`.
-- For irreversible architectural decisions, use [`record-decision`](.claude/skills/record-decision/SKILL.md) skill (wraps `/adr:new`).
-- For glossary terms, use [`/glossary:new "<term>"`](.claude/commands/glossary/new.md) (wraps [`new-glossary-entry`](.claude/skills/new-glossary-entry/SKILL.md) skill). Entries live one-per-file under [`docs/glossary/`](docs/glossary/). Legacy `ubiquitous-language` skill targeting `docs/UBIQUITOUS_LANGUAGE.md` deprecated — see [ADR-0010](docs/adr/0010-shard-glossary-into-one-file-per-term.md).
-- Where every markdown artifact lands documented in [`docs/sink.md`](docs/sink.md). Don't invent new sink locations.
-- Don't add `.claudeignore` exclusions silently — note in `docs/steering/tech.md`.
+- Subagents are project-scoped (`.claude/agents/`) with intentionally narrow tool lists. Missing tool = feature, not bug. Agent-class table lives in [`AGENTS.md`](AGENTS.md).
+- Skills live in `.claude/skills/` — see [`.claude/skills/README.md`](.claude/skills/README.md). Auto-trigger from natural language; explicit invoke via `/<skill-name>`.
+- Operational bots live under `agents/operational/`. Each = `PROMPT.md` + `README.md`; the prompt is the source of truth the scheduled run loads.
+- Permission rules live in `.claude/settings.json`. Pushes to `main` / `develop` are denied; `--no-verify` is denied. See [`docs/branching.md`](docs/branching.md).
+- Topic branches live in worktrees under `.worktrees/<slug>/`. See [`docs/worktrees.md`](docs/worktrees.md).
+- Run the verify gate before opening a PR. See [`docs/verify-gate.md`](docs/verify-gate.md).
+- For irreversible architectural decisions, use [`record-decision`](.claude/skills/record-decision/SKILL.md) (wraps `/adr:new`).
+- For glossary terms, use [`/glossary:new "<term>"`](.claude/commands/glossary/new.md) (wraps [`new-glossary-entry`](.claude/skills/new-glossary-entry/SKILL.md)). Entries live one-per-file under [`docs/glossary/`](docs/glossary/).
+- Where every markdown artifact lands is documented in [`docs/sink.md`](docs/sink.md). Don't invent new sink locations.
+- Don't add `.claudeignore` exclusions silently — note them in `docs/steering/tech.md`.
 
 ## What not to do
 
-- Don't expand workflow with new stages or roles without ADR.
-- Don't write code from vague brief — always run upstream stages first or explicit mark skipped.
-- Don't merge feature work directly into workflow template files (`docs/`, `templates/`, `.claude/`) unless improving *template itself*.
+- Don't expand the workflow with new stages or roles without an ADR.
+- Don't write code from a vague brief — run the upstream stages first or explicitly mark them skipped.
+- Don't merge feature work directly into workflow template files (`docs/`, `templates/`, `.claude/`) unless you're improving the *template itself*.


### PR DESCRIPTION
## Summary

Chunk 1 of token-budget cleanup. Stacks on #117.

Cuts the always-loaded chain (CLAUDE.md + AGENTS.md + MEMORY.md, loaded on every Claude Code session):
- **CLAUDE.md**: 8.2 KB → 4.7 KB (-43%). Five prose track sections collapsed into one table; agent-class detail moved to AGENTS.md.
- **AGENTS.md**: 9.8 KB → 7.8 KB (-20%). "Four classes of agent" prose blurbs collapsed into one table.
- **MEMORY.md**: 4.8 KB → 2.3 KB (-52%). Each rule now a true one-line hook per the file's own contract.

**Combined chain: 28 KB → 18.8 KB (-33%).** Constitution untouched.

## Plan

[`docs/superpowers/plans/2026-05-01-token-budget-cleanup.md`](docs/superpowers/plans/2026-05-01-token-budget-cleanup.md) — Chunk 1.

## Test plan

- [x] `npm run verify` green
- [x] `check:links` confirms no broken links
- [x] All `feedback_*.md` references intact in MEMORY.md
- [x] All ADR refs preserved in AGENTS.md table
- [ ] Reviewer confirms acceptable detail-loss in MEMORY.md (each rule still discoverable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)