### PR TITLE
chore(tokens): add token-budget verify gate (merge LAST)

### DIFF
--- a/docs/scripts/check-token-budget/README.md
+++ b/docs/scripts/check-token-budget/README.md
@@ -1,0 +1,13 @@
+---
+title: "check-token-budget"
+folder: "docs/scripts/check-token-budget"
+description: "Entry point for generated API reference for the check-token-budget script."
+entry_point: true
+---
+[**agentic-workflow**](../README.md)
+
+***
+
+[agentic-workflow](../modules.md) / check-token-budget
+
+# check-token-budget

--- a/docs/scripts/modules.md
+++ b/docs/scripts/modules.md
@@ -21,6 +21,7 @@
 - [check-roadmaps](check-roadmaps/README.md)
 - [check-script-docs](check-script-docs/README.md)
 - [check-spec-state](check-spec-state/README.md)
+- [check-token-budget](check-token-budget/README.md)
 - [check-traceability](check-traceability/README.md)
 - [check-workflow](check-workflow/README.md)
 - [check-workflow-docs](check-workflow-docs/README.md)

--- a/docs/token-budget.md
+++ b/docs/token-budget.md
@@ -1,0 +1,53 @@
+---
+title: Token budget
+folder: docs
+description: Caps on how much of an AI agent's context window the template's always-loaded files and skill catalog are allowed to consume, plus the verify gate that enforces them.
+entry_point: false
+---
+
+# Token budget
+
+Caps on how much of an AI agent's context window the template is allowed to consume on every session and every skill auto-trigger. Enforced by `npm run check:token-budget` (wired into `npm run verify`).
+
+## Why this exists
+
+Specorator agents read a fixed always-loaded chain at session start (`CLAUDE.md` → `AGENTS.md` → `memory/constitution.md` → `.claude/memory/MEMORY.md`) and the harness lists every skill's `description` frontmatter on every invocation. If those documents drift bigger over time, every conversation pays the cost. Each skill body is loaded when its skill is invoked, so an oversized skill body is paid every time someone uses it.
+
+The token-budget cleanup that produced this gate (`docs/superpowers/plans/2026-05-01-token-budget-cleanup.md`) cut the always-loaded chain from 28 KB to ~19 KB and the conductor skill bodies from ~53 KB to ~44 KB. The gate locks those numbers in.
+
+## Caps
+
+| Surface | Cap | Rationale |
+|---|---|---|
+| Always-loaded chain (combined) | **20 480 bytes** (≈ 20 KB) | Currently ~19 KB after dedupe; ~1.3 KB headroom for additive convention notes. Anything bigger is regression. |
+| Per-skill `SKILL.md` body | **14 336 bytes** (≈ 14 KB) | Largest is `orchestrate/SKILL.md` at ~12 KB after Chunk 3 factor; ~2 KB headroom for stage / phase additions. |
+| Skill description (frontmatter) | **700 chars** | Current max is ~650 chars (`arc42-baseline`). The original cap of 120 chars from PR #119 was rejected; 700 lets skills carry full trigger-phrase fidelity without further compression. |
+
+## What the gate checks
+
+`scripts/check-token-budget.ts` reads each cap and reports failures. Skills without YAML frontmatter (e.g., `verify`, `project-run`, `new-adr`, `review-fix`) are skipped — they pre-date the convention; the gate validates only what is enforceable.
+
+## Adding a new always-loaded file
+
+If a new file legitimately needs to ride in the always-loaded chain (e.g., a future scoped steering reference):
+
+1. Add it to `ALWAYS_LOADED_FILES` in `scripts/check-token-budget.ts`.
+2. Confirm the combined size still fits under `ALWAYS_LOADED_CAP`. If not, file an ADR proposing an increase with a token-cost rationale before raising the cap.
+
+## Bumping a cap
+
+Caps may be raised when:
+
+- A new convention requires bytes the current cap can't fit, **and**
+- The team agrees the trade-off is worth it, **and**
+- An ADR records the rationale.
+
+Caps are not silently bumped to make a failing CI run go green. If `check:token-budget` fails, the right move is to trim the file, not bump the cap.
+
+## Reproducing the gate locally
+
+```bash
+npm run check:token-budget
+# or as part of the full pre-PR gate:
+npm run verify
+```

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "check:specs": "tsx scripts/check-spec-state.ts",
     "check:roadmaps": "tsx scripts/check-roadmaps.ts",
     "check:traceability": "tsx scripts/check-traceability.ts",
+    "check:token-budget": "tsx scripts/check-token-budget.ts",
     "docs:scripts": "typedoc --options typedoc.json",
     "fix": "tsx scripts/fix-generated.ts",
     "fix:obsidian": "tsx scripts/fix-obsidian.ts",

