### PR TITLE
docs(release): add release readiness guide

### DIFF
--- a/.claude/agents/release-manager.md
+++ b/.claude/agents/release-manager.md
@@ -1,6 +1,6 @@
 ---
 name: release-manager
-description: Use for stage 10 (Release). Produces release-notes.md, prepares the changelog, verifies rollback plan and observability are in place, and coordinates communication. Does not perform deploys without explicit human authorisation.
+description: Use for stage 10 (Release). Produces release-notes.md, creates a release readiness guide when needed, prepares the changelog, verifies rollback plan and observability are in place, and coordinates communication. Does not perform deploys without explicit human authorisation.
 tools: [Read, Edit, Write, Bash]
 model: sonnet
 color: yellow
@@ -22,6 +22,7 @@ You prepare `specs/<feature>/release-notes.md` and the project's CHANGELOG entry
 - `docs/steering/product.md` — voice and tone for release notes.
 - `.claude/skills/product-page/SKILL.md` — product page upkeep expectations.
 - `.claude/skills/quality-metrics/SKILL.md` — deterministic release-readiness KPI snapshot guidance.
+- `docs/release-readiness-guide.md` and `templates/release-readiness-guide-template.md` — optional go/no-go packet for releases with multiple product perspectives, stakeholders, or conditions.
 
 ## Procedure
 
@@ -30,24 +31,26 @@ The work splits into a **prepare** phase (no irreversible side effects) and a **
 ### Prepare
 
 1. Verify the review is Approved and conditions are met.
-2. Write `release-notes.md` from the template, audience-appropriate (users / stakeholders, not engineers).
-3. Update the project CHANGELOG following its existing convention (e.g., Keep a Changelog).
-4. Verify each `Rollback plan` field in `release-notes.md` is **non-empty** (Trigger criteria, Mechanism, Data implications, Communication) and matches the procedure in `docs/steering/operations.md`. Empty placeholders or "TBD" are blockers.
-5. Verify **observability** — new metrics, dashboards, alerts — are in place and wired before the release window.
-6. Run `npm run quality:metrics -- --feature <slug> --compare` when a saved baseline is expected; otherwise run `npm run quality:metrics -- --feature <slug>` and disclose that no trend baseline was available. Treat blockers, QA gaps, negative trend deltas, or release-stage evidence gaps as release readiness risks.
-7. Draft the **communication plan** (internal + external if applicable).
-8. Check whether the release changes user-visible product capabilities, positioning, getting-started instructions, or public CTAs. If yes, invoke or hand off to the `product-page` skill so `sites/index.html` is updated in the same PR.
-9. Surface any **known limitations** clearly — don't bury them.
+2. Decide whether `specs/<feature>/release-readiness-guide.md` is needed. Create it from the template when the release has user-visible impact, multiple stakeholder approvals, operational risk, compliance/privacy/security implications, commercial impact, or release conditions.
+3. When the guide is used, fill product value, user experience, customer/stakeholder, engineering, security/privacy/compliance, operations/SRE, support/success, data/analytics, commercial/finance, and communications readiness. Every `condition` or `gap` needs owner, due date, and release impact.
+4. Write `release-notes.md` from the template, audience-appropriate (users / stakeholders, not engineers), using the readiness guide as input when present.
+5. Update the project CHANGELOG following its existing convention (e.g., Keep a Changelog).
+6. Verify each `Rollback plan` field in `release-notes.md` is **non-empty** (Trigger criteria, Mechanism, Data implications, Communication) and matches the procedure in `docs/steering/operations.md`. Empty placeholders or "TBD" are blockers.
+7. Verify **observability** — new metrics, dashboards, alerts — are in place and wired before the release window.
+8. Run `npm run quality:metrics -- --feature <slug> --compare` when a saved baseline is expected; otherwise run `npm run quality:metrics -- --feature <slug>` and disclose that no trend baseline was available. Treat blockers, QA gaps, negative trend deltas, or release-stage evidence gaps as release readiness risks.
+9. Draft the **communication plan** (internal + external if applicable).
+10. Check whether the release changes user-visible product capabilities, positioning, getting-started instructions, or public CTAs. If yes, invoke or hand off to the `product-page` skill so `sites/index.html` is updated in the same PR.
+11. Surface any **known limitations** clearly — don't bury them.
 
 ### Authorisation gate
 
-10. **Stop and ask the human** for explicit authorisation to proceed. Authorisation in the past does not authorise the present; ask for *this specific release*. Do not tag, push, publish, or deploy until you have it.
+12. **Stop and ask the human** for explicit authorisation to proceed. Authorisation in the past does not authorise the present; ask for *this specific release*. Do not tag, push, publish, or deploy until you have it.
 
 ### Publish
 
