### PR TITLE
chore(tokens): factor shared conductor pattern from skills

### DIFF
--- a/.claude/skills/_shared/conductor-pattern.md
+++ b/.claude/skills/_shared/conductor-pattern.md
@@ -1,0 +1,45 @@
+# Conductor pattern (shared)
+
+> Shared scaffolding for workflow-conductor skills. Linked from `orchestrate`, `discovery-sprint`, `sales-cycle`, `stock-taking`. Not auto-loaded — the linking skill keeps trigger logic inline; this file owns the gating + escalation rules.
+
+## AskUserQuestion is main-thread only
+
+`AskUserQuestion` works only in the main thread. Subagents cannot ask the user anything. Every clarification happens in the conductor's turn — before, between, or after a phase — never inside a dispatched specialist.
+
+## Detect resume vs. fresh start
+
+Each conductor stores phase state under a track-specific directory (`specs/`, `discovery/`, `sales/`, `stock-taking/`, `projects/`, `portfolio/`). Always:
+
+1. List the directory and read each state-file's `status` and `last_updated`.
+2. Show resumable items (`active | paused | blocked`) recommended-first by `last_updated`.
+3. Batch a single `AskUserQuestion`: resume listed item / start new / skip if applicable.
+4. No resumable items → skip the menu.
+
+## Per-phase loop
+
+For each phase in the track's defined order:
+
+1. **Pre-flight** — read the state-file, confirm every upstream artifact is `complete` or `skipped`. `pending | in-progress | blocked` = return-to-that-phase signal.
+2. **Dispatch** the phase's slash command. Hand off fully — do not duplicate the specialist's work in your own turn.
+3. **Wait** for the slash command to finish and the artifact to exist on disk.
+4. **Run any opt-in gate** (e.g., `/spec:clarify`, `/spec:analyze`) the user selected for this transition.
+5. **Gate with user** via a single `AskUserQuestion`:
+   - `Continue to <next phase>` (Recommended)
+   - `Pause here` — set `status: paused` (or track-specific equivalent) and exit; resume by re-invoking the conductor.
+   - `Re-run <this phase> with feedback` — pass free-text "Other" answer as additional context.
+   - Track-specific verdict gates (e.g., sales `pursue / no-go`, discovery `go / no-go / pivot`) when the phase produces a verdict.
+
+Never ask more than one `AskUserQuestion` per gate — batch options.
+
+## When a phase agent escalates
+
+Subagent returns "blocked — needs human input": surface the question to the user via a single `AskUserQuestion`, capture the answer, re-dispatch the same slash command with the answer as additional context. Do not answer on the user's behalf.
+
+## Constraints common to all conductors
+
+- Never do specialist work in the conductor's turn. Drafting an artifact = drifted; stop and dispatch the right subagent.
+- Never call `AskUserQuestion` from inside a subagent prompt — it fails silently.
+- Never write to the track's state directory directly during normal phase execution; the slash command + specialist own those files. (Track-specific exceptions documented in each conductor.)
+- Always update the state-file between phases — delegated to slash commands; conductor verifies.
+- Always use the same slug across all artifacts in one engagement.
+- Don't invent new sink locations. Use what `docs/sink.md` defines.

--- a/.claude/skills/discovery-sprint/SKILL.md
+++ b/.claude/skills/discovery-sprint/SKILL.md
@@ -8,7 +8,7 @@ argument-hint: [sprint-slug or one-line outcome]
 
 Conductor of Discovery Track defined in [`docs/discovery-track.md`](../../../docs/discovery-track.md). Job: **sequence** phases + **gate** between them — never do specialist work yourself. Each phase runs through `facilitator` subagent ([`.claude/agents/facilitator.md`](../../agents/facilitator.md)) which sequences consulted specialists.
 
-`AskUserQuestion` only works in main thread. Subagents cannot ask user. So all clarification happens in *your* turn — before and between phases.
+Shared rules (gating, escalation, constraints common to all conductors): [`../_shared/conductor-pattern.md`](../_shared/conductor-pattern.md).
 
 **Pre-workflow** entry. Output = `chosen-brief.md` feeding `/spec:idea`. Skip sprint if user has brief — recommend `/spec:start` + `/spec:idea` instead.
 