--- a/scripts/check-token-budget.ts
+++ b/scripts/check-token-budget.ts
@@ -1,0 +1,51 @@
+import fs from "node:fs";
+import path from "node:path";
+import { extractFrontmatter, failIfErrors, parseSimpleYaml, repoRoot, walkFiles } from "./lib/repo.js";
+
+const ALWAYS_LOADED_FILES = [
+  "CLAUDE.md",
+  "AGENTS.md",
+  "memory/constitution.md",
+  ".claude/memory/MEMORY.md",
+];
+
+const ALWAYS_LOADED_CAP = 20480;
+const SKILL_BODY_CAP = 14336;
+const SKILL_DESCRIPTION_CAP = 700;
+
+const errors: string[] = [];
+
+let combined = 0;
+for (const rel of ALWAYS_LOADED_FILES) {
+  const absolute = path.join(repoRoot, rel);
+  if (!fs.existsSync(absolute)) {
+    errors.push(`${rel} missing — required by always-loaded chain`);
+    continue;
+  }
+  combined += fs.statSync(absolute).size;
+}
+if (combined > ALWAYS_LOADED_CAP) {
+  errors.push(
+    `always-loaded chain (${ALWAYS_LOADED_FILES.join(" + ")}) = ${combined} bytes; cap ${ALWAYS_LOADED_CAP}`,
+  );
+}
+
+for (const skillFile of walkFiles(".claude/skills", (file) => path.basename(file) === "SKILL.md")) {
+  const rel = path.relative(repoRoot, skillFile).split(path.sep).join("/");
+  const size = fs.statSync(skillFile).size;
+  if (size > SKILL_BODY_CAP) {
+    errors.push(`${rel} = ${size} bytes; per-skill cap ${SKILL_BODY_CAP}`);
+  }
+
+  const text = fs.readFileSync(skillFile, "utf8");
+  const frontmatter = extractFrontmatter(text);
+  if (!frontmatter) continue;
+  const data = parseSimpleYaml(frontmatter.raw);
+  const description = typeof data.description === "string" ? data.description.trim() : "";
+  if (description.length === 0) continue;
+  if (description.length > SKILL_DESCRIPTION_CAP) {
+    errors.push(`${rel} description = ${description.length} chars; cap ${SKILL_DESCRIPTION_CAP}`);
+  }
+}
+
+failIfErrors(errors, "check:token-budget");

--- a/scripts/lib/tasks.ts
+++ b/scripts/lib/tasks.ts
@@ -105,6 +105,11 @@ export const checkTasks = [
     label: "Traceability IDs",
     script: "scripts/check-traceability.ts",
   },
+  {
+    name: "check:token-budget",
+    label: "Token budget caps",
+    script: "scripts/check-token-budget.ts",
+  },
 ];
 
 /**

--- a/tools/automation-registry.yml
+++ b/tools/automation-registry.yml
@@ -289,6 +289,16 @@ entries:
     emits_json: false
     used_by: [human, agent, ci]
     rerun_command: npm run check:traceability
+  - id: check:token-budget
+    kind: check
+    command: npm run check:token-budget
+    path: scripts/check-token-budget.ts
+    purpose: Enforce caps on always-loaded context, skill bodies, and skill descriptions.
+    read_only: true
+    safe_to_run_locally: true
+    emits_json: false
+    used_by: [human, agent, ci]
+    rerun_command: npm run check:token-budget
   - id: docs:scripts
     kind: script
     command: npm run docs:scripts


### PR DESCRIPTION
## Summary
\`scripts/check-token-budget.ts\` enforces three caps on every \`npm run verify\`:

| Surface | Cap | Current | Headroom |
|---|---|---|---|
| Always-loaded chain combined | 20 480 bytes | 19 180 | 1.3 KB |
| Per-skill \`SKILL.md\` body | 14 336 bytes | 12 338 (orchestrate) | 2 KB |
| Skill \`description\` frontmatter | 700 chars | 650 (arc42-baseline) | 50 chars |

Caps are calibrated to current state. **Locks in** the savings from earlier chunks (always-loaded 28 KB → 19 KB; conductor skill bodies trimmed via Chunk 3 factor). Bumping a cap requires an ADR, not a silent edit.

## Skills exempt from frontmatter check
\`verify\`, \`project-run\`, \`new-adr\`, \`review-fix\` lack YAML frontmatter — pre-date the convention; the gate skips them rather than retroactively flagging them. Out of scope for this PR.

## Plan reference
Chunk 9 of \`docs/superpowers/plans/2026-05-01-token-budget-cleanup.md\`. **Merge LAST** after Chunks 4 (PR #127), 6 (PR #131), 7 (PR #132) land — otherwise the gate flips red on those PRs.

## Test plan
- [x] \`npm run check:token-budget\` green locally.
- [x] Full \`npm run verify\` green.
- [x] Wired into \`scripts/lib/tasks.ts\`, \`package.json\`, \`tools/automation-registry.yml\`.
- [x] Generated docs regenerated (\`docs/scripts/check-token-budget/\`).
- [x] Policy doc at \`docs/token-budget.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)