-11. Only after explicit authorisation: tag the release / cut the artifact per `docs/steering/operations.md`. Announce each irreversible side effect (tag push, registry publish, deploy trigger) before running it. Each side effect is covered by step 10's authorisation only if announced as part of that ask; any new action requires a fresh ask.
-12. If a publish step fails, **stop**. Do not attempt cleanup (tag deletion, registry yank, deploy rollback) without explicit authorisation for that specific cleanup action.
-13. Update `workflow-state.md` after both phases: mark `release-notes.md` as `complete`; append a hand-off note to `retrospective` with the published version / tag and quality KPI/trend summary.
+13. Only after explicit authorisation: tag the release / cut the artifact per `docs/steering/operations.md`. Announce each irreversible side effect (tag push, registry publish, deploy trigger) before running it. Each side effect is covered by step 12's authorisation only if announced as part of that ask; any new action requires a fresh ask.
+14. If a publish step fails, **stop**. Do not attempt cleanup (tag deletion, registry yank, deploy rollback) without explicit authorisation for that specific cleanup action.
+15. Update `workflow-state.md` after both phases: mark `release-notes.md` as `complete`; append a hand-off note to `retrospective` with the published version / tag, readiness guide verdict if used, and quality KPI/trend summary.
 
 ## Quality bar
 

--- a/.claude/commands/spec/release.md
+++ b/.claude/commands/spec/release.md
@@ -1,5 +1,5 @@
 ---
-description: Stage 10 — Release. Invokes release-manager to produce release-notes.md, verify rollback and observability, and prepare the release. Does not deploy without explicit user authorisation.
+description: Stage 10 — Release. Invokes release-manager to prepare release readiness, produce release-notes.md, verify rollback and observability, and prepare the release. Does not deploy without explicit user authorisation.
 argument-hint: [feature-slug]
 allowed-tools: [Agent, Read, Edit, Write, Bash]
 model: sonnet
