### PR TITLE
chore(tokens): document Glob/Grep worktree exclusion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ Repo = **template for spec-driven, agentic software development**. Defines workf
 
 - Markdown for all artifacts. Concise; precision over completeness in early iterations.
 - File names = kebab-case. Per-feature work under `specs/<feature-slug>/`.
+- **Searching the repo:** when using Glob or Grep, exclude `.worktrees/**` unless you explicitly need it. Each worktree is a full repo copy — searching them inflates results, slows the search, and burns tokens. See [`docs/worktrees.md`](docs/worktrees.md#search-hygiene).
 - One `README.md` per folder max. Folders below the repo root start with frontmatter (`title`, `folder`, `description`, `entry_point: true`); root `README.md` is exempt.
 - Glossary terms one-per-file under `docs/glossary/<slug>.md` via `/glossary:new "<term>"`. Legacy single-file `docs/UBIQUITOUS_LANGUAGE.md` deprecated by [ADR-0010](docs/adr/0010-shard-glossary-into-one-file-per-term.md).
 - Commit messages: imperative, reference IDs (`feat(auth): add T-AUTH-014 password reset`).

--- a/docs/worktrees.md
+++ b/docs/worktrees.md
@@ -44,6 +44,16 @@ git worktree prune                   # if needed
 - **Don't commit anything from `.worktrees/`.** The directory is gitignored on purpose.
 - **Don't symlink dependency trees** (`node_modules`, `.venv`) between worktrees. The whole point is isolation.
 
+## Search hygiene
+
+When using **Glob** or **Grep** across the repo, exclude `.worktrees/**` unless you explicitly need to search inside one. Each worktree is a full repo copy — searching all of them inflates results, slows the search, and burns tokens. Examples:
+
+- `Glob` — pass a project-relative path (e.g. `docs/**/*.md`) instead of an open `**/*.md`, or set `path: docs/`.
+- `Grep` — pass `path: <subdir>` for a scoped search; avoid running at the repo root without a glob filter.
+- Bash `find` — start the path inside a known subtree, or add `-not -path './.worktrees/*'`.
+
+Multiplied across a session, this is a meaningful chunk of the token budget. (A repo-wide budget policy will land at `docs/token-budget.md` in a follow-up.)
+
 ## When to skip the worktree
 
 For a one‑line typo fix or a docs‑only PR you'll merge in 30 seconds, the worktree overhead isn't worth it. Cut a topic branch in the main checkout, push, merge, switch back to the integration branch.


### PR DESCRIPTION
## Summary

Chunk 5 of token-budget cleanup. Stacks on #119.

Adds explicit Glob/Grep guidance:
- AGENTS.md "Repo conventions" — short rule + cross-link
- `docs/worktrees.md` — new "Search hygiene" subsection with examples for Glob, Grep, and bash `find`

Each `.worktrees/<slug>/` is a full repo copy — searching them inflates results, slows the search, and burns tokens. Repo currently has 7-10 active worktrees totalling ~9.4 MB of `.md`.

Pruning dormant worktrees is intentionally **not automated** — that's a destructive action requiring human judgment per constitution Article IX.

## Plan

[`docs/superpowers/plans/2026-05-01-token-budget-cleanup.md`](docs/superpowers/plans/2026-05-01-token-budget-cleanup.md) — Chunk 5.

## Test plan

- [x] `npm run verify` green
- [x] `check:links` green
- [ ] Reviewer agrees pruning should remain manual

🤖 Generated with [Claude Code](https://claude.com/claude-code)