### PR TITLE
chore: ignore scheduled task lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ node_modules/
 # Claude Code local state
 .claude/settings.local.json
 .claude/.session/
+.claude/scheduled_tasks.lock
 
 # Operational-bot scratch (FAILED-* recovery files, etc.)
 .claude/cache/


### PR DESCRIPTION
## Summary

- Ignore `.claude/scheduled_tasks.lock` as Claude Code local state.

## Verification

- `git check-ignore -v .claude/scheduled_tasks.lock --no-index`
- `npm ci`
- `npm run verify`

'typedoc' was missing before `npm ci` in the fresh worktree; verification passed after dependency installation.