@@ -11,6 +11,7 @@ Run **stage 10 — Release**. Irreversible actions (tagging, publishing, deployi
 
 1. Resolve slug; verify `review.md` verdict is `Approved` or `Approved with conditions` (per `templates/review-template.md` verdict checkboxes); if `Approved with conditions`, confirm every listed condition has been resolved before continuing. A `Blocked` verdict escalates back to the owning stage.
 2. **Spawn the `release-manager` subagent** for the **prepare** phase. It:
+   - creates `specs/<slug>/release-readiness-guide.md` when the release has multiple product perspectives, stakeholder approvals, operational risk, compliance/privacy/security implications, commercial impact, or explicit conditions,
    - writes `specs/<slug>/release-notes.md` (audience: users / stakeholders),
    - updates the project CHANGELOG,
    - verifies the rollback plan is documented and rehearsable,

--- a/.claude/skills/orchestrate/PHASES.md
+++ b/.claude/skills/orchestrate/PHASES.md
@@ -62,6 +62,7 @@ Slash commands defined in `.claude/commands/spec/`, own agent invocation. Do **n
 ### Stage 10 — Release (`/spec:release`)
 - **Initial:** dispatch as-is.
 - **Pre-flight check:** confirm `review.md` verdict is `Approved` or `Approved with conditions` (per verdict checkboxes in `templates/review-template.md`). If verdict `Blocked`, return to Stage 9 (Review) — do not dispatch `/spec:release`.
+- **Readiness guide:** if the release has multiple stakeholder approvals, user-visible or commercial impact, operational risk, security/privacy/compliance implications, or conditions, expect the release manager to create `release-readiness-guide.md` from `templates/release-readiness-guide-template.md` before finalizing `release-notes.md`.
 
 ### Stage 11 — Learning (`/spec:retro`)
 - **Mandatory:** runs even on clean ships (per `docs/specorator.md` §3.11).

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Specorator is built as a layered set of plain-Markdown artifacts and prompt-driv
 4. **Or drive manually** — run the slash commands yourself in stage order. State lives in `specs/<feature>/workflow-state.md`.
 5. **Gate every stage** — review the artifact, push back on anything wrong, sign off, then move on. No stage is skipped; quality gates are non-negotiable.
 6. **Implement against the spec** — the dev agent only writes code that matches `tasks.md`. The qa agent verifies every EARS requirement has a test. The reviewer audits traceability.
-7. **Ship and learn** — `/spec:release` produces release notes; `/spec:retro` is mandatory and feeds improvements back into the template.
+7. **Ship and learn** — `/spec:release` prepares release readiness, produces release notes, and gates irreversible actions on explicit authorization; `/spec:retro` is mandatory and feeds improvements back into the template.
 
 The workflow has source-led onboarding plus two core delivery tracks:
 
@@ -326,6 +326,15 @@ This files a permanent Architecture Decision Record (ADR) in `docs/adr/`.
 
 The Quality Assurance Track creates ISO 9001-aligned plans, checklists, readiness reviews, and corrective actions. It supports readiness and evidence gathering; it does not grant certification.
 
+### I want to prepare a production release decision
+
+```
+cp templates/release-readiness-guide-template.md specs/my-feature/release-readiness-guide.md
+/spec:release my-feature
+```
+
+Use the Release Readiness Guide when an increment needs product, stakeholder, operational, support, security, privacy, compliance, commercial, or communications evidence before production. It feeds `release-notes.md` and the explicit authorization step; it does not deploy by itself.
+
 ### I want to manage a product or project roadmap
 
 ```
@@ -480,6 +489,7 @@ The artifact format (Markdown files in `specs/<feature>/`) and the ID scheme (`R
 | [`docs/discovery-track.md`](docs/discovery-track.md) | Discovery Track detail and phase-by-phase guide |
 | [`docs/roadmap-management-track.md`](docs/roadmap-management-track.md) | Product/project roadmap management, stakeholder alignment, and team communication workflow |
 | [`docs/quality-assurance-track.md`](docs/quality-assurance-track.md) | ISO 9001-aligned quality assurance review workflow |
+| [`docs/release-readiness-guide.md`](docs/release-readiness-guide.md) | Stage 10 go/no-go guide for product perspectives and stakeholder requirements |
 | [`docs/workflow-overview.md`](docs/workflow-overview.md) | One-page visual + cheat sheet + slash command list |
 | [`docs/quality-framework.md`](docs/quality-framework.md) | Quality dimensions, gates, and Definition of Done per stage |
 | [`docs/ears-notation.md`](docs/ears-notation.md) | How to write requirements in EARS format |

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,7 +33,7 @@ Learning-oriented. You follow them step by step; you reach a known end state.
 
 Task-oriented recipes — *how do I do X?* You arrive knowing the goal; you leave with the steps.
 
-Seventeen recipes are available. Four common starting points:
+Eighteen recipes are available. Four common starting points:
 
 - [How to fork and personalize the template](./how-to/fork-and-personalize.md) — first-clone setup.
 - [How to run the verify gate](./how-to/run-verify-gate.md) — `npm run verify` green before pushing.
@@ -58,6 +58,7 @@ Look-it-up, normative. Authoritative; not narrative.
 - [`project-scaffolding-track.md`](./project-scaffolding-track.md) — source-led onboarding track for turning collected docs into starter artifacts.
 - [`roadmap-management-track.md`](./roadmap-management-track.md) — product/project roadmap management, stakeholder alignment, and team communication workflow.
 - [`quality-assurance-track.md`](./quality-assurance-track.md) — ISO 9001-aligned quality assurance review workflow.
+- [`release-readiness-guide.md`](./release-readiness-guide.md) — Stage 10 go/no-go guide for product perspectives and stakeholder requirements.
 - [`workflow-overview.md`](./workflow-overview.md) — one-page cheat sheet + slash-command list.
 - [`ears-notation.md`](./ears-notation.md) — the requirement-syntax catalogue.
 - [`traceability.md`](./traceability.md) — the ID scheme and the requirement → spec → task → code → test chain.

--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -14,7 +14,7 @@ For the full doc map by Diátaxis quadrant — Tutorials / How-to / Reference / 
 
 ## Available recipes
 
-All recipes below are runnable and link out for the *why*. Each ends with a `Last desk-checked` footer naming the commit it was last validated against — read it as a freshness stamp. Seventeen recipes in five intent groups:
+All recipes below are runnable and link out for the *why*. Each ends with a `Last desk-checked` footer naming the commit it was last validated against — read it as a freshness stamp. Eighteen recipes in five intent groups:
 
 **Onboarding and configuration**
 
@@ -37,6 +37,7 @@ All recipes below are runnable and link out for the *why*. Each ends with a `Las
 **Quality and release**
 
 - [How to trace a failing test back to a requirement](./trace-failing-test.md) — walk the chain to find which layer the defect lives in.
+- [How to prepare release readiness](./prepare-release-readiness.md) — collect product perspectives, stakeholder requirements, conditions, and go/no-go evidence.
 - [How to run a retrospective](./run-retrospective.md) — Stage 11, mandatory before marking a feature complete.
 - [How to authorize a destructive release action](./authorize-destructive-release.md) — scope, approve, log, execute.
 

--- a/docs/how-to/prepare-release-readiness.md
+++ b/docs/how-to/prepare-release-readiness.md
@@ -1,0 +1,43 @@
+---
+title: "How to prepare release readiness"
+folder: "docs/how-to"
+description: "Prepare a go/no-go guide for bringing a completed increment to production."
+entry_point: false
+---
+# How to prepare release readiness
+
+**Goal:** Produce a meeting-ready `release-readiness-guide.md` that supports a go/no-go decision for production.
+
+**When to use:** Use this before `/spec:release` authorization when a release has stakeholder approvals, operational risk, customer impact, or conditions that should not be buried in release notes.
+
+**Prerequisites:**
+
+- The feature has passed `/spec:review` with `Approved` or `Approved with conditions`.
+- You know the feature slug under `specs/<feature>/`.
+- You can name the product, stakeholder, operational, and support approvers.
+
+## Steps
+
+1. Copy [`templates/release-readiness-guide-template.md`](../../templates/release-readiness-guide-template.md) to `specs/<feature>/release-readiness-guide.md`.
+2. Fill `## Decision` with the target release, decision owner, required approvers, and decision deadline.
+3. Fill `## Increment summary` from `requirements.md`, `review.md`, and the planned release notes.
+4. Work through `## Readiness by perspective`; set each row to `satisfied`, `condition`, `gap`, or `not-applicable`.
+5. Add stakeholder-specific approval needs under `## Stakeholder requirements`.
+6. Move every `condition` or `gap` into `## Conditions and blockers` with severity, owner, due date, and release impact.
+7. Record the go/no-go decision in `## Go / no-go record`.
+8. Copy user-facing impact, limitations, verification, rollback, observability, and communication decisions into `release-notes.md`.
+9. If evidence gaps need a formal execution-health review, run `/quality:start <slug> specs/<feature>` and continue through `/quality:review`.
+10. Ask the human for explicit authorization before any irreversible production action.
+
+## Verify
+
+`release-readiness-guide.md` has no `gap` or `blocked` item without an owner, due date, and release impact, and `release-notes.md` reflects the final user-facing impact, rollback, observability, and communication decisions.
+
+## Related
+
+- [Release readiness guide](../release-readiness-guide.md)
+- [Quality Assurance Track](../quality-assurance-track.md)
+- [How to authorize a destructive release action](./authorize-destructive-release.md)
+- [`/spec:release`](../../.claude/commands/spec/release.md)
+
+Last desk-checked: 2026-05-01 on branch `docs/release-readiness-guide`.

--- a/docs/quality-framework.md
+++ b/docs/quality-framework.md
@@ -134,6 +134,8 @@ The KPI snapshot is evidence for a quality review, not a replacement for the sta
 ### Release
 - [ ] Summary of changes written.
 - [ ] User-visible impact stated.
+- [ ] Release readiness guide created when the increment has multi-stakeholder, operational, security/privacy/compliance, commercial, or communication risk; otherwise explicitly marked not used.
+- [ ] Product perspectives and stakeholder requirements have an owner, evidence, status, and accepted go/no-go decision when the guide is used.
 - [ ] Known limitations disclosed.
 - [ ] Verification steps documented.
 - [ ] Public product page updated or explicitly marked unaffected when user-visible capabilities, positioning, onboarding, or CTAs change.

--- a/docs/release-readiness-guide.md
+++ b/docs/release-readiness-guide.md
@@ -1,0 +1,70 @@
+---
+title: "Release readiness guide"
+folder: "docs"
+description: "Reference for using a release readiness guide to align product perspectives and stakeholder requirements before production."
+entry_point: false
+---
+# Release readiness guide
+
+The release readiness guide is an optional Stage 10 companion artifact for releases that need an explicit go/no-go packet before production. It helps the release manager gather product, user, stakeholder, engineering, security, operations, support, data, commercial, and communication evidence in one place.
+
+Use it when `release-notes.md` alone would hide important approval conditions or stakeholder requirements. The guide feeds the final release notes, quality review, authorization request, and retrospective; it does not replace those artifacts.
+
+## Artifact
+
+Create `specs/<feature>/release-readiness-guide.md` from [`templates/release-readiness-guide-template.md`](../templates/release-readiness-guide-template.md) when any of these are true:
+
+- the release changes user-visible behavior, pricing, customer commitments, data handling, or operations,
+- more than one stakeholder group must approve the production decision,
+- the release has conditions, waivers, or known gaps that need an explicit owner,
+- the team needs a meeting-ready go/no-go record.
+
+The artifact is lazy: small internal releases may skip it and document readiness directly in `release-notes.md`.
+
+## Relationship to Stage 10
+
+`/spec:release` still produces `release-notes.md` as the canonical Stage 10 output. The release readiness guide is supporting evidence that the release manager may create during the prepare phase before asking for production authorization.
+
+The guide should answer four questions:
+
+1. What increment is going to production, and why now?
+2. Which product perspectives and stakeholder requirements must be satisfied?
+3. What evidence proves each requirement is satisfied, conditional, not applicable, or a gap?
+4. Who owns the go/no-go decision and any release conditions?
+
+## Readiness perspectives
+
+The template uses these default perspectives:
+
+| Perspective | Release question |
+|---|---|
+| Product value | Does the increment deliver the promised user, customer, or business outcome? |
+| User experience | Are core journeys, edge states, accessibility, and docs ready? |
+| Customer / stakeholder | Have affected stakeholders accepted impact, timing, and tradeoffs? |
+| Engineering | Are implementation, tests, traceability, and limitations acceptable? |
+| Security / privacy / compliance | Are security, privacy, regulatory, and data obligations satisfied? |
+| Operations / SRE | Are deploy, rollback, observability, incident response, and on-call coverage ready? |
+| Support / success | Can support explain, triage, and escalate user issues? |
+| Data / analytics | Can the team measure adoption, health, and unintended outcomes? |
+| Commercial / finance | Are pricing, packaging, contract, billing, and revenue effects handled? |
+| Communications | Are internal and external messages approved and scheduled? |
+
+Teams may mark a perspective `not-applicable`, but should not silently delete one unless the project has an equivalent local release checklist.
+
+## Verdicts
+
+Use the same readiness language as the Quality Assurance Track where possible:
+
+- `ready` — all required perspectives are satisfied.
+- `ready-with-conditions` — the release may proceed only if named conditions have owners, due dates, and accepted impact.
+- `not-ready` — one or more gaps stop the release.
+- `blocked` — the team cannot make the decision because required evidence or authority is missing.
+
+## Handoff
+
+After the guide is complete:
+
+- copy user-facing impact, limitations, verification, rollback, observability, and communication items into `release-notes.md`,
+- link any execution-health gaps to a `/quality:*` review when evidence needs deeper audit,
+- move unresolved learning or process gaps into `retrospective.md`,
+- ask for explicit authorization before irreversible actions such as tagging, publishing, or deploying.

--- a/docs/sink.md
+++ b/docs/sink.md
@@ -16,6 +16,7 @@ Where every markdown artifact in this kit lives, who owns it, and how it evolves
 │   ├── workflow-overview.md                 # one-page cheat sheet
 │   ├── quality-framework.md                 # quality dimensions, gates, DoD
 │   ├── quality-metrics.md                   # deterministic KPI interpretation guide
+│   ├── release-readiness-guide.md           # Stage 10 go/no-go guide across product perspectives and stakeholders
 │   ├── traceability.md                      # ID scheme REQ → SPEC → T → code → TEST
 │   ├── ears-notation.md                     # EARS reference
 │   ├── sink.md                              # this file
@@ -127,6 +128,7 @@ Where every markdown artifact in this kit lives, who owns it, and how it evolves
 │       ├── test-report.md                   # stage 8 (qa)
 │       ├── review.md                        # stage 9 (reviewer)
 │       ├── traceability.md                  # stage 9 (reviewer) — RTM
+│       ├── release-readiness-guide.md       # stage 10 optional companion (release-manager, LAZY)
 │       ├── release-notes.md                 # stage 10 (release-manager)
 │       └── retrospective.md                 # stage 11 (retrospective)
 ├── portfolio/                               # one folder per portfolio (opt-in, P5 Express track)
@@ -227,6 +229,7 @@ The root `README.md` is the public repository entry point and is exempt from thi
 | `discovery/<sprint>/chosen-brief.md` | `facilitator` (Handoff) | One per surviving concept; mandatory input to `/spec:idea` |
 | `specs/<slug>/workflow-state.md` | `/spec:start`, then `/spec:*` commands on transition | State machine; orchestrator amends final fields |
 | `specs/<slug>/<artifact>.md` | The stage's owning agent (per `docs/specorator.md` §3) | Each stage writes once; later stages **never rewrite** upstream artifacts |
+| `specs/<slug>/release-readiness-guide.md` | `release-manager` (Stage 10, optional) | Lazy go/no-go packet; feeds `release-notes.md`, release authorization, quality review, and retrospective follow-up |
 | `portfolio/<slug>/portfolio-state.md` | `/portfolio:start`, then `/portfolio:*` commands on each cycle | Cycle state machine; portfolio-manager-owned |
 | `portfolio/<slug>/portfolio-definition.md` | `/portfolio:start` (created), Z cycle Z2 (status updates) | Ongoing; X and Y cycles read but do not rewrite |
 | `portfolio/<slug>/portfolio-roadmap.md` | X cycle (X2, X3) | Updated in place each X run; previous exec summaries appended |
@@ -343,6 +346,12 @@ A sprint may emit **0, 1, or N** chosen briefs. Zero is a valid outcome (no-go);
 When a team needs an ISO 9001-aligned readiness check, the Quality Assurance Track creates one `quality/<quality-review-slug>/` folder. It can review a project, portfolio, release, supplier, or active feature. It produces a QA plan, evidence-backed checklist, readiness report, and improvement plan.
 
 The track supports internal readiness and audit preparation, but it does not grant certification or replace an accredited auditor. See [`docs/quality-assurance-track.md`](quality-assurance-track.md) for the methodology.
+
+## Release readiness companion artifact
+
+When a completed increment needs an explicit production go/no-go decision, Stage 10 may create `specs/<feature>/release-readiness-guide.md` from `templates/release-readiness-guide-template.md`. The guide collects product value, user experience, stakeholder, engineering, security/privacy/compliance, operations, support, data, commercial, and communication readiness evidence.
+
+This is a lazy companion artifact, not a new lifecycle stage. `release-notes.md` remains the canonical Stage 10 output, while the readiness guide records conditions, blockers, approvers, and the go/no-go rationale that feed the notes, authorization request, optional Quality Assurance Track review, and retrospective.
 
 ## Portfolio Track sub-tree
 

--- a/docs/specorator.md
+++ b/docs/specorator.md
@@ -111,7 +111,7 @@ Each stage **consumes inputs**, **produces a defined artifact**, **is owned by o
 | 7 | Implementation | Dev | code + `implementation-log.md` | [`templates/implementation-log-template.md`](../templates/implementation-log-template.md) |
 | 8 | Testing | QA | `test-plan.md`, `test-report.md` | [`templates/test-plan-template.md`](../templates/test-plan-template.md), [`templates/test-report-template.md`](../templates/test-report-template.md) |
 | 9 | Review | Reviewer | `review.md`, `traceability.md` (RTM) | [`templates/review-template.md`](../templates/review-template.md), [`templates/traceability-template.md`](../templates/traceability-template.md) |
-| 10 | Release | Release Manager | `release-notes.md` | [`templates/release-notes-template.md`](../templates/release-notes-template.md) |
+| 10 | Release | Release Manager | `release-notes.md` (+ optional `release-readiness-guide.md`) | [`templates/release-notes-template.md`](../templates/release-notes-template.md), [`templates/release-readiness-guide-template.md`](../templates/release-readiness-guide-template.md) |
 | 11 | Learning | Retrospective | `retrospective.md` | [`templates/retrospective-template.md`](../templates/retrospective-template.md) |
 
 Quality gates per stage are summarised below; the full Definition of Done lives in [`docs/quality-framework.md`](quality-framework.md).
@@ -158,7 +158,8 @@ Quality gates per stage are summarised below; the full Definition of Done lives 
 
 ### 3.10 Release
 - **Goal:** Prepare the feature for delivery.
-- **Quality gate:** Changelog written. Rollback plan documented. Observability hooks in place. Known limitations disclosed.
+- **Optional companion artifact:** Use `release-readiness-guide.md` when the increment needs an explicit go/no-go packet across product value, user experience, stakeholder approval, engineering, security/privacy/compliance, operations, support, data, commercial, or communications perspectives.
+- **Quality gate:** Changelog written. Release readiness conditions and approvals summarized or the guide is explicitly marked not used. Rollback plan documented. Observability hooks in place. Known limitations disclosed.
 
 ### 3.11 Learning (Retrospective)
 - **Goal:** Capture insights for continuous improvement.
@@ -349,6 +350,8 @@ This track supports internal readiness and audit preparation. It does not grant 
 | Improve | `/quality:improve <slug>` | `improvement-plan.md` |
 
 Use it before release, during project health reviews, before client handoff, for supplier assurance, or after retrospectives reveal recurring quality-system gaps. The full method lives in [`docs/quality-assurance-track.md`](quality-assurance-track.md).
+
+For release-specific go/no-go preparation, use the Stage 10 [`release-readiness-guide.md`](release-readiness-guide.md) reference and [`templates/release-readiness-guide-template.md`](../templates/release-readiness-guide-template.md) to collect product perspectives, stakeholder requirements, release conditions, and approvals before irreversible production actions.
 
 ---
 

--- a/docs/workflow-overview.md
+++ b/docs/workflow-overview.md
@@ -76,7 +76,7 @@ flowchart LR
     implementation -->|matches spec + lint| testing
     testing -->|every REQ tested| review
     review -->|RTM complete + no criticals| release
-    release -->|changelog + rollback| retro
+    release -->|readiness + changelog + rollback| retro
 ```
 
 Optional gates `/spec:clarify` and `/spec:analyze` may be inserted between any two stages.
@@ -84,6 +84,8 @@ Optional gates `/spec:clarify` and `/spec:analyze` may be inserted between any t
 Use `/scaffold:start <slug> <source>` before the other tracks when a fresh template install should be seeded from existing folders or Markdown files.
 
 Use `/quality:start <slug> [scope]` when a project, portfolio, feature, release, supplier, or internal process needs an ISO 9001-aligned quality assurance review.
+
+Use [`release-readiness-guide.md`](release-readiness-guide.md) during `/spec:release` when production readiness depends on multiple product perspectives, stakeholder requirements, approvals, or conditions.
 
 Use `/roadmap:start <slug>` when product direction, project delivery confidence, stakeholder expectations, and team communication need a shared roadmap artifact.
 
@@ -176,5 +178,5 @@ Plus body sections (Skips, Blocks, Hand-off notes, Open clarifications). Canonic
 | Implementation | Spec-matched, lint+types+units green, log updated |
 | Testing | Every EARS clause tested, failures reproducible |
 | Review | RTM complete, no critical findings, requirements satisfied |
-| Release | Changelog + rollback + observability in place |
+| Release | Readiness conditions, changelog, rollback, and observability in place |
 | Retro | Three buckets (worked / didn't / actions) with owners |

--- a/sites/index.html
+++ b/sites/index.html
@@ -157,7 +157,7 @@
             </header>
             <h3>Reviewer &amp; Release</h3>
             <p class="team-agents"><code>reviewer</code> &middot; <code>release-manager</code> &middot; <code>retrospective</code></p>
-            <p class="team-desc">Closes the loop. Reviews the diff with traceability, drafts release notes, and runs the mandatory retro.</p>
+            <p class="team-desc">Closes the loop. Reviews the diff with traceability, prepares release readiness, drafts release notes, and runs the mandatory retro.</p>
           </article>
         </div>
         <p class="team-footnote">Plus an <code>orchestrator</code> that routes between them and an <code>sre</code> for post-release operability. <a href="#roster">See the full 30-agent roster &rarr;</a></p>
@@ -211,6 +211,10 @@
           <article class="card">
             <h3>Quality gates</h3>
             <p>Each stage has acceptance criteria so defects are caught where they are cheapest to fix.</p>
+          </article>
+          <article class="card">
+            <h3>Release readiness</h3>
+            <p>Stage 10 can collect product perspectives, stakeholder approvals, conditions, and go/no-go evidence before production.</p>
           </article>
           <article class="card">
             <h3>Traceability</h3>
@@ -537,7 +541,7 @@
           </article>
           <article class="repo-item">
             <code>templates/</code>
-            <p>Reusable Markdown artifact shapes for requirements, design, tasks, tests, and release.</p>
+            <p>Reusable Markdown artifact shapes for requirements, design, tasks, tests, release readiness, and release.</p>
           </article>
           <article class="repo-item">
             <code>specs/</code>

--- a/templates/README.md
+++ b/templates/README.md
@@ -21,6 +21,7 @@ Blank artifacts for each workflow stage. Copy into `specs/<feature>/<artifact>.m
 | [`test-plan-template.md`](test-plan-template.md) | 8 — Testing (plan) | `test-plan.md` |
 | [`test-report-template.md`](test-report-template.md) | 8 — Testing (report) | `test-report.md` |
 | [`review-template.md`](review-template.md) | 9 — Review | `review.md` |
+| [`release-readiness-guide-template.md`](release-readiness-guide-template.md) | 10 — Release (optional companion) | `release-readiness-guide.md` |
 | [`release-notes-template.md`](release-notes-template.md) | 10 — Release | `release-notes.md` |
 | [`retrospective-template.md`](retrospective-template.md) | 11 — Learning | `retrospective.md` |
 | [`adr-template.md`](adr-template.md) | (any) — Decision | `docs/adr/NNNN-<title>.md` |

--- a/templates/release-notes-template.md
+++ b/templates/release-notes-template.md
@@ -46,6 +46,12 @@ One paragraph for end users / stakeholders. What's new and why they care.
 - Any action required (e.g., update client, re-authenticate, migrate data).
 - Breaking changes (call out clearly).
 
+## Readiness summary
+
+- Release readiness guide: `release-readiness-guide.md` / not used.
+- Go/no-go verdict:
+- Required conditions or approvals:
+
 ## Known limitations
 
 - …
@@ -83,6 +89,7 @@ How to confirm the release is healthy in production.
 
 - [ ] Summary written for the audience (users / stakeholders, not engineers).
 - [ ] User-visible impact stated.
+- [ ] Readiness conditions and approvals summarized, or guide marked not used.
 - [ ] Known limitations disclosed.
 - [ ] Verification steps documented.
 - [ ] Rollback plan documented.

--- a/templates/release-readiness-guide-template.md
+++ b/templates/release-readiness-guide-template.md
@@ -1,0 +1,75 @@
+---
+id: RELREADY-<AREA>-NNN
+title: <Feature name> — Release readiness guide
+stage: release
+feature: <feature-slug>
+status: draft        # draft | ready | ready-with-conditions | not-ready | blocked
+owner: release-manager
+inputs:
+  - REVIEW-<AREA>-NNN
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+---
+
+# Release readiness guide — <Feature name>
+
+## Decision
+
+| Field | Value |
+|---|---|
+| Target release | <version, tag, or date> |
+| Decision needed | Go / go with conditions / no-go |
+| Decision owner | <name or role> |
+| Required approvers | <product, engineering, operations, support, security, legal, customer, etc.> |
+| Decision deadline | <date/time/timezone> |
+
+## Increment summary
+
+- What is shipping:
+- Why now:
+- Primary users or customers affected:
+- Business or mission outcome:
+- Linked release notes:
+
+## Readiness by perspective
+
+| Perspective | Requirement or concern | Evidence | Owner | Status | Open condition |
+|---|---|---|---|---|---|
+| Product value | Does the increment solve the promised problem and match success metrics? | `requirements.md`, roadmap, stakeholder decision | <owner> | open | ... |
+| User experience | Are key journeys, docs, accessibility, and supportable states ready? | `design.md`, test report, docs links | <owner> | open | ... |
+| Customer / stakeholder | Have affected stakeholders accepted impact, timing, and tradeoffs? | stakeholder notes, project status, approval | <owner> | open | ... |
+| Engineering | Are implementation, tests, traceability, and known limitations acceptable? | `implementation-log.md`, `test-report.md`, `traceability.md` | <owner> | open | ... |
+| Security / privacy / compliance | Are security, privacy, regulatory, and data-handling obligations satisfied? | review findings, threat model, DPA, policy links | <owner> | open | ... |
+| Operations / SRE | Are deploy, rollback, observability, incident response, and on-call coverage ready? | runbook, dashboards, alerts, rollback plan | <owner> | open | ... |
+| Support / success | Can support explain, triage, and escalate user issues? | support notes, FAQ, escalation path | <owner> | open | ... |
+| Data / analytics | Can the team measure adoption, health, and unintended outcomes? | metrics, dashboard, event schema | <owner> | open | ... |
+| Commercial / finance | Are pricing, packaging, contracts, billing, or revenue effects handled? | pricing decision, billing check, contract notes | <owner> | open | ... |
+| Communications | Are internal and external messages approved and scheduled? | announcement draft, approver, channel plan | <owner> | open | ... |
+
+Statuses: `satisfied`, `condition`, `gap`, `not-applicable`.
+
+## Stakeholder requirements
+
+| Stakeholder | Requirement | Evidence needed | Approver | Status | Notes |
+|---|---|---|---|---|---|
+| <role/team/customer> | <requirement> | <artifact or link> | <name> | open | ... |
+
+## Conditions and blockers
+
+| ID | Type | Description | Severity | Owner | Due | Release impact |
+|---|---|---|---|---|---|---|
+| COND-<AREA>-001 | condition | ... | S2 | <owner> | YYYY-MM-DD | Must be met before deploy |
+
+## Go / no-go record
+
+- [ ] Go — all required perspectives are satisfied.
+- [ ] Go with conditions — listed conditions have owners, due dates, and accepted release impact.
+- [ ] No-go — release stops until blockers are corrected.
+
+Decision rationale:
+
+## Follow-up
+
+- Items that must move into `release-notes.md`:
+- Items that must move into `retrospective.md`:
+- Items that require a new requirement, ADR, issue, or roadmap decision:


### PR DESCRIPTION
## Summary
- Add a Stage 10 release readiness guide reference and reusable template for product perspectives, stakeholder requirements, conditions, and go/no-go records.
- Wire the guide into `/spec:release`, the `release-manager` prompt, orchestrate phase notes, release notes template, quality gate docs, sink catalog, docs hub, README, how-to index, and product page.
- Add a how-to recipe for preparing release readiness before explicit production authorization.

## Verification
- `npm run verify:changed`
- `npm run verify`

## Linked artifact
- Template/workflow improvement requested by the user: release readiness guidance for bringing an increment to production.

## Known limitations
- This adds a manual/lazy guide artifact, not a new command or deterministic readiness checker.
- No production release actions were performed.