### PR TITLE
docs: codify PR title CI checks

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -20,6 +20,7 @@ One-line pointers into `.claude/memory/`. Read first. See [`README.md`](./README
 - **Docs ride with their PR** — user-visible change updates the doc in the same PR. See [`feedback_docs_with_pr.md`](./feedback_docs_with_pr.md).
 - **Parallel PRs: merge not rebase** — preserves reviewer line anchors. See [`feedback_parallel_pr_conflicts.md`](./feedback_parallel_pr_conflicts.md).
 - **Autonomous merge** — only after green review + green CI + clean mergeable. See [`feedback_autonomous_merge.md`](./feedback_autonomous_merge.md).
+- **PR title CI** — title metadata must use the allowed Conventional Commit type before handoff. See [`feedback_pr_title_ci.md`](./feedback_pr_title_ci.md).
 - **Memory edits are docs-only** — no changeset, no bundling with code. See [`feedback_memory_edits.md`](./feedback_memory_edits.md).
 - **Token-budget review** — quarterly or pre-release: `/token-review` runs the audit + emits a per-area cleanup plan. See [`token-budget-review`](../skills/token-budget-review/SKILL.md).
 

--- a/.claude/memory/feedback_pr_title_ci.md
+++ b/.claude/memory/feedback_pr_title_ci.md
@@ -1,0 +1,21 @@
+# PR title CI — validate metadata before handoff
+
+## Rule
+
+Before opening or handing off a PR, choose a title that passes the `pr-title` GitHub Actions workflow.
+
+Allowed Conventional Commit types are:
+
+`feat`, `fix`, `chore`, `docs`, `refactor`, `perf`, `test`, `build`, `ci`, and `revert`.
+
+Use `docs:` for planning artifacts, specs, workflow notes, roadmap rows, and other documentation-only work. Do not use unsupported descriptive types such as `plan:`, `release:`, or `workflow:` unless the PR also updates the CI allowlist as its explicit concern.
+
+## Why
+
+Local `verify` checks repository content. It cannot validate PR metadata that only exists after the PR is opened. A bad title creates a CI failure even when the branch content is correct, which wastes a review cycle and makes the PR look less ready than it is.
+
+## How to apply
+
+- Pick the PR title before creating the PR, not after CI fails.
+- If the PR-title check fails, update the PR title directly. Do not push a no-op or unrelated commit just to rerun CI.
+- When changing the allowed type list, update `.github/workflows/pr-title.yml`, [`docs/ci-automation.md`](../../docs/ci-automation.md), and [`docs/branching.md`](../../docs/branching.md) together.

--- a/.codex/workflows/pr-delivery.md
+++ b/.codex/workflows/pr-delivery.md
@@ -18,8 +18,8 @@ This repo treats Codex as an autonomous topic-branch contributor. When a human a
 6. Run the relevant verification gate before pushing. In this template, use `npm run verify` as the final gate. During iteration, `npm run check:fast`, `npm run check:content`, `npm run check:workflow`, and `npm run verify:changed` are available for narrower feedback; use `npm run verify:json` when structured diagnostics are needed. If a downstream project has no single `verify` command for the change type, run targeted checks and say exactly what passed.
 7. Commit with an imperative message that references relevant IDs or issue paths.
 8. Push the topic branch to `origin`.
-9. Open a pull request against the integration branch.
-10. Re-check PR mergeability or CI status when available.
+9. Open a pull request against the integration branch with a Conventional Commits title that matches the CI allowlist. Allowed title types are `feat`, `fix`, `chore`, `docs`, `refactor`, `perf`, `test`, `build`, `ci`, and `revert`; scopes are optional. Do not invent descriptive types such as `plan:` or `release:`. For planning artifacts and documentation-only specs, use `docs: ...`.
+10. After opening the PR, re-check PR mergeability and CI status. If the PR-title check fails, update the PR title immediately instead of pushing a code-only retry.
 11. Final response must include the PR URL, branch, commit, verification result, and any remaining risk.
 12. Ask the human what they want next: review, merge, follow-up changes, or cleanup after merge.
 
@@ -40,5 +40,7 @@ Every Codex-opened PR should include:
 - Verification commands or checks run.
 - Linked requirement, task, ADR, issue, or local issue file when one exists.
 - Known limitations or skipped checks.
+
+The PR title is part of the delivery contract, not cosmetic metadata. Validate it against [`docs/ci-automation.md`](../../docs/ci-automation.md#pr-title-rules) before opening the PR so CI does not fail on a metadata-only error after local `verify` has passed.
 
 Codex should not stop at "pushed a branch" when GitHub access is available. The expected endpoint is an open PR and an explicit next-step prompt for the human.

--- a/docs/branching.md
+++ b/docs/branching.md
@@ -37,6 +37,16 @@ The default `.claude/settings.json` shipped with this template denies pushes to 
 
 These prefixes match the allowlist in `.claude/settings.json` and the regexes in the operational bots' branch‑name idempotency checks. Adding a new prefix means updating both.
 
+## Pull request titles
+
+PR titles are validated by [`.github/workflows/pr-title.yml`](../.github/workflows/pr-title.yml), so every PR title must use a Conventional Commits type from the CI allowlist:
+
+`feat`, `fix`, `chore`, `docs`, `refactor`, `perf`, `test`, `build`, `ci`, or `revert`.
+
+Scopes are optional. The expected shape is `<type>: <subject>` or `<type>(<scope>): <subject>`. The subject must start with an alphanumeric character and must not end with a period.
+
+Use `docs:` for planning artifacts, specs, workflow notes, README changes, and other documentation-only work. Do not use descriptive-but-unsupported types such as `plan:`, `release:`, or `workflow:` unless the CI allowlist is updated in the same concern.
+
 ## Rules
 
 1. **No direct commits on `main` (or `develop`)** — *ever*. Every change lands via a topic branch and a merged PR. This applies to code, docs, ADRs, glossary entries, memory files, brainstorm output, planning artifacts, and generated docs. There is no "small enough" exception. The `.claude/settings.json` push deny is a backstop; the rule applies even to local commits, because extracting a stray `main` commit into a topic branch later costs more than cutting the branch up front. See [`feedback_no_main_commits.md`](../.claude/memory/feedback_no_main_commits.md).

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -46,6 +46,8 @@ Allowed types are intentionally narrow:
 
 Scopes are optional. The convention recorded in [AGENTS.md](../AGENTS.md) is `<type>(<scope>): <subject>` and that pattern still applies — `requireScope` is set to `false` only because some tracks (e.g. cross-cutting docs PRs) genuinely have no single scope.
 
+Planning work is not a separate PR type. A PR that adds or updates plans, specs, workflow docs, README roadmap rows, or issue-linked planning artifacts should normally use `docs: ...`. Metadata-only CI failures should be fixed by editing the PR title, not by pushing an unrelated retry commit.
+
 ## typos config
 
 `_typos.toml` lives at repo root.
@@ -84,8 +86,9 @@ The cooldown defends against the "compromised release window" supply-chain attac
 # typos
 typos --config _typos.toml
 
-# Conventional Commits PR-title check has no local equivalent — read the
-# rule in AGENTS.md and pick the matching type.
+# Conventional Commits PR-title check has no local equivalent — read
+# the allowed type list above and pick the matching type before opening
+# the PR.
 ```
 
 ## Adopting in a downstream project


### PR DESCRIPTION
## Summary

- Codify the PR-title CI failure mode in Codex's PR delivery workflow.
- Add shared branching and CI automation guidance for allowed Conventional Commit PR title types.
- Add a memory note so agents treat PR title metadata as part of the handoff contract.

## Root cause captured

A PR with title `plan: ...` can pass local `npm run verify` but fail CI because the `pr-title` workflow only allows `feat`, `fix`, `chore`, `docs`, `refactor`, `perf`, `test`, `build`, `ci`, and `revert`. Planning artifacts should use `docs: ...` unless the CI allowlist changes in the same concern.

## Verification

- `npm ci`
- `npm run verify`

## Notes

This is docs and memory only. No runtime or workflow YAML behavior changed.