### PR TITLE
chore(tokens): compress 15 longest skill descriptions (retry of #119)

### DIFF
--- a/.claude/skills/design-twice/SKILL.md
+++ b/.claude/skills/design-twice/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: design-twice
-description: Generate two or three radically different design alternatives for a module, interface, flow, or architecture in parallel using the Task tool, then synthesize a recommendation. Use during stage 4 (Design) of the workflow on non-trivial features, when the user wants to explore options, compare module shapes, "design it twice", or whenever an irreversible design choice needs deliberation.
+description: Generate 2-3 radically different design alternatives in parallel via Task tool, then synthesize a pick. Use in stage 4 (Design). Triggers "design it twice", "explore options", "compare module shapes".
 argument-hint: <one-line scope, e.g. "user profile editing API">
 ---
 

--- a/.claude/skills/domain-context/SKILL.md
+++ b/.claude/skills/domain-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: domain-context
-description: Maintain a living domain context map at docs/CONTEXT.md (or scoped contexts under docs/contexts/) — the project's shared mental model of what the system is, who its users are, what bounded contexts exist, and how they relate. Lazily creates the file on first need. Use when a stage agent discovers a new domain concept, when a context boundary shifts, or whenever the user mentions "domain model", "context map", or "bounded context".
+description: Maintain living domain context map at docs/CONTEXT.md (or docs/contexts/) — system overview, users, bounded contexts, relationships. Lazily created. Triggers "domain model", "context map", "bounded context".
 argument-hint: [optional context name for multi-context repos]
 ---
 

--- a/.claude/skills/github-project-setup/SKILL.md
+++ b/.claude/skills/github-project-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-project-setup
-description: Set up a new GitHub repository as a manageable product/project workspace by creating labels, milestones, and baseline issues for repo setup, product vision, PRDs, use cases, UX/design, architecture, traceability, optional plugin shell work, and P3.express initiation up to kickoff. Use when a user asks to prepare a new repo, create a GitHub-backed project setup, make a product setup repeatable, or scaffold project-management issues for a new project.
+description: Scaffold a new GitHub repo as a project workspace — labels, milestones, baseline issues for vision, PRD, UX, architecture, traceability, P3.express kickoff. Triggers "prepare new repo", "scaffold project setup", "GitHub project setup".
 argument-hint: owner/repo [project name]
 ---
 

--- a/.claude/skills/grill/SKILL.md
+++ b/.claude/skills/grill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: grill
-description: Interview the user relentlessly about a plan, design, or requirement until every branch of the decision tree is resolved. Asks one question at a time, walks down each branch, gives a recommended answer, and explores the codebase to answer questions that don't need a human. Use when the user wants to stress-test a plan, sharpen ambiguity, get grilled on a design, run a clarification gate, or mentions "grill me", "interrogate this", or "tighten this up".
+description: Interrogate user one question at a time until every branch of a plan/design/requirement is resolved. Recommends answers, explores codebase. Triggers "grill me", "stress-test", "tighten this up", "interrogate".
 argument-hint: [path or topic to grill, e.g. "specs/payments/spec.md"]
 ---
 

--- a/.claude/skills/new-glossary-entry/SKILL.md
+++ b/.claude/skills/new-glossary-entry/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: new-glossary-entry
-description: Scaffold a new glossary entry under docs/glossary/<slug>.md from templates/glossary-entry-template.md. Use this skill when invoked via /glossary:new "<term>", when a new domain term is coined inside a workflow, when a stage agent reports terminology ambiguity, or when the user mentions "glossary", "define this term", "add a glossary entry", or "what does X mean in this repo". Replaces the deprecated ubiquitous-language skill (see ADR-0010).
+description: Scaffold a glossary entry at docs/glossary/<slug>.md from template. Triggers /glossary:new, "glossary", "define this term", "add glossary entry", or terminology ambiguity. Replaces ubiquitous-language (ADR-0010).
 argument-hint: "<term>"
 allowed-tools: [Read, Edit, Write, Bash]
 ---

--- a/.claude/skills/portfolio-track/SKILL.md
+++ b/.claude/skills/portfolio-track/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: portfolio-track
-description: Drive a portfolio management cycle based on P5 Express (https://p5.express/). Detects which cycle is due (X: 6-monthly strategy, Y: monthly review, Z: daily operations) and dispatches /portfolio:x, /portfolio:y, or /portfolio:z. Use when the user says "run portfolio review", "update the portfolio", "check portfolio health", "portfolio cycle", or asks about portfolio status across multiple projects. Opt-in — does not affect the Specorator 11-stage lifecycle.
+description: Drive P5 Express portfolio cycle. Detects which cycle (X strategy / Y monthly / Z daily) is due, dispatches /portfolio:x|y|z. Triggers "run portfolio review", "portfolio cycle", "portfolio health". Opt-in.
 argument-hint: [portfolio-slug or "list"]
 ---
 

--- a/.claude/skills/product-page/SKILL.md
+++ b/.claude/skills/product-page/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: product-page
-description: Create and keep alive a public product page for a project or product, with a directly accessible sites/index.html and hosting via GitHub Pages when available. Use when starting a new project or product, changing positioning, shipping a user-visible release, or when the user asks for a website, landing page, product page, GitHub Pages site, or public homepage.
+description: Maintain public product page at sites/index.html, hosted on GitHub Pages. Triggers new project, repositioning, user-visible release, or "website", "landing page", "product page", "GitHub Pages".
 argument-hint: [product or project name]
 ---
 

--- a/.claude/skills/project-scaffolding/SKILL.md
+++ b/.claude/skills/project-scaffolding/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-scaffolding
-description: Drive the Project Scaffolding Track end-to-end by gathering source pointers up front, dispatching the project-scaffolder through Intake -> Extract -> Assemble -> Handoff, and producing a reviewable starter pack from existing folders or Markdown documentation. Use when a fresh template install should be seeded from collected docs, meeting notes, briefs, or general project documentation.
+description: Drive Project Scaffolding Track end-to-end. Dispatches project-scaffolder through Intake -> Extract -> Assemble -> Handoff to seed a fresh install from collected docs, briefs, or notes.
 argument-hint: [project-slug or source pointer]
 ---
 

--- a/.claude/skills/quality-assurance/SKILL.md
+++ b/.claude/skills/quality-assurance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quality-assurance
-description: Run an ISO 9001-aligned quality assurance workflow that plans, executes, reviews, and improves project quality using evidence-backed checklists. Use when the user asks for quality assurance, ISO 9001 readiness, project execution health, delivery readiness, quality drift checks, or corrective action planning.
+description: Run ISO 9001-aligned QA workflow — plan, execute, review, improve via evidence-backed checklists. Triggers "quality assurance", "ISO 9001 readiness", "delivery readiness", "corrective actions".
 argument-hint: "<phase> <quality-review-slug>"
 ---
 

--- a/.claude/skills/quality-metrics/SKILL.md
+++ b/.claude/skills/quality-metrics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quality-metrics
-description: Present deterministic quality KPIs for workflow deliverables, documentation, traceability, QA checklists, blockers, clarifications, maturity, and trend snapshots. Use when the user asks for current quality status, project KPIs, workflow deliverable health, quality metrics, quality trend, or an information-system quality report.
+description: Report deterministic quality KPIs — deliverables, traceability, QA checklists, blockers, maturity, trends. Triggers "quality status", "project KPIs", "quality metrics", "quality trend".
 argument-hint: "[--feature <slug>] [--json] [--compare] [--save]"
 ---
 

--- a/.claude/skills/record-decision/SKILL.md
+++ b/.claude/skills/record-decision/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: record-decision
-description: File a new Architecture Decision Record (ADR) under docs/adr/ for a hard-to-reverse decision. Wraps the existing /adr:new command with guidance on when an ADR is warranted, what to capture, and how to link it back to the workflow. Use when the user wants to record a decision, file an ADR, document a trade-off, or whenever a stage agent flags an irreversible architectural choice.
+description: File a new ADR under docs/adr/ for a hard-to-reverse decision. Wraps /adr:new with guidance on when warranted and what to capture. Triggers "record decision", "file ADR", "document trade-off".
 argument-hint: <one-line decision title>
 ---
 

--- a/.claude/skills/roadmap-management/SKILL.md
+++ b/.claude/skills/roadmap-management/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: roadmap-management
-description: Conduct the Roadmap Management Track for product and project roadmaps. Use when the user asks to create, update, review, align, communicate, or manage a roadmap for product management, project management, stakeholder alignment, or team communication.
+description: Conduct Roadmap Management Track for product/project roadmaps. Triggers "create roadmap", "update roadmap", "review roadmap", "align stakeholders", "roadmap communication".
 argument-hint: [roadmap-slug or "list"]
 ---
 

--- a/.claude/skills/tdd-cycle/SKILL.md
+++ b/.claude/skills/tdd-cycle/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tdd-cycle
-description: Implement one slice using strict red → green → refactor. Write the failing test first, write the smallest code that makes it pass, then refactor only on green. Use during stage 7 (Implementation), when the user mentions "TDD", "red-green-refactor", "test-first", or whenever the dev agent is executing a task from tasks.md.
+description: Implement one slice via strict red -> green -> refactor. Failing test first, smallest passing code, refactor only on green. Use in stage 7 (Implementation). Triggers "TDD", "red-green-refactor", "test-first".
 argument-hint: [task-id, e.g. "T-PAY-014"]
 ---
 

--- a/.claude/skills/tracer-bullet/SKILL.md
+++ b/.claude/skills/tracer-bullet/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tracer-bullet
-description: Decompose a spec into vertical-slice tasks where each slice goes end-to-end through every layer it needs to and leaves the codebase in a working, committable state. Use during stage 6 (Tasks) of the workflow, when the user wants to break work into independently shippable steps, when a plan reads as horizontal slices ("first all the data layer, then all the API…"), or when the user mentions "tracer bullet", "vertical slice", or "smallest possible commits".
+description: Decompose spec into vertical end-to-end slices, each committable. Use in stage 6 (Tasks). Triggers "tracer bullet", "vertical slice", "smallest commits", or when a plan reads as horizontal layers.
 argument-hint: [feature-slug, e.g. "user-profile"]
 ---
 

--- a/.claude/skills/ubiquitous-language/SKILL.md
+++ b/.claude/skills/ubiquitous-language/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ubiquitous-language
-description: "[Deprecated by ADR-0010] Legacy single-file glossary at docs/UBIQUITOUS_LANGUAGE.md. New terms go in docs/glossary/<slug>.md via /glossary:new (handled by the new-glossary-entry skill). This skill is retained only so that forks of earlier template versions still resolve their references; it should not auto-trigger for new work."
+description: "[Deprecated by ADR-0010] Legacy single-file glossary at docs/UBIQUITOUS_LANGUAGE.md. New terms now use /glossary:new (new-glossary-entry skill). Retained for fork compatibility only — should not auto-trigger."
 argument-hint: "[deprecated — use /glossary:new instead]"
 ---
 


### PR DESCRIPTION
## Summary

Retry of [#119](https://github.com/Luis85/agentic-workflow/pull/119), which was closed unmerged on 2026-05-01 due to CRLF churn from a Python text-mode write on Windows.

This pass:
- Uses **Edit tool only** — no Python writes. `git diff` shows pure 1-line replacements (15 +, 15 -). No whole-file CRLF normalisation noise.
- Compresses YAML frontmatter `description:` of the 15 longest single-line skill descriptions (was 211-461 chars; now 130-285 chars).
- Each compressed description preserves: (a) one-sentence purpose, (b) primary trigger phrases in quotes, (c) primary slash command where relevant.

**Net: 5962 → 3198 bytes across 15 files (-2764 bytes / -46%)** in the skill catalog the harness lists on every Claude Code session.

## Skipped

- `caveman`, `caveman-commit`, `caveman-review` — multi-line YAML scalar (`>-`) format makes edits fragile and per-skill gain is small. All under the 700-char Chunk 9 cap already.

## Plan

Token-budget cleanup [continuation doc](docs/superpowers/plans/2026-05-01-token-budget-cleanup-CONTINUATION.md) — Chunk 2 retry.

## Test plan

- [x] `npm run verify` green (incl. `check:token-budget`)
- [x] All 15 `name:` fields untouched
- [x] Longest description after pass ≤ 700 chars (Chunk 9 cap)
- [x] Diff shows clean LF (no CRLF churn)
- [ ] Reviewer confirms compressed descriptions still trigger reliably for primary use cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)