### PR TITLE
docs: add V09 stakeholder sparring partner plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,8 @@ Full version in [`memory/constitution.md`](memory/constitution.md).
 | v0.5 | Planned | [Release workflow, branching strategy, GitHub Releases and Packages](specs/version-0-5-plan/tasks.md) |
 | v0.6 | Planned | [Productization, cross-tool adapters, live proof, hooks, and agentic security](specs/version-0-6-plan/tasks.md) |
 | v0.7 | Planned | [Automation quality hardening for agents and humans](https://github.com/Luis85/agentic-workflow/issues/98) |
+| v0.8 | Planned | [Content-driven product page generation](specs/version-0-8-plan/tasks.md) |
+| v0.9 | Planned | [Stakeholder sparring partner for roadmap communication](specs/version-0-9-plan/tasks.md) ([issue #125](https://github.com/Luis85/agentic-workflow/issues/125)) |
 
 ---
 

--- a/specs/version-0-9-plan/design.md
+++ b/specs/version-0-9-plan/design.md
@@ -1,0 +1,99 @@
+---
+id: DESIGN-V09-001
+title: Version 0.9 stakeholder sparring partner plan - Design
+stage: design
+feature: version-0-9-plan
+status: accepted
+owner: architect
+inputs:
+  - PRD-V09-001
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+# Design - Version 0.9 stakeholder sparring partner plan
+
+## User flow
+
+1. A roadmap owner maintains `roadmaps/<slug>/stakeholder-map.md` during `/roadmap:align`.
+2. Before a meeting or update, the owner runs the stakeholder sparring workflow for one stakeholder role or audience.
+3. The workflow reads the stakeholder map, roadmap board, delivery plan, communication log, decision log, linked lifecycle artifacts, and approved conversation summaries.
+4. The workflow creates a preparation output with:
+   - selected role or audience;
+   - evidence sources;
+   - current project-state framing;
+   - likely questions, objections, and decisions needed;
+   - open questions and assumptions;
+   - optional sparring prompt boundaries.
+5. If the user starts an interactive sparring session, the agent responds as the role while keeping simulation limits visible.
+6. The human decides what to send. Sent communication still goes through `/roadmap:communicate` and is logged separately.
+
+## Artifact model
+
+v0.9 should add one preparation artifact under each roadmap workspace:
+
+```text
+roadmaps/<slug>/
+|-- stakeholder-map.md
+|-- communication-log.md
+|-- decision-log.md
+|-- stakeholder-sparring.md   # preparation-only briefs and session summaries
+```
+
+`stakeholder-sparring.md` is append-oriented for preparation records. It must not replace `communication-log.md` or `decision-log.md`.
+
+Each entry should include:
+
+- date;
+- requested stakeholder role or named stakeholder;
+- purpose;
+- evidence sources;
+- current-state framing;
+- likely questions and concerns;
+- open questions;
+- assumptions;
+- simulation boundary;
+- follow-up actions.
+
+## Command and skill surface
+
+Preferred command shape:
+
+```text
+/roadmap:spar <slug> <stakeholder-or-audience>
+```
+
+The command may be backed by a `roadmap-sparring` skill so tools without slash-command support can use the same method.
+
+## Evidence rules
+
+- Required: `stakeholder-map.md`.
+- Recommended: `roadmap-board.md`, `delivery-plan.md`, `communication-log.md`, `decision-log.md`.
+- Optional: linked `specs/`, `projects/`, `quality/`, `portfolio/`, issue or PR summaries, and approved conversation-summary files.
+- Excluded by default: private raw transcripts, direct-message logs, and unapproved personal notes.
+
+## Safety and UX boundaries
+
+- Start every roleplay output with "Simulation boundary" and "Evidence basis".
+- Prefer stakeholder roles over named-person impersonation.
+- For named people, use only recorded role, requirements, feedback, and assumptions.
+- Keep commitments out of sparring output. Decisions remain human-owned and logged in `decision-log.md`.
+- Treat low-evidence claims as questions to ask, not facts to state.
+
+## Affected surfaces
+
+| Surface | Change |
+|---|---|
+| `docs/roadmap-management-track.md` | Add sparring phase/command, artifact rules, quality gate, and safety boundaries. |
+| `.claude/agents/roadmap-manager.md` | Teach the roadmap manager how to run sparring and when to escalate. |
+| `.claude/skills/roadmap-management/SKILL.md` | Add the conversational entry path for stakeholder sparring. |
+| `templates/` | Add `stakeholder-sparring-template.md` or extend roadmap templates. |
+| `scripts/` | Add or extend roadmap validation for sparring artifact structure where practical. |
+| `README.md` and command inventory | Document `/roadmap:spar` when implementation lands. |
+
+## Quality gate
+
+- [x] Uses the existing Roadmap Management Track as the owning context.
+- [x] Separates preparation-only output from real communication and decisions.
+- [x] Names evidence, privacy, and simulation boundaries.
+- [x] Keeps v0.9 implementation surfaces bounded.

--- a/specs/version-0-9-plan/idea.md
+++ b/specs/version-0-9-plan/idea.md
@@ -1,0 +1,54 @@
+---
+id: IDEA-V09-001
+title: Version 0.9 stakeholder sparring partner plan
+stage: idea
+feature: version-0-9-plan
+status: accepted
+owner: analyst
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+# Idea - Version 0.9 stakeholder sparring partner plan
+
+## Problem
+
+The Roadmap Management Track already captures stakeholders, decision owners, alignment risks, planned communications, and roadmap decisions. That creates a useful baseline, but it still leaves a gap before a human presents project state: maintainers must manually infer how each stakeholder might react, which questions they may ask, which open concerns matter to them, and how to frame the current state for their role.
+
+Before v1.0, Specorator should make stakeholder alignment more actionable without replacing real stakeholder conversations. A roadmap agent should be able to act as a constrained sparring partner for a named stakeholder role, grounded in the stakeholder map, past communication evidence, unresolved questions, requirements, decisions, and current project or roadmap state.
+
+## Target users
+
+- Roadmap owners preparing stakeholder updates.
+- Project managers rehearsing decision meetings.
+- Product leads checking whether a status narrative fits an audience.
+- Delivery teams anticipating objections, role-specific questions, and requirement trade-offs.
+- Reviewers checking that generated stakeholder advice stays evidence-backed and does not impersonate a real person without limits.
+
+## Desired outcome
+
+v0.9 should add a stakeholder sparring workflow that:
+
+- reads `roadmaps/<slug>/stakeholder-map.md` as the baseline source for roles, needs, stance, cadence, and alignment risks;
+- uses communication logs, decision logs, open questions, linked requirements, and current roadmap/project/spec state as evidence;
+- drafts likely questions, concerns, objections, and role-specific framing advice;
+- can run a bounded sparring session where the agent answers as a stakeholder role while labeling assumptions and evidence;
+- logs generated preparation outputs without rewriting historical stakeholder records;
+- keeps humans responsible for final messaging and real stakeholder commitments.
+
+## Constraints
+
+- The feature must not claim to know a stakeholder's private intent beyond recorded evidence.
+- It must distinguish role-based simulation from real stakeholder feedback.
+- It must preserve append-only communication and decision logs.
+- It must avoid committing sensitive raw conversations unless the project has explicitly approved that source material.
+- It should extend the Roadmap Management Track rather than create a separate stakeholder management system.
+- It must land before v1.0 as a bounded workflow addition, not a conversational memory platform.
+
+## Open questions
+
+- Should generated sparring outputs live in a new artifact such as `stakeholder-briefs.md`, a new `sparring-log.md`, or planned entries in `communication-log.md`?
+- Which past-conversation sources are acceptable by default: committed logs only, imported transcript summaries, issue comments, PR comments, meeting notes, or all approved evidence?
+- Should the first implementation be a slash command, a reusable skill, a script that assembles evidence, or a combination?
+- How should the workflow handle a named person versus a generic stakeholder role?
+- What labels are required when the agent is role-playing versus summarizing evidence?

--- a/specs/version-0-9-plan/requirements.md
+++ b/specs/version-0-9-plan/requirements.md
@@ -1,0 +1,141 @@
+---
+id: PRD-V09-001
+title: Version 0.9 stakeholder sparring partner plan
+stage: requirements
+feature: version-0-9-plan
+status: accepted
+owner: pm
+inputs:
+  - IDEA-V09-001
+  - RESEARCH-V09-001
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+# PRD - Version 0.9 stakeholder sparring partner plan
+
+## Summary
+
+Plan v0.9 as a Roadmap Management Track extension that lets a roadmap agent act as a bounded stakeholder sparring partner. The workflow uses the stakeholder map as the baseline, consumes recorded evidence and open questions, and helps humans rehearse role-specific questions, concerns, and presentation framing before stakeholder communication.
+
+## Goals
+
+- Convert stakeholder maps into practical meeting and communication preparation.
+- Support role-specific sparring based on evidence, requirements, decisions, and current state.
+- Make open questions and likely stakeholder objections visible before presenting project state.
+- Preserve clear boundaries between simulated perspective, evidence, assumptions, and real feedback.
+- Keep generated preparation artifacts traceable and reviewable.
+
+## Non-goals
+
+- No replacement for actual stakeholder interviews, approvals, or decisions.
+- No claim to infer private beliefs, motives, or unrecorded commitments.
+- No CRM, relationship-history database, or persistent personal profiling system.
+- No automatic sending of stakeholder communications.
+- No ingestion of private raw transcripts by default.
+
+## Functional requirements (EARS)
+
+### REQ-V09-001 - Use stakeholder map as baseline
+
+- **Pattern:** ubiquitous
+- **Statement:** The stakeholder sparring workflow shall use `roadmaps/<slug>/stakeholder-map.md` as the baseline for stakeholder roles, needs, stance, cadence, decision ownership, and alignment risks.
+- **Acceptance:** Running the workflow without a stakeholder map fails or asks for the missing baseline instead of inventing stakeholder roles.
+- **Priority:** must
+- **Satisfies:** IDEA-V09-001, RESEARCH-V09-001
+
+### REQ-V09-002 - Collect approved evidence
+
+- **Pattern:** ubiquitous
+- **Statement:** The stakeholder sparring workflow shall collect evidence from approved roadmap, project, spec, decision, communication, and conversation-summary artifacts.
+- **Acceptance:** The output lists the evidence sources used and distinguishes committed artifacts from optional human-supplied summaries.
+- **Priority:** must
+- **Satisfies:** RESEARCH-V09-001
+
+### REQ-V09-003 - Generate role-specific questions and concerns
+
+- **Pattern:** event-driven
+- **Statement:** When a user selects a stakeholder role, the workflow shall generate likely questions, concerns, objections, and decision needs for that role.
+- **Acceptance:** Generated questions cite stakeholder-map fields or evidence artifacts where practical and label unsupported inferences as assumptions.
+- **Priority:** must
+- **Satisfies:** IDEA-V09-001
+
+### REQ-V09-004 - Prepare audience-specific project-state framing
+
+- **Pattern:** event-driven
+- **Statement:** When a user asks how to present current state to a stakeholder role, the workflow shall draft role-specific framing guidance based on current roadmap, delivery, requirement, and open-question state.
+- **Acceptance:** The guidance states what to emphasize, what to avoid overclaiming, what decisions are needed, and which open questions should be surfaced.
+- **Priority:** must
+- **Satisfies:** IDEA-V09-001
+
+### REQ-V09-005 - Support bounded sparring sessions
+
+- **Pattern:** event-driven
+- **Statement:** When a user requests a sparring session, the agent shall answer as the selected stakeholder role within explicit simulation boundaries.
+- **Acceptance:** The session labels the selected role, evidence basis, assumptions, and simulation limits before role-based responses begin.
+- **Priority:** should
+- **Satisfies:** IDEA-V09-001
+
+### REQ-V09-006 - Preserve real-feedback boundaries
+
+- **Pattern:** unwanted behavior
+- **Statement:** The workflow shall not record generated sparring responses as actual stakeholder feedback, decisions, or commitments.
+- **Acceptance:** Generated preparation outputs are stored separately from sent communications and decisions, or clearly marked as preparation-only if referenced elsewhere.
+- **Priority:** must
+- **Satisfies:** RESEARCH-V09-001, RISK-V09-001
+
+### REQ-V09-007 - Handle named people safely
+
+- **Pattern:** unwanted behavior
+- **Statement:** When the selected stakeholder is a named person, the workflow shall constrain responses to the recorded role, known requirements, documented feedback, and explicit assumptions.
+- **Acceptance:** Output avoids unsupported personal claims and includes a reminder that the simulation is not a substitute for asking the stakeholder.
+- **Priority:** must
+- **Satisfies:** IDEA-V09-001, RESEARCH-V09-001
+
+### REQ-V09-008 - Track open questions
+
+- **Pattern:** ubiquitous
+- **Statement:** The workflow shall surface open questions relevant to the selected stakeholder role from roadmap, project, spec, and preparation artifacts.
+- **Acceptance:** Open questions are grouped by decision needed, risk, requirement clarification, or communication gap.
+- **Priority:** must
+- **Satisfies:** IDEA-V09-001
+
+### REQ-V09-009 - Add maintainable workflow guidance
+
+- **Pattern:** event-driven
+- **Statement:** When stakeholder sparring is introduced, roadmap docs, agent guidance, and command or skill documentation shall explain how to run it and how to review outputs.
+- **Acceptance:** A roadmap owner can identify required inputs, output locations, evidence rules, and quality gates without reading implementation code.
+- **Priority:** must
+- **Satisfies:** RESEARCH-V09-001
+
+### REQ-V09-010 - Verify artifact contracts
+
+- **Pattern:** ubiquitous
+- **Statement:** The repository shall provide deterministic validation or documented targeted checks for stakeholder sparring artifacts.
+- **Acceptance:** Verification catches missing evidence-source sections, missing simulation labels, or malformed preparation artifact frontmatter where practical.
+- **Priority:** should
+- **Satisfies:** IDEA-V09-001, RESEARCH-V09-001
+
+## Non-functional requirements
+
+| ID | Category | Requirement | Target |
+|---|---|---|---|
+| NFR-V09-001 | traceability | Sparring outputs must cite their source artifacts. | Every preparation artifact lists evidence sources and assumptions. |
+| NFR-V09-002 | privacy | Raw conversation ingestion must be opt-in and documented. | Default workflow consumes committed logs and approved summaries only. |
+| NFR-V09-003 | usability | A roadmap owner can run the preparation flow from an existing stakeholder map. | One command or skill path produces a useful first brief. |
+| NFR-V09-004 | safety | Simulated roleplay must stay visibly bounded. | Output labels simulation, evidence, assumptions, and real-feedback limits. |
+| NFR-V09-005 | maintainability | The feature must extend roadmap artifacts without creating a competing stakeholder system. | Docs describe sparring as preparation for roadmap communication. |
+
+## Success metrics
+
+- A roadmap owner can generate a stakeholder-specific preparation brief from a valid roadmap workspace.
+- The brief includes likely questions, role-specific framing, relevant open questions, evidence sources, and assumptions.
+- Generated sparring output cannot be confused with sent communication or real stakeholder decisions.
+- The roadmap-manager guidance explains when to use sparring and when to escalate to a real stakeholder conversation.
+- Local verification or targeted checks cover the preparation artifact contract.
+
+## Quality gate
+
+- [x] Functional requirements use EARS and stable IDs.
+- [x] Acceptance criteria are testable.
+- [x] Non-goals prevent the feature from becoming a CRM, transcript store, or substitute for real stakeholder approval.

--- a/specs/version-0-9-plan/research.md
+++ b/specs/version-0-9-plan/research.md
@@ -1,0 +1,68 @@
+---
+id: RESEARCH-V09-001
+title: Version 0.9 stakeholder sparring partner plan - Research
+stage: research
+feature: version-0-9-plan
+status: accepted
+owner: analyst
+inputs:
+  - IDEA-V09-001
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+# Research - Version 0.9 stakeholder sparring partner plan
+
+## Context reviewed
+
+- `docs/roadmap-management-track.md` defines `stakeholder-map.md`, `communication-log.md`, and `decision-log.md` as the roadmap alignment and communication source of truth.
+- `docs/specorator.md` positions roadmap management as an optional companion track that reads feature/project evidence and may recommend lifecycle work.
+- `README.md` roadmap reserves pre-v1.0 releases for workflow hardening and productization.
+- The constitution requires plain language, traceability, quality gates, and human ownership of intent, priorities, and acceptance.
+
+## Alternatives considered
+
+### Alternative A - Add a stakeholder sparring workflow to Roadmap Management
+
+Extend `/roadmap:communicate` or add a new roadmap command/skill that assembles stakeholder evidence and produces a role-specific sparring brief or session prompt.
+
+**Pros:** Reuses the existing stakeholder map and roadmap communication artifacts. Keeps the capability close to the user need. Fits pre-v1.0 workflow hardening.
+
+**Cons:** Requires careful boundaries so simulated stakeholder responses are not mistaken for real stakeholder feedback.
+
+### Alternative B - Add a separate stakeholder intelligence track
+
+Create a new track for stakeholder profiles, conversation history, presentation prep, and influence mapping.
+
+**Pros:** More room for a rich stakeholder management model.
+
+**Cons:** Too large before v1.0, duplicates roadmap responsibilities, and risks making stakeholder records feel like a CRM.
+
+### Alternative C - Add only a generic prompt template
+
+Document a prompt that asks an agent to impersonate a stakeholder using manually pasted context.
+
+**Pros:** Fast and lightweight.
+
+**Cons:** Weak traceability, no durable source model, no quality gate, and easy to misuse with unevidenced assumptions.
+
+## Recommendation
+
+Choose Alternative A. v0.9 should implement stakeholder sparring as a bounded Roadmap Management Track extension. The feature should create a durable preparation artifact, define a strict evidence model, and require visible labels for simulated perspective, assumptions, open questions, and real stakeholder feedback.
+
+## Risks
+
+| ID | Risk | Severity | Mitigation |
+|---|---|---|---|
+| RISK-V09-001 | Simulated responses are mistaken for actual stakeholder commitments. | High | Require explicit labels and keep generated sparring outputs separate from sent communication and decision logs. |
+| RISK-V09-002 | The agent invents personal motives or private views. | High | Ground output in role, recorded evidence, and declared assumptions only. |
+| RISK-V09-003 | Raw past conversations introduce privacy or confidentiality problems. | Medium | Default to committed logs and approved summaries; document raw transcript handling as opt-in. |
+| RISK-V09-004 | The workflow duplicates roadmap communication outputs. | Medium | Treat sparring as preparation; sent communications remain in `communication-log.md`. |
+| RISK-V09-005 | The first version becomes too broad. | Medium | Limit v0.9 to one roadmap-oriented command or skill, one artifact contract, and deterministic checks where practical. |
+
+## Inputs for requirements
+
+- The source baseline is `stakeholder-map.md`.
+- Evidence may include `communication-log.md`, `decision-log.md`, linked specs, project state, roadmap board, delivery plan, and approved conversation summaries.
+- The output should support both asynchronous briefs and interactive sparring.
+- The feature must preserve human approval for messages and commitments.

--- a/specs/version-0-9-plan/spec.md
+++ b/specs/version-0-9-plan/spec.md
@@ -1,0 +1,59 @@
+---
+id: SPECDOC-V09-001
+title: Version 0.9 stakeholder sparring partner plan - Specification
+stage: specification
+feature: version-0-9-plan
+status: accepted
+owner: architect
+inputs:
+  - DESIGN-V09-001
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+# Specification - Version 0.9 stakeholder sparring partner plan
+
+### SPEC-V09-001 - Roadmap sparring command
+
+- **Satisfies:** REQ-V09-001, REQ-V09-003, REQ-V09-004, REQ-V09-005, NFR-V09-003
+- **Behavior:** A roadmap sparring command or skill accepts a roadmap slug and stakeholder role or audience, then creates role-specific preparation grounded in the roadmap workspace.
+- **Acceptance:** The workflow refuses to proceed without `stakeholder-map.md` and names the selected stakeholder role before generating preparation output.
+
+### SPEC-V09-002 - Evidence collector
+
+- **Satisfies:** REQ-V09-002, REQ-V09-008, NFR-V09-001, NFR-V09-002
+- **Behavior:** The workflow collects approved evidence from roadmap artifacts, linked lifecycle artifacts, and optional approved summaries.
+- **Acceptance:** Every generated preparation entry lists evidence sources and separates assumptions from sourced facts.
+
+### SPEC-V09-003 - Stakeholder sparring artifact
+
+- **Satisfies:** REQ-V09-006, REQ-V09-010, NFR-V09-004, NFR-V09-005
+- **Behavior:** `roadmaps/<slug>/stakeholder-sparring.md` stores preparation-only entries with simulation labels, evidence sources, likely questions, open questions, assumptions, and follow-up actions.
+- **Acceptance:** Generated sparring entries are not appended to `communication-log.md` or `decision-log.md` as real feedback or decisions.
+
+### SPEC-V09-004 - Named-stakeholder guardrails
+
+- **Satisfies:** REQ-V09-007, NFR-V09-002, NFR-V09-004
+- **Behavior:** For named stakeholders, the workflow constrains output to recorded role, documented requirements, known feedback, and explicit assumptions.
+- **Acceptance:** Output avoids unsupported personal claims and includes a reminder to confirm material points with the stakeholder.
+
+### SPEC-V09-005 - Roadmap guidance updates
+
+- **Satisfies:** REQ-V09-009, NFR-V09-005
+- **Behavior:** Roadmap docs, agent prompts, skill guidance, and command inventories describe how stakeholder sparring fits between `/roadmap:align` and `/roadmap:communicate`.
+- **Acceptance:** A reader can tell that sparring is preparation-only and that sent updates still use `/roadmap:communicate`.
+
+## Test scenarios
+
+| ID | Requirement | Scenario | Expected result |
+|---|---|---|---|
+| TEST-V09-001 | REQ-V09-001 | The user runs sparring for a roadmap without `stakeholder-map.md`. | The workflow stops and asks for the baseline map. |
+| TEST-V09-002 | REQ-V09-002 | The user runs sparring on a complete roadmap workspace. | The preparation entry lists roadmap and linked evidence sources. |
+| TEST-V09-003 | REQ-V09-003 | The user selects a delivery-team stakeholder role. | Output includes likely questions, concerns, objections, and decision needs for that role. |
+| TEST-V09-004 | REQ-V09-004 | The user asks how to present current project state to leadership. | Output emphasizes outcomes, trade-offs, risk, investment, decisions needed, and overclaiming warnings. |
+| TEST-V09-005 | REQ-V09-005 | The user starts an interactive sparring session. | The agent states role, evidence basis, assumptions, and simulation boundary before responding. |
+| TEST-V09-006 | REQ-V09-006 | A sparring session generates strong objections. | They are stored only as preparation or assumptions, not as real stakeholder feedback. |
+| TEST-V09-007 | REQ-V09-007 | The user selects a named stakeholder. | Output avoids unsupported personal claims and asks the human to confirm important points. |
+| TEST-V09-008 | REQ-V09-008 | There are unresolved roadmap and spec questions. | Output groups relevant questions by decision, risk, clarification, or communication gap. |
+| TEST-V09-009 | REQ-V09-009 | A roadmap owner reads the docs. | Required inputs, command path, output location, and review rules are clear. |
+| TEST-V09-010 | REQ-V09-010 | A malformed sparring artifact is checked. | Targeted validation reports missing labels, evidence sources, or frontmatter where practical. |

--- a/specs/version-0-9-plan/tasks.md
+++ b/specs/version-0-9-plan/tasks.md
@@ -1,0 +1,78 @@
+---
+id: TASKS-V09-001
+title: Version 0.9 stakeholder sparring partner plan - Tasks
+stage: tasks
+feature: version-0-9-plan
+status: complete
+owner: planner
+inputs:
+  - PRD-V09-001
+  - SPECDOC-V09-001
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+# Tasks - Version 0.9 stakeholder sparring partner plan
+
+### T-V09-001 - Define sparring artifact contract
+
+- **Description:** Add `stakeholder-sparring.md` template and artifact rules, including evidence sources, assumptions, simulation boundary, likely questions, open questions, and follow-up actions.
+- **Satisfies:** REQ-V09-006, REQ-V09-010, NFR-V09-001, NFR-V09-004, SPEC-V09-003
+- **Owner:** architect
+- **Estimate:** M
+
+### T-V09-002 - Add roadmap sparring command or skill
+
+- **Description:** Add `/roadmap:spar <slug> <stakeholder-or-audience>` or equivalent skill path that reads the roadmap workspace and produces preparation output.
+- **Satisfies:** REQ-V09-001, REQ-V09-003, REQ-V09-004, REQ-V09-005, NFR-V09-003, SPEC-V09-001
+- **Depends on:** T-V09-001
+- **Owner:** dev
+- **Estimate:** L
+
+### T-V09-003 - Implement evidence collection rules
+
+- **Description:** Reuse or extend roadmap evidence collection so sparring can cite stakeholder map, roadmap board, delivery plan, communication log, decision log, linked lifecycle artifacts, and approved summaries.
+- **Satisfies:** REQ-V09-002, REQ-V09-008, NFR-V09-001, NFR-V09-002, SPEC-V09-002
+- **Depends on:** T-V09-001
+- **Owner:** dev
+- **Estimate:** M
+
+### T-V09-004 - Add named-stakeholder guardrails
+
+- **Description:** Document and enforce output rules for named stakeholders, including role-based constraints, assumption labels, and reminders to confirm material points directly.
+- **Satisfies:** REQ-V09-007, NFR-V09-002, NFR-V09-004, SPEC-V09-004
+- **Depends on:** T-V09-002
+- **Owner:** reviewer
+- **Estimate:** M
+
+### T-V09-005 - Update roadmap manager guidance
+
+- **Description:** Update `docs/roadmap-management-track.md`, roadmap-manager agent guidance, roadmap-management skill guidance, and command inventories to show how sparring fits between alignment and communication.
+- **Satisfies:** REQ-V09-009, NFR-V09-005, SPEC-V09-005
+- **Depends on:** T-V09-001, T-V09-002
+- **Owner:** pm
+- **Estimate:** M
+
+### T-V09-006 - Add validation for sparring artifacts
+
+- **Description:** Add deterministic checks or targeted documented validation for sparring frontmatter, evidence-source sections, simulation labels, and preparation-only boundaries.
+- **Satisfies:** REQ-V09-010, NFR-V09-001, NFR-V09-004, SPEC-V09-003
+- **Depends on:** T-V09-001
+- **Owner:** qa
+- **Estimate:** M
+
+### T-V09-007 - Add examples and review scenarios
+
+- **Description:** Add a minimal example roadmap sparring entry and test/review scenarios that cover leadership, delivery-team, customer/client, and sales/support audiences.
+- **Satisfies:** REQ-V09-003, REQ-V09-004, REQ-V09-005, REQ-V09-008, SPEC-V09-001, SPEC-V09-002
+- **Depends on:** T-V09-002, T-V09-003, T-V09-004
+- **Owner:** qa
+- **Estimate:** M
+
+### T-V09-008 - Verify v0.9 release readiness
+
+- **Description:** Run targeted roadmap, command-inventory, agent-artifact, link, traceability, and full `npm run verify` checks; document remaining risks and skipped checks.
+- **Satisfies:** REQ-V09-001, REQ-V09-002, REQ-V09-003, REQ-V09-004, REQ-V09-005, REQ-V09-006, REQ-V09-007, REQ-V09-008, REQ-V09-009, REQ-V09-010, SPEC-V09-001, SPEC-V09-002, SPEC-V09-003, SPEC-V09-004, SPEC-V09-005
+- **Depends on:** T-V09-005, T-V09-006, T-V09-007
+- **Owner:** qa
+- **Estimate:** S

--- a/specs/version-0-9-plan/workflow-state.md
+++ b/specs/version-0-9-plan/workflow-state.md
@@ -1,0 +1,59 @@
+---
+feature: version-0-9-plan
+area: V09
+current_stage: implementation
+status: active
+last_updated: 2026-05-01
+last_agent: planner
+artifacts:
+  idea.md: complete
+  research.md: complete
+  requirements.md: complete
+  design.md: complete
+  spec.md: complete
+  tasks.md: complete
+  implementation-log.md: pending
+  test-plan.md: pending
+  test-report.md: pending
+  review.md: pending
+  traceability.md: pending
+  release-notes.md: pending
+  retrospective.md: pending
+---
+
+# Workflow state - version-0-9-plan
+
+## Stage progress
+
+| Stage | Artifact | Status |
+|---|---|---|
+| 1. Idea | `idea.md` | complete |
+| 2. Research | `research.md` | complete |
+| 3. Requirements | `requirements.md` | complete |
+| 4. Design | `design.md` | complete |
+| 5. Specification | `spec.md` | complete |
+| 6. Tasks | `tasks.md` | complete |
+| 7. Implementation | `implementation-log.md` + code/docs | pending |
+| 8. Testing | `test-plan.md`, `test-report.md` | pending |
+| 9. Review | `review.md`, `traceability.md` | pending |
+| 10. Release | `release-notes.md` | pending |
+| 11. Learning | `retrospective.md` | pending |
+
+## Skips
+
+- None.
+
+## Blocks
+
+- None.
+
+## Hand-off notes
+
+- Tracker issue: https://github.com/Luis85/agentic-workflow/issues/125
+- 2026-05-01 (codex): Planned v0.9 through Stage 6 from the request for a stakeholder sparring partner before v1.0. Recommended implementation order is define the `stakeholder-sparring.md` artifact contract, add the roadmap sparring command or skill, extend evidence collection, add named-stakeholder guardrails, update roadmap docs/agents/skills/command inventories, add validation and examples, then run full verification.
+
+## Open clarifications
+
+- [ ] CLAR-V09-001 - Confirm whether the preparation artifact should be named `stakeholder-sparring.md` or split into per-stakeholder files.
+- [ ] CLAR-V09-002 - Confirm whether the first implementation should expose `/roadmap:spar`, a skill-only flow, or both.
+- [ ] CLAR-V09-003 - Confirm which past-conversation sources are acceptable by default beyond committed communication and decision logs.


### PR DESCRIPTION
## Summary

- Add `specs/version-0-9-plan/` lifecycle artifacts for the stakeholder sparring partner feature idea.
- Plan v0.9 as a Roadmap Management Track extension that uses `stakeholder-map.md` as the baseline and produces preparation-only stakeholder sparring outputs.
- Update the README roadmap with v0.8 and v0.9 rows, linking v0.9 to tracker issue #125.

## Verification

- `npm ci`
- `npm run check:traceability`
- `npm run verify`

## Linked Issue

Refs #125

## Notes

The plan keeps three clarifications open in `workflow-state.md`: artifact sharding/naming, command vs skill exposure, and which past-conversation sources are acceptable by default.