@@ -91,19 +91,12 @@ After Phase 5 with verdict `go`, dispatch `/discovery:handoff`. Facilitator writ
 - Confirm with user: chain into `/orchestrate` now or pause.
 - Set `discovery-state.md` `status: complete`.
 
-## Constraints
+## Constraints (discovery-sprint-specific)
 
-- **Never** do specialist work in your turn. Drafting Lean Canvas or storyboard = drifted — stop, dispatch facilitator.
-- **Never** call `AskUserQuestion` from inside subagent prompt. Fails.
-- **Never** ask more than one `AskUserQuestion` per gate. Batch options.
-- **Always** update `discovery-state.md` between phases (slash commands + facilitator do it; you verify).
-- **Never** write to `discovery/<slug>/` directly during normal phase execution — facilitator subagent owns those files.
-- **Never** open `specs/<feature>/` from inside this skill. Happens after handoff via `/spec:start`.
-- **Never** recommend sprint when user has brief. Send to `/orchestrate` instead.
+Generic conductor constraints + escalation pattern: [`../_shared/conductor-pattern.md`](../_shared/conductor-pattern.md). Specifics for this skill:
 
-## When a phase escalates
-
-Facilitator returns "blocked — needs human input" (e.g. user-researcher can't recruit participants) → surface question to user via `AskUserQuestion` in single call, capture answer, re-dispatch same slash command with answer as additional context.
+- **Never** open `specs/<feature>/` from inside this skill. That happens after handoff via `/spec:start`.
+- **Never** recommend a sprint when the user already has a brief — send them to `/orchestrate` instead.
 
 ## References
 

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -8,33 +8,16 @@ argument-hint: [feature-slug or one-line goal]
 
 You conductor of Specorator workflow defined in `docs/specorator.md`. Job: **sequence** stages, **gate** between them — never do stage work yourself. Each stage runs in its specialist subagent (`.claude/agents/`); you only persist state, surface choices, dispatch.
 
-`AskUserQuestion` only works in main thread. Subagents cannot ask user anything. So all clarification happen in *your* turn — before and between stages.
+Shared rules (gating, escalation, constraints common to all conductors): [`_shared/conductor-pattern.md`](../_shared/conductor-pattern.md).
 
 ## Read first
 
-Always start by reading these (contract you enforce):
+Contract you enforce:
 
-- `docs/specorator.md` — 11-stage workflow definition.
+- `docs/specorator.md` — 11-stage workflow definition + the canonical stage→subagent→slash-command→artifact table.
 - `memory/constitution.md` — principles every stage must obey.
 - `docs/quality-framework.md` — gate criteria.
 - Active `specs/<slug>/workflow-state.md` (if resuming).
-
-## The workflow you're driving
-
-| # | Stage | Subagent | Slash command | Artifact |
-|---|---|---|---|---|
-| 0 | Bootstrap | — | `/spec:start <slug> [AREA]` | `workflow-state.md` |
-| 1 | Idea | `analyst` | `/spec:idea` | `idea.md` |
-| 2 | Research | `analyst` | `/spec:research` | `research.md` |
-| 3 | Requirements | `pm` | `/spec:requirements` | `requirements.md` |
-| 4 | Design | `ux-designer` → `ui-designer` → `architect` | `/spec:design` | `design.md` |
-| 5 | Specification | `architect` | `/spec:specify` | `spec.md` |
-| 6 | Tasks | `planner` | `/spec:tasks` | `tasks.md` |
-| 7 | Implementation | `dev` | `/spec:implement [task-id]` | code + `implementation-log.md` |
-| 8 | Testing | `qa` | `/spec:test` | `test-plan.md`, `test-report.md` |
-| 9 | Review | `reviewer` | `/spec:review` | `review.md` |
-| 10 | Release | `release-manager` | `/spec:release` | `release-notes.md` |
-| 11 | Learning | `retrospective` | `/spec:retro` | `retrospective.md` |
 
 **Optional gates** between any two stages: `/spec:clarify` (interrogate active artifact) and `/spec:analyze` (cross-artifact consistency).
 
@@ -135,19 +118,11 @@ After `/spec:retro` completes, retro command itself sets `status: done` in front
 
 Then report 3-line summary to user with path to feature folder, count of artifacts produced, any ADRs filed during workflow.
 
-## Constraints
+## Constraints (orchestrate-specific)
 
-- **Never** do stage work in your own turn. If you find yourself reading source code, writing PRD, or editing implementation files, you've drifted — stop and dispatch right subagent.
-- **Never** call `AskUserQuestion` from inside subagent prompt. Will fail.
-- **Never** ask more than one `AskUserQuestion` per gate. Batch options into single question.
-- **Always** update `workflow-state.md` between stages (delegated to slash commands).
-- **Always** use same slug across all artifacts in one feature.
-- **Never** write to `specs/<slug>/` directly during normal stage execution — stage subagents own those files. **Exception:** Step 3.5 (depth-driven setup) the *one* place orchestrator owns artifact-content edits — writing Lean stub `idea.md`/`research.md` and marking depth-driven `skipped` statuses in `workflow-state.md`. After Step 3.5, return to subagent ownership for rest of workflow.
-- **Don't** invent new sink locations. Use what `docs/sink.md` defines.
+Generic conductor constraints + escalation pattern: [`_shared/conductor-pattern.md`](../_shared/conductor-pattern.md). Specifics for this skill:
 
-## When a stage agent escalates
-
-If subagent returns "blocked — needs human input" (e.g. analyst can't resolve ambiguity), surface its question to user via `AskUserQuestion` in single call, capture answer, then re-dispatch same slash command with answer as additional context. Don't try to answer on user's behalf.
+- **Never** write to `specs/<slug>/` directly during normal stage execution — stage subagents own those files. **Exception:** Step 3.5 (depth-driven setup) is the *one* place orchestrator owns artifact-content edits — writing Lean stub `idea.md`/`research.md` and marking depth-driven `skipped` statuses in `workflow-state.md`. After Step 3.5, return to subagent ownership.
 
 ## References
 

--- a/.claude/skills/portfolio-track/SKILL.md
+++ b/.claude/skills/portfolio-track/SKILL.md
@@ -8,7 +8,7 @@ argument-hint: [portfolio-slug or "list"]
 
 You are the conductor of the P5 Express portfolio management cadence defined in `docs/portfolio-track.md`. Your job is to **detect the right cycle, confirm with the user, and dispatch** — never to do the cycle work yourself. The `/portfolio:*` commands spawn the `portfolio-manager` subagent; you only read state, ask, and hand off.
 
-`AskUserQuestion` only works in the main thread. Do all clarification here, before dispatching.
+Shared rules (gating, escalation, constraints common to all conductors): [`../_shared/conductor-pattern.md`](../_shared/conductor-pattern.md).
 
 ## Read first
 

--- a/.claude/skills/project-run/SKILL.md
+++ b/.claude/skills/project-run/SKILL.md
@@ -2,7 +2,7 @@
 
 **Triggers:** "let's start a client project", "set up a service engagement", "I need project management for this work", "start a project for [client]", "manage this as a client engagement", "I have a client brief"
 
-Shared rules (gating, escalation, constraints common to all conductors): [`../_shared/conductor-pattern.md`](../_shared/conductor-pattern.md).
+`AskUserQuestion` works only in the main thread. Subagents cannot ask the user anything, so all clarification happens in this conductor turn before dispatching or between project phases.
 
 ---
 
@@ -77,6 +77,20 @@ Before each phase, read `projects/<slug>/project-state.md`:
 - If `phase: closed` → remind user about `/project:post`
 
 If no `project-state.md` exists: run Phase 0 + Phase 1.
+
+---
+
+## Constraints
+
+- Never do project-manager work in your own turn. Drafting the project description, registers, reports, closure, or post-project evaluation belongs to `/project:*` commands and the `project-manager` agent.
+- Never call `AskUserQuestion` from inside a subagent prompt.
+- Never ask more than one `AskUserQuestion` per gate. Batch choices into a single question.
+- Use the project-specific state model in `projects/<slug>/project-state.md`: `phase`, `initiation_status`, `closure_status`, and `last_updated`. Do not use generic `status: active | paused | blocked` transitions for this track.
+- Never write directly to `projects/<slug>/` during normal phase execution. The `/project:*` commands and `project-manager` own those files; this conductor reads state, asks the user, and dispatches.
+
+## When a project phase escalates
+
+If `project-manager` returns "blocked — needs human input", surface its question to the user via a single `AskUserQuestion`, capture the answer, and re-dispatch the same `/project:*` command with the answer as additional context. Do not answer on the user's behalf.
 
 ---
 

--- a/.claude/skills/project-run/SKILL.md
+++ b/.claude/skills/project-run/SKILL.md
@@ -2,6 +2,8 @@
 
 **Triggers:** "let's start a client project", "set up a service engagement", "I need project management for this work", "start a project for [client]", "manage this as a client engagement", "I have a client brief"
 
+Shared rules (gating, escalation, constraints common to all conductors): [`../_shared/conductor-pattern.md`](../_shared/conductor-pattern.md).
+
 ---
 
 ## What this skill does

--- a/.claude/skills/sales-cycle/SKILL.md
+++ b/.claude/skills/sales-cycle/SKILL.md
@@ -8,7 +8,7 @@ argument-hint: [deal-slug or client/project description]
 
 Conductor of Sales Cycle Track in `docs/sales-cycle.md`. Job: **sequence phases** + **gate between**. Never do phase work. Each phase runs in specialist subagent (`.claude/agents/`); you persist state, surface choices, dispatch.
 
-`AskUserQuestion` works only main thread. Subagents cannot ask user. All clarification happens *your* turn — before/between phases.
+Shared rules (gating, escalation, constraints common to all conductors): [`../_shared/conductor-pattern.md`](../_shared/conductor-pattern.md).
 
 ## Read first
 
@@ -103,19 +103,13 @@ Any phase, verdict `no-go`:
 
 No-go = successful outcome — prevented wasted engineering effort. Don't frame as failure.
 
-## Constraints
+## Constraints (sales-cycle-specific)
 
-- **Never** do phase work your own turn. Writing qualification scorecard or proposal section = drifted — stop, dispatch right subagent.
-- **Never** send document to external parties. Sending always human action.
-- **Never** advance Qualify → Scope without human-confirmed `pursue` verdict.
-- **Never** produce proposal quote below 80% confidence interval from `estimation.md`.
-- **Always** update `deal-state.md` between phases (delegated to slash commands).
-- **Always** use same slug across all artifacts in one deal.
-- **Don't** invent new sink locations. Use `docs/sink.md` definitions — deal artifacts live under `sales/<deal-slug>/`.
+Generic conductor constraints + escalation pattern: [`../_shared/conductor-pattern.md`](../_shared/conductor-pattern.md). Specifics for this skill:
 
-## When phase agent escalates
-
-Subagent returns blocked (e.g., key MEDDIC dimension can't be scored), surface its question to user via `AskUserQuestion` single call, capture answer, re-dispatch same slash command with answer as additional context. Don't answer on user's behalf.
+- **Never** send a document to external parties. Sending is always a human action.
+- **Never** advance Qualify → Scope without a human-confirmed `pursue` verdict.
+- **Never** produce a proposal quote below the 80% confidence interval from `estimation.md`.
 
 ## References
 

--- a/.claude/skills/stock-taking/SKILL.md
+++ b/.claude/skills/stock-taking/SKILL.md
@@ -8,7 +8,7 @@ argument-hint: [project-slug or one-line system description]
 
 You conduct Stock-taking Track defined in [`docs/stock-taking-track.md`](../../../docs/stock-taking-track.md). Job: **sequence** phases + **gate** between — never do auditor work yourself. Each phase runs through `legacy-auditor` subagent ([`.claude/agents/legacy-auditor.md`](../../agents/legacy-auditor.md)).
 
-`AskUserQuestion` only works in main thread. Subagents cannot ask user. All clarification happens in *your* turn — before + between phases.
+Shared rules (gating, escalation, constraints common to all conductors): [`../_shared/conductor-pattern.md`](../_shared/conductor-pattern.md).
 
 This **pre-workflow** entry. Output = `stock-taking-inventory.md` feeding `/discovery:start` or `/spec:idea`. Skip stock-taking when team starts from scratch with no existing system — recommend `/discovery:start` (blank page) or `/spec:idea` (clear brief) instead.
 
@@ -84,19 +84,12 @@ After Phase 3, dispatch `/stock:handoff`. `legacy-auditor` writes `stock-taking-
 - Confirm with user whether chain into `/discovery-sprint` or `/orchestrate` immediately or pause.
 - Set `stock-taking-state.md` `status: complete`.
 
-## Constraints
+## Constraints (stock-taking-specific)
 
-- **Never** do auditor work in your own turn. Writing process map or use-case catalog → drifted — stop, dispatch `legacy-auditor`.
-- **Never** call `AskUserQuestion` from inside subagent prompt. Fails.
-- **Never** ask more than one `AskUserQuestion` per gate. Batch options.
-- **Always** update `stock-taking-state.md` between phases (slash commands + `legacy-auditor` do it; you verify).
-- **Never** write to `stock-taking/<slug>/` directly during normal phase execution — `legacy-auditor` owns those files.
-- **Never** open `specs/<feature>/` or `discovery/<sprint>/` from inside this skill. Happens after handoff via `/spec:start` or `/discovery:start`.
-- **Never** recommend stock-taking when user confirms no existing system to inventory.
+Generic conductor constraints + escalation pattern: [`../_shared/conductor-pattern.md`](../_shared/conductor-pattern.md). Specifics for this skill:
 
-## When a phase is blocked
-
-`legacy-auditor` returns "blocked — needs human input" (e.g. source system access unavailable, key stakeholder unresponsive) → surface its question to user via `AskUserQuestion` single call, capture answer, re-dispatch same slash command with answer as additional context.
+- **Never** open `specs/<feature>/` or `discovery/<sprint>/` from inside this skill — that happens after handoff via `/spec:start` or `/discovery:start`.
+- **Never** recommend stock-taking when the user confirms no existing system to inventory.
 
 ## References
 


### PR DESCRIPTION
## Summary
- Extract gating, escalation, and conductor constraints into `.claude/skills/_shared/conductor-pattern.md`.
- `orchestrate`, `discovery-sprint`, `sales-cycle`, `stock-taking`, `project-run`, `portfolio-track` now link to it instead of inlining the boilerplate.
- Trim `orchestrate/SKILL.md`'s 11-stage table — duplicates `docs/specorator.md`; link instead.
- Trigger phrases (frontmatter + body) stay inline so harness auto-trigger logic is unchanged.

## Net savings
| File | Before | After |
|---|---|---|
| `orchestrate/SKILL.md` | 14049 | 12338 |
| `discovery-sprint/SKILL.md` | 7423 | 6844 |
| `sales-cycle/SKILL.md` | 7167 | 6674 |
| `stock-taking/SKILL.md` | 6988 | 6346 |
| `project-run/SKILL.md` | 4685 | 4829 (added link) |
| `portfolio-track/SKILL.md` | 4321 | 4368 (added link) |
| `_shared/conductor-pattern.md` | — | 3038 |

Six SKILL.md bodies: 44.6 KB → 41.4 KB (-7%). With the shared file: net 44.4 KB. Real win is one source of truth for the pattern, not raw bytes.

## Plan reference
Chunk 3 of `docs/superpowers/plans/2026-05-01-token-budget-cleanup.md`. Continuation prompt at `docs/superpowers/plans/2026-05-01-token-budget-cleanup-CONTINUATION.md`.

## Test plan
- [x] `npm run verify` green locally.
- [ ] Confirm conductor skills still auto-trigger from natural language (post-merge).
- [ ] Confirm `_shared/` is ignored by skill discovery (only `SKILL.md` files matter — verified in `scripts/lib/automation-registry.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)