### PR TITLE
feat(design): adopt specorator-design skill (ADR-0016)

### DIFF
--- a/.claude/agents/product-page-designer.md
+++ b/.claude/agents/product-page-designer.md
@@ -20,6 +20,11 @@ You create and maintain the project's public product page. The canonical static 
 - `docs/steering/ux.md` — visual direction, accessibility, content rules.
 - `docs/steering/tech.md` and `docs/steering/operations.md` — hosting and build constraints.
 - `.claude/skills/product-page/SKILL.md`
+- `.claude/skills/specorator-design/SKILL.md` — brand source of truth (tokens, voice, iconography rules)
+
+## Brand dependency
+
+Before editing `sites/` or generating any user-visible HTML/CSS, **invoke the `specorator-design` skill**. Lift values from `colors_and_type.css` by token name (`var(--ink)`, `var(--paper)`, `var(--accent)`, `var(--highlighter)`, …); never invent new colors, weights, radii, or shadows. If a token is missing for the work in front of you, propose an addition to `colors_and_type.css` via a separate PR before using it. The non-negotiable rules in the skill's README (no emoji, no icons, cream paper not white, chartreuse as a pop not a wash, sentence-case headlines that end with a period, lane coding Define = green / Build = blue / Ship = gold) are load-bearing — do not relax them.
 
 ## Procedure
 

--- a/.claude/skills/specorator-design/CHANGELOG.md
+++ b/.claude/skills/specorator-design/CHANGELOG.md
@@ -1,0 +1,11 @@
+# specorator-design — changelog
+
+## 0.1.0 — Initial import
+
+- Cross-compatible skill descriptor (`SKILL.md`).
+- Brand README — voice, content fundamentals, visual foundations, iconography.
+- `colors_and_type.css` — full token set (color, type, spacing, radius, shadow, motion).
+- `assets/` — `specorator-mark.svg`, `specorator-workflow.svg`.
+- `preview/` — 22 specimen cards (colors, type, components, spacing, radius, shadows).
+- `ui_kits/product-page/` — high-fidelity React recreation of the live product page.
+- `slides/` — 6-slide 16:9 deck system with `deck-stage.js` host.

--- a/.claude/skills/specorator-design/README.md
+++ b/.claude/skills/specorator-design/README.md
@@ -1,0 +1,175 @@
+---
+title: "Specorator Design System"
+folder: ".claude/skills/specorator-design"
+description: "Canonical brand source for Specorator — tokens, voice, iconography rules, UI kit components, and reference deck system."
+entry_point: true
+---
+# Specorator Design System
+
+> An editorial, document-first visual language for **Specorator** — an open-source, spec-driven workflow template for agentic software development. The "product" is a repository of conventions, agents, skills, and slash commands; the public surface is a single product page (`sites/index.html`) that this design system distills into reusable primitives.
+
+**Tagline:** _Stop letting AI write the wrong code._
+**Positioning:** Specs first, code second. Humans decide _what_; specialist agents handle _how_; every decision stays traceable.
+
+## Sources
+
+| Source                                | What's there                                                                                |
+| ------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `Luis85/agentic-workflow` (default `main`) | The whole template repo. Public page lives at `sites/`; brand assets at `sites/assets/`. |
+| `Luis85/specorator`                   | Empty placeholder repo (LICENSE only).                                                       |
+| Live site                             | <https://luis85.github.io/agentic-workflow/>                                                |
+| Source product page                   | `sites/index.html`, `sites/styles.css` in this project                                      |
+
+No Figma file; no design tokens file in the repo. The CSS in `sites/styles.css` is the canonical source of truth — every variable in `colors_and_type.css` derives from it.
+
+---
+
+## Index
+
+| File                              | Purpose                                                                          |
+| --------------------------------- | -------------------------------------------------------------------------------- |
+| `README.md` *(this file)*         | Brand context, content fundamentals, visual foundations, iconography.            |
+| `colors_and_type.css`             | All foundational tokens — color, type, spacing, radius, shadow, motion.          |
+| `assets/`                         | `specorator-mark.svg` (logo glyph), `specorator-workflow.svg` (workflow diagram). |
+| `sites/`                          | Pristine import of the live product page, kept for reference.                    |
+| `preview/`                        | Design-system specimen cards (registered to the Design System tab).              |
+| `ui_kits/product-page/`           | High-fidelity React UI kit — sections, cards, terminal, workflow rail.           |
+| `slides/`                         | Sample 16:9 slides reusing the visual system.                                    |
+| `SKILL.md`                        | Cross-compatible skill descriptor for use in Claude Code.                        |
+
+---
+
+## Content fundamentals
+
+**Voice.** Direct, opinionated, lower-case-friendly headlines that turn into proper sentences. Specorator talks like a thoughtful senior IC, not a marketing department. Confident statements, occasional em-dash asides, and no hedging.
+
+> _"Stop letting AI write the wrong code."_
+> _"Specs first, code second."_
+> _"You decide what to build; specialist agents handle how."_
+
+**Person.** Second person ("you"), often imperative ("Clone or fork", "Read the workflow", "Get started"). Never "we" except in incidental copy. The product is "Specorator" or "the workflow" — capitalized when standalone, lowercase when used in the slug `agentic-workflow`.
+
+**Casing.** Sentence case for headlines and titles ("A specialist for every stage."). Title-cased nouns only for established concepts: Discovery Track, Lifecycle Track, Quality Gate, Architecture Decision Record (ADR), EARS. Section headers end with a period — declarative statements, not labels.
+
+**Tone words to favor.** _spec, traceable, owned, gated, opinionated, predictable, durable, hand-off, scope, intent._
+**Words to avoid.** _seamless, magical, revolutionary, AI-powered, leverage, supercharge_.
+
+**Emoji.** Never. There is no emoji anywhere in the product page or docs. Use text labels, lane chips (`Define`, `Build`, `Ship`), or monospace tokens (`/spec:start`) instead.
+
+**Numerals & abbreviations.** Numerals for stage counts, agent counts, version numbers (`11 stages`, `30 agents`, `v0.2`). Spelled-out in body prose only when stylistic ("eight role families"). IDs are always uppercase-monospace: `REQ-CLI-001`, `T-AUTH-014`, `ADR-0009`.
+
+**Examples (verbatim).**
+
+- Eyebrows: `OPEN-SOURCE TEMPLATE` · `MIT · the agentic-workflow repo`
+- CTAs: `Get started`, `Read the workflow`, `Browse every cli-todo artifact →`
+- Card headlines: `11-stage lifecycle`, `Discovery track`, `Quality gates`, `Worktree discipline`
+- Audience prompts: `"let's start a feature: user auth"`, `"continue the user-auth feature"`, `/adr:new "Switch to Postgres"`
+- Slash commands: `/spec:start`, `/discovery:start`, `/quality:plan`
+
+**Dashes & punctuation.** Em-dashes (`—`) glue thoughts; en-dashes never appear. Mid-dot (`·`) separates meta items in eyebrows. Right-arrow (`→`) ends "more" links; never the unicode `>`.
+
+---
+
+## Visual foundations
+
+### The mood
+Editorial-paper-meets-developer-doc. A near-black ink on warm cream, a single accent forest green, a single signature chartreuse highlighter, plus four soft pastel surfaces (green, blue, yellow, orange) used to color-code panels by purpose. Layouts are document-like — wide gutters, thin hairline borders, clear rows — never card-graveyard SaaS.
+
+### Color
+- **Foreground / paper.** `--ink` (#17201B) and `--paper` (#fbfcf8) form the base. The cream paper is non-negotiable; do not substitute pure white at the page level.
+- **Surface.** White (`--surface`) for crisp cards on cream; alt-band sections use `--surface-2` (#f5f7f1) or `--surface-3` (#eef1ea).
+- **Accent.** `--accent` (#1b6f55) and `--accent-strong` (#12543f) for links, eyebrows, status pills, ID tokens. Never use a different green.
+- **Highlighter.** `--highlighter` (#e6ff70) is the load-bearing brand color. Reserved for: the `S` brand-mark glyph, the primary CTA button (`.button.highlight`), step numbers in dark sections, and inline code chips on dark backgrounds. **Never** use for body text or fills > 200×200px — it's a pop, not a wash.
+- **Soft surfaces by purpose.** Yellow = problem / gate. Green = solution / discovery / status-good. Blue = lifecycle / traceability. Orange = poor-fit. Purple = PR discipline (only in the workflow SVG). The mapping is intentional; reuse the right one.
+- **Lane coding.** Define = green (#159166), Build = blue (#365fa3), Ship = gold (#d49a14). Each lane has a soft pill variant.
+
+### Typography
+- **Sans.** Inter, weights 400/500/650/700/760/800/850. The rare 760 and 850 weights matter — they're how the brand looks heavier than typical Inter use.
+- **Mono.** JetBrains Mono (substitute for the original `ui-monospace` stack — _flagged_, see Substitutions below). Used for: code chips, slash commands, file paths, IDs, stage owners, "you'd say" labels.
+- **Scale.** Display 84px → H2 58px → H2-panel 42px → H3-large 38px → H3 22px → Lead 24px → Body 16px → Caption 14px → Eyebrow 13px → Micro 11px. Headlines use clamp() to scale fluidly.
+- **Tracking.** Display tightens (-0.015em). H3s tighten slightly (-0.01em). Eyebrows track wide (+0.11em). Lane chips track even wider (+0.12em).
+- **Leading.** Display 0.98 (very tight). Body 1.5. Code 1.6.
+
+### Spacing
+- **Section gutter.** `clamp(56px, 8vw, 104px)` vertical padding inside `.section`.
+- **Page gutter.** `clamp(20px, 5vw, 72px)` horizontal.
+- **Card gap.** 14–18px in dense grids; 24px in 2-up splits.
+- **Rule of 8.** All component padding lands on multiples of 2 (10/12/14/18/22/24/28/36).
+
+### Radius
+- 6px (code chips) → 8px (buttons, stages, panels, terminal pre) → 12px (audience/team/faq cards) → 14px (some cards) → 28px (hero-visual). The 8px panel is the dominant rhythm; resist extra-rounded blobs.
+
+### Borders
+- **Hairline.** 1px `--line` (#d8ded3) on light surfaces; rgba(216,222,211,.22) on dark.
+- **Dashed.** 1px dashed for the "artifact-meta" annotation block — used sparingly to mark optional/derivative content.
+- **Hover border.** Cards transition `border-color` → `--ink` on hover (200ms ease).
+
+### Shadow & elevation
+- **Card hover.** `0 12px 30px rgba(23,32,27,0.08)` + `translateY(-2px)`.
+- **Hero artwork.** `0 24px 70px rgba(23,32,27,0.13)`.
+- **Terminal.** `0 12px 28px rgba(0,0,0,0.35)` — heavier, dramatic.
+- Inner shadows: not used. The system trusts hairlines + soft fills.
+
+### Backgrounds
+- Flat color-blocked sections; alternating `--paper`, `--surface-2`, `--surface-3`, `--ink` (dark sections). No gradients. No images. No textures. The hero artwork is one flat SVG diagram — that's the only "imagery" in the brand.
+- The sticky site-header uses `rgba(251, 252, 248, 0.9)` + `backdrop-filter: blur(16px)` — the sole use of blur in the system.
+
+### Motion
+- **Duration.** 200ms.
+- **Easing.** Default `ease`; cards `ease`; smooth-scroll for anchor nav.
+- **Hover.** Cards lift 2px and tighten their border. Buttons darken (#0e1512). Links shift to ink color.
+- **Press.** No press state defined; rely on `:active` UA defaults. Buttons retain the same color.
+- **Reduced motion.** Honored — `scroll-behavior: auto` under the media query.
+- **No bouncing, no scaling beyond 2px lift, no parallax, no scroll-triggered animation.**
+
+### Component patterns
+- **Buttons.** Solid `--ink` rect with 1px ink border; `.highlight` swaps to chartreuse fill; `.secondary` is transparent with ink text. Min-height 44px, 18px horizontal padding, weight 760, 8px radius.
+- **Cards.** White surface, 1px `--line` border, 12–14px radius, 22–28px padding, hover lift. The `.team-card` adds a 3px top border in lane color (`#159166`/`#365fa3`/`#d49a14`).
+- **Stages.** 8px radius pill-rectangles with two stacked labels (name + monospace owner). Color by track: yellow (gate), green (discovery), blue (lifecycle).
+- **Terminal.** Macos-style chrome (3 traffic-light dots), `#0e1512` body, 14px mono text.
+- **Pills (status, lane chips).** 999px radius, 10–12px padding, 11px micro type, uppercase, wide tracking.
+- **Audience cards.** `data-num` attribute renders a giant `850`-weight numeral as a watermark in the top-right, 6% black opacity. Beautiful detail; use it.
+
+### Layout rules
+- **Sticky header** with backdrop blur. Skip-link reveals on focus.
+- **Two-column hero** (0.82fr / 1fr) collapses to single column at 980px.
+- **4-up grids** (`feature-grid`, `audience-grid`, `team-grid`, `track-grid`) collapse to 2-up at 980px, 1-up at 720px.
+- Section headers use a flex row: H2 left, kicker right (max 410px), end-aligned. Collapse to stacked at 980px.
+- Max line measure: ~17ch for h1, 760px for h2, 680px for body p, 720px for hero-proof grid.
+
+### Transparency & blur
+- Single use of blur: header backdrop.
+- Subtle alphas: card hover shadow rgba(.08), big numeral watermark rgba(.06), card-on-dark `rgba(255,255,255,0.06)` fill, ink-tint code-chip `rgba(23,32,27,0.06)`.
+
+### Imagery vibe
+- The only "image" is `specorator-workflow.svg` — a flat editorial diagram. If new imagery is ever added, it should match: warm-paper background, hairline strokes, soft-pastel callout boxes, monospace-style annotations, no photography, no 3D, no gradients.
+
+---
+
+## Iconography
+
+Specorator's product page uses **zero icons**. There are no SVG icons, no icon font, no Lucide / Heroicons / Phosphor / Feather — none. The brand voice _is_ the iconography: monospace code chips (`/spec:start`), arrows in copy (`→`), the `S` brand mark, status pills with a colored dot, and traffic-light circles in the terminal chrome.
+
+**This is intentional and load-bearing.** Resist the urge to add icons.
+
+When you must indicate something:
+
+| Need              | Use                                                            |
+| ----------------- | -------------------------------------------------------------- |
+| "More" / next     | Trailing `→` (right arrow, U+2192) in link text                |
+| Bullet separator  | `·` (middle dot, U+00B7) between meta items                    |
+| Status            | A `.status-pill` with a 6×6 colored dot and uppercase label    |
+| Command / file    | Monospace code chip (`.code-chip` or `.code-chip-dark`)        |
+| Brand stamp       | `assets/specorator-mark.svg` — the chartreuse-on-ink "S" glyph |
+| Workflow diagram  | `assets/specorator-workflow.svg` — the editorial map           |
+| Process step      | A numbered `.step-number` circle (chartreuse fill, ink text)   |
+
+**Substitution flag.** If a future surface genuinely needs a small icon set (settings, file tree, etc.), the closest CDN match is **Lucide** (1.5–2px stroke, geometric, no fills) — but flag it to the user before adding. Do **not** add emoji as a substitute.
+
+---
+
+## Substitutions to flag
+
+- **Mono font.** The product page uses the system stack (`ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas`). This system loads **JetBrains Mono** from Google Fonts as a stable substitute. If the brand wants a specific licensed mono, swap it in `colors_and_type.css` and replace the `@import`.
+- **Sans.** Inter is loaded from Google Fonts (used by the live site too). No substitution needed.
+- **Workflow SVG.** Single asset, kept verbatim.

--- a/.claude/skills/specorator-design/SKILL.md
+++ b/.claude/skills/specorator-design/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: specorator-design
+description: Use this skill to generate well-branded interfaces and assets for Specorator (the open-source agentic-workflow template), either for production or throwaway prototypes/mocks/etc. Contains essential design guidelines, colors, type, fonts, assets, and UI kit components for prototyping.
+user-invocable: true
+---
+
+Read the README.md file within this skill, and explore the other available files.
+
+If creating visual artifacts (slides, mocks, throwaway prototypes, etc), copy assets out and create static HTML files for the user to view. If working on production code, you can copy assets and read the rules here to become an expert in designing with this brand.
+
+If the user invokes this skill without any other guidance, ask them what they want to build or design, ask some questions, and act as an expert designer who outputs HTML artifacts _or_ production code, depending on the need.
+
+## Quick map
+
+- `README.md` — voice, content fundamentals, visual foundations, iconography rules.
+- `colors_and_type.css` — every token: color, type, spacing, radius, shadow, motion. Drop this into any new HTML.
+- `assets/` — `specorator-mark.svg` (logo), `specorator-workflow.svg` (workflow diagram).
+- `ui_kits/product-page/` — pixel-faithful React recreation of the live product page. Read its components to learn idiomatic Specorator section/card/terminal patterns.
+- `sites/` — pristine import of the live page; the canonical source of truth for the visual system.
+- `preview/` — small specimen cards (colors, type, components) you can crib from.
+
+## Non-negotiables
+
+- **No emoji. No icons.** The brand uses zero iconography. Use monospace code chips, arrows in copy (`→`), middle-dots (`·`), and status pills instead.
+- **Cream paper, not white.** Page backgrounds use `--paper` (#fbfcf8). White is for cards.
+- **Chartreuse is a pop, not a wash.** `--highlighter` (#e6ff70) is reserved for the brand mark, the primary CTA, step-number circles, and inline code chips on dark backgrounds. Never as a body fill.
+- **Sentence-case headlines that end with a period.** "A specialist for every stage."
+- **Em-dashes glue thoughts; never en-dashes.**
+- **Lane coding is intentional.** Define = green, Build = blue, Ship = gold. Reuse the right one.
+
+## Default fonts
+
+- Sans: **Inter** (weights 400–850, including the unusual 760).
+- Mono: **JetBrains Mono** (substitute for the original system mono — flagged in README).
+
+Load both from Google Fonts unless the project provides licensed files.

--- a/.claude/skills/specorator-design/assets/specorator-mark.svg
+++ b/.claude/skills/specorator-design/assets/specorator-mark.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Specorator mark">
+  <rect width="64" height="64" rx="14" fill="#17201B"></rect>
+  <path d="M20 24c0-6 5-10 14-10 6 0 11 2 15 5l-5 6c-3-2-6-3-10-3-4 0-6 1-6 3 0 2 2 3 8 4 10 2 15 5 15 12 0 7-6 11-16 11-7 0-13-2-17-6l5-6c4 3 8 4 13 4 5 0 7-1 7-3 0-2-2-3-8-4-10-2-15-5-15-13Z" fill="#E6FF70"></path>
+</svg>

--- a/.claude/skills/specorator-design/assets/specorator-workflow.svg
+++ b/.claude/skills/specorator-design/assets/specorator-workflow.svg
@@ -1,0 +1,65 @@
+<svg width="1040" height="720" viewBox="0 0 1040 720" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Specorator workflow artifact map</title>
+  <desc id="desc">A product-style workflow visual showing discovery, lifecycle stages, quality gates, and traceability artifacts.</desc>
+  <rect width="1040" height="720" rx="28" fill="#F7F8F4"></rect>
+  <rect x="48" y="44" width="944" height="632" rx="24" fill="#FFFFFF" stroke="#D8DED3" stroke-width="2"></rect>
+  <rect x="84" y="80" width="872" height="88" rx="18" fill="#17201B"></rect>
+  <text x="116" y="119" fill="#FAFBF8" font-family="Inter, Arial, sans-serif" font-size="28" font-weight="700">Specorator</text>
+  <text x="116" y="146" fill="#C7D5CD" font-family="Inter, Arial, sans-serif" font-size="16">Specs first. Agents in lanes. Quality gates before code moves.</text>
+  <rect x="766" y="104" width="154" height="40" rx="20" fill="#E6FF70"></rect>
+  <text x="804" y="130" fill="#17201B" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700">Ready to ship</text>
+
+  <text x="88" y="224" fill="#58635E" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing=".12em">DISCOVERY TRACK</text>
+  <rect x="84" y="244" width="136" height="74" rx="14" fill="#E6F6EF" stroke="#A8D9C4"></rect>
+  <text x="116" y="277" fill="#17201B" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="700">Frame</text>
+  <text x="111" y="299" fill="#59645E" font-family="Inter, Arial, sans-serif" font-size="13">Problem space</text>
+  <rect x="244" y="244" width="136" height="74" rx="14" fill="#E6F6EF" stroke="#A8D9C4"></rect>
+  <text x="275" y="277" fill="#17201B" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="700">Diverge</text>
+  <text x="280" y="299" fill="#59645E" font-family="Inter, Arial, sans-serif" font-size="13">Options</text>
+  <rect x="404" y="244" width="136" height="74" rx="14" fill="#E6F6EF" stroke="#A8D9C4"></rect>
+  <text x="433" y="277" fill="#17201B" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="700">Converge</text>
+  <text x="440" y="299" fill="#59645E" font-family="Inter, Arial, sans-serif" font-size="13">Brief</text>
+  <path d="M220 281H244" stroke="#7EA793" stroke-width="3" stroke-linecap="round"></path>
+  <path d="M380 281H404" stroke="#7EA793" stroke-width="3" stroke-linecap="round"></path>
+
+  <text x="88" y="382" fill="#58635E" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing=".12em">LIFECYCLE TRACK</text>
+  <g fill="#EEF1EA" stroke="#CAD3C7">
+    <rect x="84" y="404" width="96" height="62" rx="13"></rect>
+    <rect x="198" y="404" width="96" height="62" rx="13"></rect>
+    <rect x="312" y="404" width="110" height="62" rx="13"></rect>
+    <rect x="440" y="404" width="96" height="62" rx="13"></rect>
+    <rect x="554" y="404" width="118" height="62" rx="13"></rect>
+    <rect x="690" y="404" width="96" height="62" rx="13"></rect>
+    <rect x="804" y="404" width="108" height="62" rx="13"></rect>
+  </g>
+  <g fill="#17201B" font-family="Inter, Arial, sans-serif" font-size="14" font-weight="700">
+    <text x="118" y="441">Idea</text>
+    <text x="219" y="441">Research</text>
+    <text x="330" y="441">Requirements</text>
+    <text x="471" y="441">Design</text>
+    <text x="580" y="441">Specification</text>
+    <text x="713" y="441">Tasks</text>
+    <text x="828" y="441">Build</text>
+  </g>
+  <g stroke="#9AA89F" stroke-width="3" stroke-linecap="round">
+    <path d="M180 435H198"></path>
+    <path d="M294 435H312"></path>
+    <path d="M422 435H440"></path>
+    <path d="M536 435H554"></path>
+    <path d="M672 435H690"></path>
+    <path d="M786 435H804"></path>
+  </g>
+
+  <rect x="84" y="520" width="250" height="82" rx="16" fill="#FFF8D8" stroke="#E2CF73"></rect>
+  <text x="112" y="553" fill="#17201B" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="700">Quality gate</text>
+  <text x="112" y="579" fill="#59645E" font-family="Inter, Arial, sans-serif" font-size="14">Deterministic checks first, then review.</text>
+  <rect x="388" y="520" width="250" height="82" rx="16" fill="#EBF0FF" stroke="#B9C5ED"></rect>
+  <text x="416" y="553" fill="#17201B" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="700">Traceability</text>
+  <text x="416" y="579" fill="#59645E" font-family="Inter, Arial, sans-serif" font-size="14">Requirement to spec to task to test.</text>
+  <rect x="692" y="520" width="220" height="82" rx="16" fill="#F2E9FF" stroke="#D0B8F0"></rect>
+  <text x="720" y="553" fill="#17201B" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="700">PR discipline</text>
+  <text x="720" y="579" fill="#59645E" font-family="Inter, Arial, sans-serif" font-size="14">Worktree, verify, review, ship.</text>
+
+  <path d="M472 319C472 356 472 369 472 404" stroke="#7EA793" stroke-width="3" stroke-linecap="round" stroke-dasharray="7 8"></path>
+  <path d="M534 466C534 496 534 501 534 520" stroke="#8E98B8" stroke-width="3" stroke-linecap="round"></path>
+</svg>

--- a/.claude/skills/specorator-design/colors_and_type.css
+++ b/.claude/skills/specorator-design/colors_and_type.css
@@ -1,0 +1,238 @@
+/*
+ * Specorator — colors_and_type.css
+ * Foundational tokens lifted from sites/styles.css (the canonical product page).
+ * Brand vocabulary: forest-ink, olive-paper, highlighter-chartreuse, soft pastels for panels.
+ *
+ * Usage:
+ *   <link rel="stylesheet" href="colors_and_type.css">
+ *   <body class="specorator">  // optional; tokens are on :root
+ */
+
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&display=swap");
+
+:root {
+  /* ─────────── Color · Core ─────────── */
+  --ink: #17201b;            /* primary fg, dark-mode bg, brand-mark bg */
+  --ink-soft: #0e1512;       /* deeper terminal black */
+  --muted: #59645e;          /* secondary text */
+  --paper: #fbfcf8;          /* page bg */
+  --surface: #ffffff;        /* card / panel bg */
+  --surface-2: #f5f7f1;      /* alt-band sections (fit, team, scaffolding) */
+  --surface-3: #eef1ea;      /* example section bg */
+  --line: #d8ded3;           /* hairline borders */
+  --line-soft: rgba(216, 222, 211, 0.72);
+
+  /* ─────────── Color · Brand Accents ─────────── */
+  --accent: #1b6f55;         /* primary accent — forest green */
+  --accent-strong: #12543f;  /* darker accent — eyebrow text, links */
+  --highlighter: #e6ff70;    /* signature chartreuse — CTAs, brand mark glyph */
+
+  /* ─────────── Color · Soft Tinted Surfaces ─────────── */
+  --soft-green: #e6f6ef;     /* solution panel, status pill, discovery stage */
+  --soft-blue: #ebf0ff;      /* lifecycle stage, traceability panel */
+  --soft-yellow: #fff8d8;    /* problem panel, gate stage */
+  --soft-orange: #fff5ee;    /* poor-fit panel */
+  --soft-purple: #f2e9ff;    /* PR discipline panel (workflow svg) */
+
+  /* ─────────── Color · Lane Coding ─────────── */
+  --lane-define: #159166;    /* green — Define lane (analyst→architect) */
+  --lane-build:  #365fa3;    /* blue  — Build lane (planner→qa) */
+  --lane-ship:   #d49a14;    /* gold  — Ship lane (review→retro) */
+  --lane-define-soft: #bce5d2;
+  --lane-build-soft:  #cbd9f7;
+  --lane-ship-soft:   #f9e3a0;
+
+  /* ─────────── Color · Inverse / Dark surfaces ─────────── */
+  --on-ink:      #f8faf5;
+  --on-ink-mute: #c7d5cd;
+  --on-ink-dim:  rgba(248, 250, 245, 0.55);
+
+  /* ─────────── Type · Families ─────────── */
+  --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+               "Segoe UI", sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo,
+               Consolas, monospace;
+
+  /* ─────────── Type · Scale (display & body) ─────────── */
+  --fs-display:  clamp(44px, 6.6vw, 84px);  /* h1 hero */
+  --fs-h2:       clamp(34px, 4.4vw, 58px);  /* section h2 */
+  --fs-h2-panel: clamp(28px, 3.0vw, 42px);  /* panel h2 (problem/solution) */
+  --fs-h3-lg:    clamp(26px, 3.0vw, 38px);  /* fit-panel h3 */
+  --fs-h3:       22px;                       /* card h3 */
+  --fs-h3-sm:    20px;                       /* roster h3 */
+  --fs-lead:     clamp(18px, 1.9vw, 24px);  /* hero copy */
+  --fs-body:     16px;
+  --fs-body-lg:  18px;
+  --fs-body-sm:  15px;
+  --fs-caption:  14px;
+  --fs-meta:     13px;
+  --fs-eyebrow:  13px;
+  --fs-micro:    11px;     /* status pill, lane chip */
+  --fs-mono:     12.5px;   /* code in artifacts */
+
+  /* ─────────── Type · Weight ─────────── */
+  --fw-regular: 400;
+  --fw-medium:  500;
+  --fw-semi:    650;       /* nav links */
+  --fw-bold:    700;
+  --fw-strong:  760;       /* button / stage labels */
+  --fw-x:       800;       /* eyebrow, brand */
+  --fw-xx:      850;       /* proof values, audience numerals */
+
+  /* ─────────── Type · Tracking & Leading ─────────── */
+  --tracking-display: -0.015em;
+  --tracking-h2:      0;
+  --tracking-h3:      -0.01em;
+  --tracking-eyebrow: 0.11em;
+  --tracking-pill:    0.08em;
+  --tracking-lane:    0.12em;
+
+  --leading-display:  0.98;
+  --leading-tight:    1.08;
+  --leading-snug:     1.3;
+  --leading-body:     1.5;
+  --leading-relaxed:  1.65;
+
+  /* ─────────── Spacing ─────────── */
+  --gutter-section: clamp(56px, 8vw, 104px);
+  --gutter-page:    clamp(20px, 5vw, 72px);
+  --gap-card:       clamp(20px, 2.4vw, 26px);
+  --gap-panel:      clamp(26px, 4vw, 42px);
+
+  /* ─────────── Radius ─────────── */
+  --r-sm:  6px;    /* code chip */
+  --r-md:  8px;    /* button, stage, panel, terminal pre */
+  --r-lg:  12px;   /* audience-card, team-card, faq-item */
+  --r-xl:  14px;
+  --r-2xl: 28px;   /* hero-visual */
+  --r-pill: 999px;
+
+  /* ─────────── Shadow ─────────── */
+  --shadow-sm:    0 6px 20px rgba(23, 32, 27, 0.04);
+  --shadow-md:    0 12px 30px rgba(23, 32, 27, 0.08);
+  --shadow-hero:  0 24px 70px rgba(23, 32, 27, 0.13);
+  --shadow-term:  0 12px 28px rgba(0, 0, 0, 0.35);
+
+  /* ─────────── Motion ─────────── */
+  --ease-out: cubic-bezier(0.2, 0.8, 0.2, 1);
+  --dur-fast: 0.2s;
+}
+
+/* ═══════════════════════════════════════════════
+   SEMANTIC TYPE — apply these classes/elements
+   ═══════════════════════════════════════════════ */
+
+body, .body {
+  font-family: var(--font-sans);
+  font-size: var(--fs-body);
+  line-height: var(--leading-body);
+  color: var(--ink);
+  background: var(--paper);
+}
+
+.h1, h1.specorator {
+  font-family: var(--font-sans);
+  font-size: var(--fs-display);
+  font-weight: var(--fw-x);
+  line-height: var(--leading-display);
+  letter-spacing: var(--tracking-display);
+  color: var(--ink);
+  max-width: 17ch;
+  margin: 0 0 22px;
+}
+
+.h2, h2.specorator {
+  font-family: var(--font-sans);
+  font-size: var(--fs-h2);
+  font-weight: var(--fw-x);
+  line-height: 1.02;
+  letter-spacing: var(--tracking-h2);
+  color: var(--ink);
+}
+
+.h3, h3.specorator {
+  font-family: var(--font-sans);
+  font-size: var(--fs-h3);
+  font-weight: var(--fw-x);
+  line-height: var(--leading-snug);
+  letter-spacing: var(--tracking-h3);
+  color: var(--ink);
+}
+
+.lead {
+  font-size: var(--fs-lead);
+  line-height: 1.4;
+  color: var(--muted);
+}
+
+.eyebrow {
+  font-size: var(--fs-eyebrow);
+  font-weight: var(--fw-x);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--accent-strong);
+}
+
+.proof-value {
+  font-size: 24px;
+  font-weight: var(--fw-xx);
+  color: var(--ink);
+}
+
+.code, code, kbd, samp, pre {
+  font-family: var(--font-mono);
+  font-size: var(--fs-mono);
+}
+
+.code-chip {
+  display: inline-block;
+  padding: 2px 7px;
+  border-radius: var(--r-sm);
+  background: rgba(23, 32, 27, 0.06);
+  color: var(--ink);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: var(--fw-bold);
+}
+
+.code-chip-dark {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: var(--r-sm);
+  background: rgba(230, 255, 112, 0.1);
+  color: var(--highlighter);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: var(--fw-bold);
+}
+
+.id-token {
+  display: inline-block;
+  padding: 0 5px;
+  border-radius: 3px;
+  background: rgba(27, 111, 85, 0.1);
+  color: var(--accent-strong);
+  font-family: var(--font-mono);
+  font-weight: var(--fw-x);
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: var(--r-pill);
+  background: var(--soft-green);
+  color: var(--accent-strong);
+  font-size: var(--fs-micro);
+  letter-spacing: var(--tracking-pill);
+  font-weight: var(--fw-x);
+  text-transform: uppercase;
+}
+.status-pill::before {
+  content: "";
+  display: inline-block;
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+}

--- a/.claude/skills/specorator-design/preview/_card.css
+++ b/.claude/skills/specorator-design/preview/_card.css
@@ -1,0 +1,22 @@
+/* Specorator preview card chrome — shared by all /preview/*.html */
+@import url("../colors_and_type.css");
+
+* { box-sizing: border-box; }
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  line-height: 1.45;
+  width: 700px;
+}
+.card {
+  padding: 24px 28px;
+  min-height: 100px;
+}
+.row { display: flex; gap: 12px; flex-wrap: wrap; align-items: center; }
+.col { display: flex; flex-direction: column; gap: 12px; }
+.label { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); }
+.kbd { font-family: var(--font-mono); font-size: 11px; color: var(--muted); }

--- a/.claude/skills/specorator-design/preview/brand-mark.html
+++ b/.claude/skills/specorator-design/preview/brand-mark.html
@@ -1,0 +1,14 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"><style>
+body { width: 700px; padding: 22px 28px; background: var(--paper); display: flex; gap: 18px; align-items: center; }
+.mark { width: 88px; height: 88px; border-radius: 14px; }
+.col { display: flex; flex-direction: column; gap: 8px; }
+.brand { display: inline-flex; align-items: center; gap: 10px; font-weight: 800; font-size: 22px; }
+.brand-mark { width: 32px; height: 32px; border-radius: 8px; background: var(--ink); color: var(--highlighter); font-size: 18px; font-weight: 800; display: grid; place-items: center; }
+.tag { font-size: 13px; color: var(--muted); font-family: var(--font-mono); }
+</style></head><body>
+<img class="mark" src="../assets/specorator-mark.svg" alt="Specorator mark">
+<div class="col">
+  <span class="brand"><span class="brand-mark">S</span><span>Specorator</span></span>
+  <span class="tag">Wordmark · 32 · weight 800 · paired with brand-mark badge</span>
+</div>
+</body></html>

--- a/.claude/skills/specorator-design/preview/brand-workflow-art.html
+++ b/.claude/skills/specorator-design/preview/brand-workflow-art.html
@@ -1,0 +1,8 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"><style>
+body { width: 700px; padding: 16px 20px; background: var(--paper); }
+img { width: 100%; height: auto; border-radius: 14px; box-shadow: 0 12px 30px rgba(23,32,27,0.08); display: block; }
+.cap { font-family: var(--font-mono); font-size: 10px; color: var(--muted); margin-top: 8px; text-align: center; }
+</style></head><body>
+<img src="../assets/specorator-workflow.svg" alt="Specorator workflow diagram">
+<p class="cap">specorator-workflow.svg · the only "image" in the system</p>
+</body></html>

--- a/.claude/skills/specorator-design/preview/colors-brand.html
+++ b/.claude/skills/specorator-design/preview/colors-brand.html
@@ -1,0 +1,12 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"><style>
+.swatch { width: 100%; aspect-ratio: 1.4/1; border-radius: 8px; display: flex; align-items: flex-end; padding: 10px; font-size: 10px; font-weight: 700; }
+.grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
+.name { font-family: var(--font-mono); font-size: 11px; color: var(--muted); margin-top: 6px; display: block; }
+.hex  { font-family: var(--font-mono); font-size: 10px; color: var(--muted); display: block; }
+</style></head><body class="card">
+<div class="grid">
+  <div><div class="swatch" style="background:var(--accent); color:#fff">Accent</div><span class="name">--accent</span><span class="hex">#1B6F55</span></div>
+  <div><div class="swatch" style="background:var(--accent-strong); color:#fff">Accent strong</div><span class="name">--accent-strong</span><span class="hex">#12543F</span></div>
+  <div><div class="swatch" style="background:var(--highlighter); color:var(--ink)">Highlighter</div><span class="name">--highlighter</span><span class="hex">#E6FF70</span></div>
+</div>
+</body></html>

--- a/.claude/skills/specorator-design/preview/colors-core.html
+++ b/.claude/skills/specorator-design/preview/colors-core.html
@@ -1,0 +1,14 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"><style>
+.swatch { width: 100%; aspect-ratio: 1.4/1; border-radius: 8px; border: 1px solid rgba(0,0,0,.06); display: flex; align-items: flex-end; padding: 10px; font-size: 10px; font-weight: 700; }
+.grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 12px; }
+.name { font-family: var(--font-mono); font-size: 11px; color: var(--muted); margin-top: 6px; display: block; }
+.hex  { font-family: var(--font-mono); font-size: 10px; color: var(--muted); display: block; }
+</style></head><body class="card">
+<div class="grid">
+  <div><div class="swatch" style="background:var(--ink); color:var(--highlighter)">Aa</div><span class="name">--ink</span><span class="hex">#17201B</span></div>
+  <div><div class="swatch" style="background:var(--paper); color:var(--ink); border-color:var(--line)">Aa</div><span class="name">--paper</span><span class="hex">#FBFCF8</span></div>
+  <div><div class="swatch" style="background:var(--surface); color:var(--ink); border-color:var(--line)">Aa</div><span class="name">--surface</span><span class="hex">#FFFFFF</span></div>
+  <div><div class="swatch" style="background:var(--surface-2); color:var(--ink); border-color:var(--line)">Aa</div><span class="name">--surface-2</span><span class="hex">#F5F7F1</span></div>
+  <div><div class="swatch" style="background:var(--muted); color:#fff">Aa</div><span class="name">--muted</span><span class="hex">#59645E</span></div>
+</div>
+</body></html>

--- a/.claude/skills/specorator-design/preview/colors-lanes.html
+++ b/.claude/skills/specorator-design/preview/colors-lanes.html
@@ -1,0 +1,28 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"><style>
+.lane { padding: 14px 16px; border-radius: 8px; border: 1px solid var(--line); background: var(--surface); position: relative; overflow: hidden; }
+.lane::before { content:""; position:absolute; top:0; left:0; right:0; height:3px; }
+.lane.define::before { background: var(--lane-define); }
+.lane.build::before  { background: var(--lane-build); }
+.lane.ship::before   { background: var(--lane-ship); }
+.chip { display: inline-block; padding: 3px 9px; border-radius: 999px; font-size: 10px; font-weight: 800; letter-spacing: 0.12em; text-transform: uppercase; }
+.chip.define { color: var(--accent-strong); background: var(--lane-define-soft); }
+.chip.build  { color: #2d4a73; background: var(--lane-build-soft); }
+.chip.ship   { color: #6b5400; background: var(--lane-ship-soft); }
+.grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+.swatchrow { display: flex; gap: 6px; margin-top: 10px; }
+.sw { width: 24px; height: 24px; border-radius: 4px; }
+.hex { font-family: var(--font-mono); font-size: 10px; color: var(--muted); display: block; margin-top: 6px; }
+h4 { margin: 6px 0 0; font-size: 14px; }
+</style></head><body class="card">
+<div class="grid">
+  <div class="lane define"><span class="chip define">Define</span><h4>Analyst → Architect</h4>
+    <div class="swatchrow"><div class="sw" style="background:var(--lane-define)"></div><div class="sw" style="background:var(--lane-define-soft)"></div></div>
+    <span class="hex">#159166 · #BCE5D2</span></div>
+  <div class="lane build"><span class="chip build">Build</span><h4>Planner → QA</h4>
+    <div class="swatchrow"><div class="sw" style="background:var(--lane-build)"></div><div class="sw" style="background:var(--lane-build-soft)"></div></div>
+    <span class="hex">#365FA3 · #CBD9F7</span></div>
+  <div class="lane ship"><span class="chip ship">Ship</span><h4>Review → Retro</h4>
+    <div class="swatchrow"><div class="sw" style="background:var(--lane-ship)"></div><div class="sw" style="background:var(--lane-ship-soft)"></div></div>
+    <span class="hex">#D49A14 · #F9E3A0</span></div>
+</div>
+</body></html>

--- a/.claude/skills/specorator-design/preview/colors-soft-surfaces.html
+++ b/.claude/skills/specorator-design/preview/colors-soft-surfaces.html
@@ -1,0 +1,15 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"><style>
+.swatch { width: 100%; aspect-ratio: 1.4/1; border-radius: 8px; border: 1px solid var(--line); display: flex; align-items: flex-end; padding: 10px; font-size: 10px; font-weight: 700; color: var(--ink); }
+.grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 12px; }
+.name { font-family: var(--font-mono); font-size: 11px; color: var(--muted); margin-top: 6px; display: block; }
+.hex  { font-family: var(--font-mono); font-size: 10px; color: var(--muted); display: block; }
+.use  { font-family: var(--font-mono); font-size: 9px; color: var(--muted); display: block; margin-top: 2px;}
+</style></head><body class="card">
+<div class="grid">
+  <div><div class="swatch" style="background:var(--soft-green)">Solution</div><span class="name">--soft-green</span><span class="hex">#E6F6EF</span><span class="use">solution / status</span></div>
+  <div><div class="swatch" style="background:var(--soft-blue)">Lifecycle</div><span class="name">--soft-blue</span><span class="hex">#EBF0FF</span><span class="use">lifecycle / trace</span></div>
+  <div><div class="swatch" style="background:var(--soft-yellow)">Problem</div><span class="name">--soft-yellow</span><span class="hex">#FFF8D8</span><span class="use">problem / gate</span></div>
+  <div><div class="swatch" style="background:var(--soft-orange)">Poor fit</div><span class="name">--soft-orange</span><span class="hex">#FFF5EE</span><span class="use">poor fit</span></div>
+  <div><div class="swatch" style="background:var(--soft-purple)">PR</div><span class="name">--soft-purple</span><span class="hex">#F2E9FF</span><span class="use">PR discipline</span></div>
+</div>
+</body></html>

--- a/.claude/skills/specorator-design/preview/components-artifact.html
+++ b/.claude/skills/specorator-design/preview/components-artifact.html
@@ -1,0 +1,20 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"><style>
+body { width: 700px; padding: 22px 28px; background: var(--paper); }
+.art { display: flex; flex-direction: column; border: 1px solid var(--line); border-radius: 12px; background: var(--surface); overflow: hidden; box-shadow: 0 6px 20px rgba(23,32,27,0.04); }
+.head { padding: 12px 16px; border-bottom: 1px solid var(--line); background: rgba(23,32,27,0.04); }
+.step { display: block; margin-bottom: 4px; color: var(--accent-strong); font-size: 10px; font-weight: 800; letter-spacing: 0.1em; text-transform: uppercase; }
+.path { color: var(--muted); font-family: var(--font-mono); font-size: 11px; font-weight: 600; }
+pre { margin: 0; padding: 16px 18px; font-family: var(--font-mono); font-size: 12px; line-height: 1.65; color: var(--ink); white-space: pre-wrap; }
+.h1 { font-weight: 800; }
+.id { display: inline-block; padding: 0 5px; border-radius: 3px; background: rgba(27,111,85,0.1); color: var(--accent-strong); font-weight: 800; }
+.em { color: #8a4a00; font-weight: 700; }
+</style></head><body>
+<figure class="art">
+  <header class="head"><span class="step">Stage 3 · Requirements</span><span class="path">examples/cli-todo/requirements.md</span></header>
+<pre><span class="h1"># Requirements: CLI todo app</span>
+
+<span class="id">REQ-CLI-001</span>
+<span class="em">When</span> the user invokes `todo add`,
+<span class="em">the CLI shall</span> create a new task and persist it.</pre>
+</figure>
+</body></html>

--- a/.claude/skills/specorator-design/preview/components-audience-card.html
+++ b/.claude/skills/specorator-design/preview/components-audience-card.html
@@ -1,0 +1,16 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"><style>
+body { width: 700px; padding: 22px 28px; background: var(--paper); }
+.ac { position: relative; padding: 22px 24px; border: 1px solid var(--line); border-radius: 14px; background: var(--surface); overflow: hidden; }
+.ac::before { content: attr(data-num); position: absolute; top: 8px; right: 18px; color: rgba(23,32,27,0.06); font-size: 64px; font-weight: 850; line-height: 1; letter-spacing: -0.04em; }
+h3 { margin: 0; font-size: 18px; letter-spacing: -0.01em; position: relative; }
+.body { margin: 8px 0 10px; color: var(--muted); font-size: 13px; line-height: 1.55; position: relative; }
+.say { margin: 6px 0 4px; color: var(--muted); font-family: var(--font-mono); font-size: 10px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; position: relative; }
+.cta { display: block; padding: 9px 12px; border-radius: 8px; background: rgba(27,111,85,0.08); color: var(--accent-strong); font-family: var(--font-mono); font-size: 12px; font-weight: 700; position: relative; }
+</style></head><body>
+<article class="ac" data-num="01">
+  <h3>Product managers &amp; designers</h3>
+  <p class="body">Run discovery, shape requirements, review designs, and keep intent explicit. No code required.</p>
+  <p class="say">You'd say</p>
+  <code class="cta">"let's start a feature: user auth"</code>
+</article>
+</body></html>

--- a/.claude/skills/specorator-design/preview/components-buttons.html
+++ b/.claude/skills/specorator-design/preview/components-buttons.html
@@ -1,0 +1,16 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"><style>
+body { width: 700px; padding: 26px 28px; }
+.row { display: flex; gap: 12px; flex-wrap: wrap; align-items: center; }
+.btn { display: inline-flex; align-items: center; min-height: 44px; padding: 0 18px; border: 1px solid var(--ink); border-radius: 8px; font-weight: 760; font-family: var(--font-sans); font-size: 14px; cursor: default; }
+.primary { background: var(--ink); color: #fff; }
+.highlight { background: var(--highlighter); color: var(--ink); border-color: var(--highlighter); }
+.secondary { background: transparent; color: var(--ink); }
+.lbl { display:block; font-family: var(--font-mono); font-size: 10px; color: var(--muted); margin-top: 8px; }
+.col { display: flex; flex-direction: column; gap: 4px; }
+</style></head><body>
+<div class="row">
+  <div class="col"><span class="btn highlight">Get started</span><span class="lbl">.button.highlight · primary CTA</span></div>
+  <div class="col"><span class="btn primary">Read the workflow</span><span class="lbl">.button · default</span></div>
+  <div class="col"><span class="btn secondary">Read the workflow</span><span class="lbl">.button.secondary</span></div>
+</div>
+</body></html>

--- a/.claude/skills/specorator-design/preview/components-panels.html
+++ b/.claude/skills/specorator-design/preview/components-panels.html
@@ -1,0 +1,15 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"><style>
+body { width: 700px; padding: 22px 28px; background: var(--paper); }
+.split { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+.p { padding: 18px 22px; border: 1px solid var(--line); border-radius: 8px; min-height: 130px; }
+.p.problem { background: var(--soft-yellow); }
+.p.solution { background: var(--soft-green); }
+.eb { font-size: 11px; font-weight: 800; letter-spacing: 0.11em; text-transform: uppercase; color: var(--accent-strong); margin: 0 0 6px; }
+h3 { margin: 0 0 8px; font-size: 22px; line-height: 1.08; }
+p { margin: 0; color: var(--muted); font-size: 13px; }
+</style></head><body>
+<div class="split">
+  <article class="p problem"><p class="eb">The problem</p><h3>AI starts in the wrong place.</h3><p>Most assistants jump straight to implementation.</p></article>
+  <article class="p solution"><p class="eb">The product</p><h3>Specs first, code second.</h3><p>Staged artifacts, specialist roles, quality gates.</p></article>
+</div>
+</body></html>

--- a/.claude/skills/specorator-design/preview/components-pills.html
+++ b/.claude/skills/specorator-design/preview/components-pills.html
@@ -1,0 +1,18 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"><style>
+body { width: 700px; padding: 26px 28px; }
+.row { display: flex; gap: 10px; flex-wrap: wrap; align-items: center; margin-bottom: 14px; }
+.row:last-child { margin-bottom: 0; }
+.lbl { font-family: var(--font-mono); font-size: 10px; color: var(--muted); width: 110px; flex: 0 0 110px; }
+.pill { display: inline-flex; align-items: center; gap: 6px; padding: 4px 10px; border-radius: 999px; font-size: 11px; letter-spacing: 0.08em; font-weight: 800; text-transform: uppercase; }
+.pill.status { background: var(--soft-green); color: var(--accent-strong); }
+.pill.status::before { content:""; width: 6px; height: 6px; border-radius: 50%; background: var(--accent); }
+.pill.track { background: var(--soft-green); color: var(--accent-strong); letter-spacing: 0.1em; padding: 3px 9px; font-size: 10px; }
+.lane { padding: 3px 9px; border-radius: 999px; font-size: 10px; font-weight: 800; letter-spacing: 0.12em; text-transform: uppercase; }
+.lane.define { color: var(--accent-strong); background: var(--lane-define-soft); }
+.lane.build  { color: #2d4a73; background: var(--lane-build-soft); }
+.lane.ship   { color: #6b5400; background: var(--lane-ship-soft); }
+</style></head><body>
+<div class="row"><span class="lbl">status</span><span class="pill status">Open-source template</span><span class="pill status">Ready to ship</span></div>
+<div class="row"><span class="lbl">track-when</span><span class="pill track">Pre-brief</span><span class="pill track">Legacy systems</span><span class="pill track">Always-on</span></div>
+<div class="row"><span class="lbl">lane chip</span><span class="lane define">Define</span><span class="lane build">Build</span><span class="lane ship">Ship</span></div>
+</body></html>

--- a/.claude/skills/specorator-design/preview/components-stages.html
+++ b/.claude/skills/specorator-design/preview/components-stages.html
@@ -1,0 +1,20 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"><style>
+body { width: 700px; padding: 24px 28px; background: var(--paper); }
+.row { display: flex; flex-wrap: wrap; gap: 10px; }
+.stage { display: flex; flex-direction: column; gap: 4px; padding: 12px 14px; border: 1px solid var(--line); border-radius: 8px; background: var(--surface); min-width: 130px; align-items: center; }
+.stage .nm { font-size: 13px; font-weight: 760; color: var(--ink); }
+.stage .ow { font-family: var(--font-mono); font-size: 10px; color: var(--muted); }
+.stage.discovery { background: var(--soft-green); }
+.stage.lifecycle { background: var(--soft-blue); }
+.stage.gate      { background: var(--soft-yellow); }
+.stage.gate .ow  { color: #6b5400; }
+.lbl { font-family: var(--font-mono); font-size: 10px; color: var(--muted); margin: 0 0 8px; text-transform: uppercase; letter-spacing: 0.08em; }
+</style></head><body>
+<p class="lbl">Stage chips · 3 variants</p>
+<div class="row">
+  <div class="stage discovery"><span class="nm">Frame</span><span class="ow">product-strategist</span></div>
+  <div class="stage lifecycle"><span class="nm">3. Requirements</span><span class="ow">pm</span></div>
+  <div class="stage gate"><span class="nm">Brief gate</span><span class="ow">human</span></div>
+  <div class="stage lifecycle"><span class="nm">7. Implementation</span><span class="ow">dev</span></div>
+</div>
+</body></html>

--- a/.claude/skills/specorator-design/preview/components-team-card.html
+++ b/.claude/skills/specorator-design/preview/components-team-card.html
@@ -1,0 +1,28 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"><style>
+body { width: 700px; padding: 22px 28px; background: var(--paper); }
+.cards { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+.tc { position: relative; padding: 18px 20px; border: 1px solid var(--line); border-radius: 12px; background: var(--surface); overflow: hidden; }
+.tc::before { content:""; position: absolute; top: 0; left: 0; right: 0; height: 3px; }
+.tc.define::before { background: var(--lane-define); }
+.tc.build::before  { background: var(--lane-build); }
+.head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px; }
+.num { font-family: var(--font-mono); font-size: 12px; font-weight: 700; color: var(--muted); }
+.lane { font-size: 10px; font-weight: 800; letter-spacing: 0.12em; text-transform: uppercase; padding: 3px 9px; border-radius: 999px; }
+.tc.define .lane { color: var(--accent-strong); background: var(--lane-define-soft); }
+.tc.build  .lane { color: #2d4a73; background: var(--lane-build-soft); }
+h3 { margin: 0 0 4px; font-size: 18px; letter-spacing: -0.01em; }
+.agents { margin: 0 0 8px; font-size: 11px; color: var(--muted); }
+.agents code { display: inline-block; padding: 2px 7px; border-radius: 5px; background: rgba(23,32,27,.06); color: var(--ink); font-family: var(--font-mono); font-size: 11px; font-weight: 700; }
+.desc { margin: 0; color: var(--muted); font-size: 12.5px; line-height: 1.5; }
+</style></head><body>
+<div class="cards">
+  <article class="tc define"><div class="head"><span class="num">01</span><span class="lane">Define</span></div>
+    <h3>Analyst</h3>
+    <p class="agents"><code>analyst</code></p>
+    <p class="desc">Frames the problem. Runs idea capture, research, and discovery sprints.</p></article>
+  <article class="tc build"><div class="head"><span class="num">06</span><span class="lane">Build</span></div>
+    <h3>Developer</h3>
+    <p class="agents"><code>dev</code></p>
+    <p class="desc">Writes the code. Implements from task specs with TDD discipline.</p></article>
+</div>
+</body></html>

--- a/.claude/skills/specorator-design/preview/components-terminal.html
+++ b/.claude/skills/specorator-design/preview/components-terminal.html
@@ -1,0 +1,18 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"><style>
+body { width: 700px; padding: 22px 28px; background: var(--paper); }
+.term { border: 1px solid rgba(216,222,211,0.18); border-radius: 10px; overflow: hidden; background: #0e1512; box-shadow: 0 12px 28px rgba(0,0,0,0.35); }
+.chrome { display: flex; align-items: center; gap: 7px; padding: 10px 14px; border-bottom: 1px solid rgba(216,222,211,0.08); background: rgba(255,255,255,0.03); }
+.dot { width: 11px; height: 11px; border-radius: 50%; }
+.r { background: #ff5f57; } .y { background: #febc2e; } .g { background: #28c840; }
+.title { margin-left: 10px; color: rgba(248,250,245,0.55); font-family: var(--font-mono); font-size: 11px; }
+pre { margin: 0; padding: 16px 18px; color: #f8faf5; font-family: var(--font-mono); font-size: 13px; line-height: 1.6; }
+</style></head><body>
+<figure class="term">
+  <header class="chrome"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="title">my-project — claude</span></header>
+  <pre>git clone https://github.com/Luis85/agentic-workflow.git my-project
+cd my-project
+npm install
+npm run verify
+claude</pre>
+</figure>
+</body></html>

--- a/.claude/skills/specorator-design/preview/iconography.html
+++ b/.claude/skills/specorator-design/preview/iconography.html
@@ -1,0 +1,17 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"><style>
+body { width: 700px; padding: 22px 28px; background: var(--paper); }
+.row { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; margin-bottom: 12px; }
+.row:last-child { margin-bottom: 0; }
+.lbl { font-family: var(--font-mono); font-size: 10px; color: var(--muted); width: 90px; flex: 0 0 90px; text-transform: uppercase; letter-spacing: 0.06em; }
+.arrow { font-size: 18px; color: var(--accent-strong); font-weight: 700; }
+.dot { color: rgba(89,100,94,.45); margin: 0 4px; }
+.code { font-family: var(--font-mono); font-size: 12px; color: var(--ink); background: rgba(23,32,27,0.06); padding: 2px 7px; border-radius: 6px; font-weight: 700; }
+.step-num { display: inline-grid; width: 28px; height: 28px; place-items: center; border-radius: 50%; background: var(--highlighter); color: var(--ink); font-weight: 850; font-size: 13px; }
+.note { color: var(--muted); font-size: 11px; }
+</style></head><body>
+<div class="row"><span class="lbl">arrow</span><span class="arrow">→</span><span class="note">U+2192 · used in "more" links and copy</span></div>
+<div class="row"><span class="lbl">middot</span><span class="dot">·</span><span class="note">U+00B7 · separates eyebrow meta items</span></div>
+<div class="row"><span class="lbl">command</span><span class="code">/spec:start</span><span class="code">/discovery:converge</span><span class="note">monospace chip = action</span></div>
+<div class="row"><span class="lbl">step num</span><span class="step-num">1</span><span class="step-num">2</span><span class="step-num">3</span><span class="note">chartreuse circle, 850 weight</span></div>
+<div class="row"><span class="lbl">no emoji</span><span class="note">— intentionally absent. No icon font, no Lucide. The brand voice is the iconography.</span></div>
+</body></html>

--- a/.claude/skills/specorator-design/preview/radius.html
+++ b/.claude/skills/specorator-design/preview/radius.html
@@ -1,0 +1,14 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"><style>
+body { width: 700px; padding: 22px 28px; }
+.grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 14px; }
+.demo { background: var(--surface); border: 1px solid var(--line); height: 64px; display: flex; align-items: center; justify-content: center; font-family: var(--font-mono); font-size: 11px; color: var(--muted); }
+.lbl { display: block; font-family: var(--font-mono); font-size: 10px; color: var(--muted); margin-top: 6px; text-align: center; }
+</style></head><body>
+<div class="grid">
+  <div><div class="demo" style="border-radius: 6px">6</div><span class="lbl">--r-sm · chips</span></div>
+  <div><div class="demo" style="border-radius: 8px">8</div><span class="lbl">--r-md · panels</span></div>
+  <div><div class="demo" style="border-radius: 12px">12</div><span class="lbl">--r-lg · cards</span></div>
+  <div><div class="demo" style="border-radius: 14px">14</div><span class="lbl">--r-xl · audience</span></div>
+  <div><div class="demo" style="border-radius: 28px">28</div><span class="lbl">--r-2xl · hero</span></div>
+</div>
+</body></html>

--- a/.claude/skills/specorator-design/preview/shadows.html
+++ b/.claude/skills/specorator-design/preview/shadows.html
@@ -1,0 +1,14 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"><style>
+body { width: 700px; padding: 28px; background: var(--paper); }
+.grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+.tile { background: var(--surface); border-radius: 12px; height: 90px; display: flex; align-items: end; padding: 12px; font-family: var(--font-mono); font-size: 10px; color: var(--muted); }
+.t1 { box-shadow: 0 6px 20px rgba(23, 32, 27, 0.04); }
+.t2 { box-shadow: 0 12px 30px rgba(23, 32, 27, 0.08); }
+.t3 { box-shadow: 0 24px 70px rgba(23, 32, 27, 0.13); }
+</style></head><body>
+<div class="grid">
+  <div class="tile t1">--shadow-sm · artifact-card</div>
+  <div class="tile t2">--shadow-md · card hover</div>
+  <div class="tile t3">--shadow-hero · hero visual</div>
+</div>
+</body></html>

--- a/.claude/skills/specorator-design/preview/spacing-scale.html
+++ b/.claude/skills/specorator-design/preview/spacing-scale.html
@@ -1,0 +1,14 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"><style>
+body { width: 700px; padding: 22px 28px; }
+.row { display: flex; align-items: center; gap: 16px; margin-bottom: 12px; }
+.bar { background: var(--accent); border-radius: 4px; height: 18px; }
+.lbl { font-family: var(--font-mono); font-size: 11px; color: var(--muted); width: 90px; flex: 0 0 90px; }
+.val { font-family: var(--font-mono); font-size: 11px; color: var(--ink); }
+</style></head><body>
+<div class="row"><span class="lbl">--space-2</span><div class="bar" style="width: 8px"></div><span class="val">8 px</span></div>
+<div class="row"><span class="lbl">--space-3</span><div class="bar" style="width: 12px"></div><span class="val">12 px</span></div>
+<div class="row"><span class="lbl">card-pad</span><div class="bar" style="width: 22px"></div><span class="val">22 px</span></div>
+<div class="row"><span class="lbl">panel-pad</span><div class="bar" style="width: 42px"></div><span class="val">26–42 px (clamp)</span></div>
+<div class="row"><span class="lbl">page-gutter</span><div class="bar" style="width: 72px"></div><span class="val">20–72 px (clamp)</span></div>
+<div class="row"><span class="lbl">section-gutter</span><div class="bar" style="width: 104px"></div><span class="val">56–104 px (clamp)</span></div>
+</body></html>

--- a/.claude/skills/specorator-design/preview/type-display.html
+++ b/.claude/skills/specorator-design/preview/type-display.html
@@ -1,0 +1,11 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"><style>
+body { width: 700px; }
+.spec { padding: 22px 28px 26px; background: var(--paper); }
+.disp { font-size: 64px; font-weight: 800; line-height: 0.98; letter-spacing: -0.015em; margin: 0; max-width: 17ch; }
+.meta { font-family: var(--font-mono); font-size: 10px; color: var(--muted); margin-top: 8px; }
+</style></head><body>
+<div class="spec">
+  <p class="disp">Stop letting AI write the wrong code.</p>
+  <p class="meta">Inter · 800 · clamp(44, 6.6vw, 84) · line 0.98 · letter -0.015</p>
+</div>
+</body></html>

--- a/.claude/skills/specorator-design/preview/type-mono.html
+++ b/.claude/skills/specorator-design/preview/type-mono.html
@@ -1,0 +1,16 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"><style>
+body { width: 700px; padding: 22px 28px;}
+.row { display: flex; align-items: baseline; gap: 16px; padding: 8px 0; border-bottom: 1px dashed var(--line); }
+.lbl { font-family: var(--font-mono); font-size: 10px; color: var(--muted); width: 80px; flex: 0 0 80px; }
+.mono { font-family: var(--font-mono); font-size: 14px; color: var(--ink); }
+.idtok { display: inline-block; padding: 0 5px; border-radius: 3px; background: rgba(27, 111, 85, 0.1); color: var(--accent-strong); font-family: var(--font-mono); font-weight: 800; font-size: 13px; }
+.chip { display: inline-block; padding: 2px 7px; border-radius: 6px; background: rgba(23,32,27,0.06); color: var(--ink); font-family: var(--font-mono); font-size: 12px; font-weight: 700; }
+.chipd { display: inline-block; padding: 4px 10px; border-radius: 6px; background: rgba(230,255,112,0.1); color: var(--highlighter); font-family: var(--font-mono); font-size: 12px; font-weight: 700; }
+.dark { background: var(--ink); padding: 8px 12px; border-radius: 6px; display: inline-block;}
+</style></head><body>
+<div class="row"><span class="lbl">mono</span><span class="mono">JetBrains Mono · 12–14</span></div>
+<div class="row"><span class="lbl">command</span><span class="chip">/spec:start</span> <span class="chip">/discovery:converge</span></div>
+<div class="row"><span class="lbl">id token</span><span class="idtok">REQ-CLI-001</span> <span class="idtok">T-AUTH-014</span> <span class="idtok">ADR-0009</span></div>
+<div class="row"><span class="lbl">file path</span><span class="mono" style="color:var(--muted); font-size: 12px;">specs/&lt;feature&gt;/workflow-state.md</span></div>
+<div class="row"><span class="lbl">on dark</span><span class="dark"><span class="chipd">analyst</span></span> <span class="dark"><span class="chipd">orchestrator</span></span></div>
+</body></html>

--- a/.claude/skills/specorator-design/preview/type-scale.html
+++ b/.claude/skills/specorator-design/preview/type-scale.html
@@ -1,0 +1,22 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"><style>
+body { width: 700px; }
+.spec { padding: 22px 28px; }
+.row { display: flex; align-items: baseline; gap: 16px; padding: 6px 0; border-bottom: 1px dashed var(--line); }
+.row:last-child { border-bottom: 0; }
+.lbl { font-family: var(--font-mono); font-size: 10px; color: var(--muted); width: 110px; flex: 0 0 110px; }
+.h2 { font-size: 38px; font-weight: 800; line-height: 1.02; margin: 0; }
+.h3 { font-size: 22px; font-weight: 800; letter-spacing: -0.01em; margin: 0; }
+.lead { font-size: 20px; color: var(--muted); line-height: 1.4; margin: 0; }
+.body { font-size: 16px; margin: 0; }
+.cap  { font-size: 14px; color: var(--muted); margin: 0; }
+.eb { font-size: 13px; font-weight: 800; letter-spacing: 0.11em; text-transform: uppercase; color: var(--accent-strong); margin: 0; }
+</style></head><body>
+<div class="spec">
+  <div class="row"><span class="lbl">eyebrow / 13</span><p class="eb">Open-source template</p></div>
+  <div class="row"><span class="lbl">h2 / 38–58</span><p class="h2">A specialist for every stage.</p></div>
+  <div class="row"><span class="lbl">h3 / 22</span><p class="h3">11-stage lifecycle</p></div>
+  <div class="row"><span class="lbl">lead / 20–24</span><p class="lead">Specs first, code second. You decide what to build.</p></div>
+  <div class="row"><span class="lbl">body / 16</span><p class="body">Fork it, adapt it, make it yours.</p></div>
+  <div class="row"><span class="lbl">caption / 14</span><p class="cap">MIT licensed.</p></div>
+</div>
+</body></html>

--- a/.claude/skills/specorator-design/slides/ArtifactSlide.jsx
+++ b/.claude/skills/specorator-design/slides/ArtifactSlide.jsx
@@ -1,0 +1,99 @@
+// ArtifactSlide.jsx — three markdown specimens, the trace chain
+function ArtifactCard({ step, path, code }) {
+  return (
+    <figure style={{
+      background: "var(--surface)",
+      border: "1px solid var(--line)",
+      borderRadius: 12,
+      padding: 0,
+      display: "flex",
+      flexDirection: "column",
+      overflow: "hidden",
+    }}>
+      <header style={{
+        padding: "20px 24px",
+        borderBottom: "1px solid var(--line)",
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+      }}>
+        <span className="mono" style={{fontSize: 13, color: "var(--accent-strong)", textTransform: "uppercase", letterSpacing: "0.1em", fontWeight: 800}}>{step}</span>
+        <code className="mono" style={{fontSize: 16, color: "var(--ink)"}}>{path}</code>
+      </header>
+      <pre className="mono" style={{
+        margin: 0,
+        padding: "24px 28px",
+        fontSize: 15,
+        lineHeight: 1.55,
+        color: "var(--ink)",
+        flex: 1,
+        background: "var(--paper)",
+        whiteSpace: "pre-wrap",
+      }} dangerouslySetInnerHTML={{__html: code}} />
+    </figure>
+  );
+}
+
+const A_IDEA =
+`<span style="color:var(--accent-strong);font-weight:700"># Idea: CLI todo app</span>
+
+<span style="color:var(--accent-strong);font-weight:700">## Brief</span>
+Solo engineers want to capture, list,
+and complete short-lived tasks without
+leaving the shell.
+
+<span style="color:var(--accent-strong);font-weight:700">## Outcome</span>
+A \`todo\` binary with add, list, done,
+rm. First add → list → done in
+under two minutes.`;
+
+const A_REQ =
+`<span style="color:var(--accent-strong);font-weight:700"># Requirements: CLI todo app</span>
+
+<span style="background:var(--soft-blue);color:#22397a;font-weight:700;padding:1px 6px;border-radius:4px">REQ-CLI-001</span>
+<span style="font-style:italic">When</span> the user invokes \`todo add\`
+with a non-empty text argument,
+<span style="font-style:italic">the CLI shall</span> create a new task
+with a unique sequential ID and persist
+it for later \`todo list\` calls.
+
+<span style="background:var(--soft-blue);color:#22397a;font-weight:700;padding:1px 6px;border-radius:4px">REQ-CLI-002</span>
+<span style="font-style:italic">When</span> the user invokes \`todo list\`,
+<span style="font-style:italic">the CLI shall</span> display every open
+task on its own line.`;
+
+const A_TASKS =
+`<span style="color:var(--accent-strong);font-weight:700"># Tasks: CLI todo app</span>
+
+<span style="background:var(--soft-yellow);color:#8a6309;font-weight:700;padding:1px 6px;border-radius:4px">T-CLI-007</span>  Command behavior tests
+  owner: qa    → <span style="background:var(--soft-blue);color:#22397a;font-weight:700;padding:1px 6px;border-radius:4px">REQ-CLI-001</span>, <span style="background:var(--soft-blue);color:#22397a;font-weight:700;padding:1px 6px;border-radius:4px">REQ-CLI-002</span>
+
+<span style="background:var(--soft-yellow);color:#8a6309;font-weight:700;padding:1px 6px;border-radius:4px">T-CLI-008</span>  Implement task commands
+  owner: dev   → <span style="background:var(--soft-blue);color:#22397a;font-weight:700;padding:1px 6px;border-radius:4px">REQ-CLI-001</span>, <span style="background:var(--soft-blue);color:#22397a;font-weight:700;padding:1px 6px;border-radius:4px">REQ-CLI-002</span>
+
+<span style="background:var(--soft-yellow);color:#8a6309;font-weight:700;padding:1px 6px;border-radius:4px">T-CLI-009</span>  Review and traceability
+  owner: dev   → <span style="background:var(--soft-blue);color:#22397a;font-weight:700;padding:1px 6px;border-radius:4px">REQ-CLI-001</span>, <span style="background:var(--soft-blue);color:#22397a;font-weight:700;padding:1px 6px;border-radius:4px">REQ-CLI-002</span>`;
+
+function ArtifactSlide() {
+  return (
+    <section data-screen-label="05 Artifact chain" className="bg-paper">
+      <SlideCorner kicker="EXAMPLE · 05 / 06" />
+      <div className="slide-pad" style={{paddingTop: 160}}>
+        <Eyebrow>Example · cli-todo</Eyebrow>
+        <h2 className="h-title" style={{maxWidth: 1600, marginBottom: 48, fontSize: 76}}>
+          From a one-line brief to working code.
+        </h2>
+        <div style={{display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 28, flex: 1, minHeight: 0}}>
+          <ArtifactCard step="Stage 1 · Idea" path="examples/cli-todo/idea.md" code={A_IDEA} />
+          <ArtifactCard step="Stage 3 · Requirements" path="examples/cli-todo/requirements.md" code={A_REQ} />
+          <ArtifactCard step="Stage 6 · Tasks" path="examples/cli-todo/tasks.md" code={A_TASKS} />
+        </div>
+        <p style={{marginTop: 32, fontSize: 22, color: "var(--muted)", maxWidth: 1500}}>
+          Every requirement carries a stable ID that flows forward &mdash; <code className="mono" style={{color: "var(--accent-strong)"}}>REQ</code> to <code className="mono" style={{color: "var(--accent-strong)"}}>T</code> to <code className="mono" style={{color: "var(--accent-strong)"}}>TEST</code>. Nothing ships without a chain.
+        </p>
+      </div>
+      <SlideFoot left={<BrandMini />} right={<span>05 / 06</span>} />
+    </section>
+  );
+}
+window.ArtifactSlide = ArtifactSlide;

--- a/.claude/skills/specorator-design/slides/ClosingSlide.jsx
+++ b/.claude/skills/specorator-design/slides/ClosingSlide.jsx
@@ -1,0 +1,76 @@
+// ClosingSlide.jsx — call to action with terminal quickstart
+function ClosingSlide() {
+  return (
+    <section data-screen-label="06 Closing" className="bg-ink">
+      <SlideCorner kicker="GET STARTED · 06 / 06" />
+      <div className="slide-pad" style={{paddingTop: 200, justifyContent: "center"}}>
+        <div style={{display: "grid", gridTemplateColumns: "1fr 1fr", gap: 96, alignItems: "center"}}>
+          <div>
+            <Eyebrow>Get started in one repository</Eyebrow>
+            <h2 className="h-title" style={{color: "var(--on-ink)", maxWidth: 850, fontSize: 96}}>
+              Clone, personalize, ship.
+            </h2>
+            <p className="lead" style={{marginTop: 40, maxWidth: 750}}>
+              Fork the repo, adapt the steering docs, and start a feature through natural language or slash commands.
+            </p>
+            <div style={{display: "flex", gap: 20, marginTop: 56, alignItems: "center"}}>
+              <a style={{
+                display: "inline-flex",
+                alignItems: "center",
+                background: "var(--highlighter)",
+                color: "var(--ink)",
+                padding: "22px 40px",
+                borderRadius: 8,
+                fontWeight: 760,
+                fontSize: 24,
+                textDecoration: "none",
+                border: "1px solid var(--highlighter)",
+              }}>Get started</a>
+              <span className="mono" style={{fontSize: 20, color: "var(--on-ink-mute)"}}>github.com/Luis85/agentic-workflow</span>
+            </div>
+          </div>
+          <figure style={{
+            background: "var(--ink-soft)",
+            borderRadius: 12,
+            border: "1px solid rgba(248, 250, 245, 0.12)",
+            overflow: "hidden",
+            boxShadow: "0 24px 60px rgba(0,0,0,0.5)",
+          }}>
+            <header style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 10,
+              padding: "16px 20px",
+              borderBottom: "1px solid rgba(248, 250, 245, 0.08)",
+              background: "rgba(255,255,255,0.02)",
+            }}>
+              <span style={{width: 14, height: 14, borderRadius: 999, background: "#ff5f57"}}></span>
+              <span style={{width: 14, height: 14, borderRadius: 999, background: "#febc2e"}}></span>
+              <span style={{width: 14, height: 14, borderRadius: 999, background: "#28c840"}}></span>
+              <span className="mono" style={{marginLeft: 16, fontSize: 16, color: "var(--on-ink-dim)"}}>my-project &mdash; claude</span>
+            </header>
+            <pre className="mono" style={{
+              margin: 0,
+              padding: "32px 36px",
+              fontSize: 22,
+              lineHeight: 1.65,
+              color: "var(--on-ink)",
+              whiteSpace: "pre",
+            }}>
+{`$ git clone https://github.com/Luis85/agentic-workflow.git my-project
+$ cd my-project
+$ npm install
+$ npm run verify
+$ claude`}
+            </pre>
+          </figure>
+        </div>
+      </div>
+      <SlideFoot
+        left={<BrandMini />}
+        right={<span>specs first &middot; code second</span>}
+      />
+    </section>
+  );
+}
+window.ClosingSlide = ClosingSlide;

--- a/.claude/skills/specorator-design/slides/CoverSlide.jsx
+++ b/.claude/skills/specorator-design/slides/CoverSlide.jsx
@@ -1,0 +1,22 @@
+// CoverSlide.jsx — opening title slide
+function CoverSlide() {
+  return (
+    <section data-screen-label="01 Cover" className="bg-paper">
+      <SlideCorner kicker="OPEN-SOURCE TEMPLATE · MIT" />
+      <div className="slide-pad" style={{justifyContent: "center", paddingTop: 240}}>
+        <Eyebrow>The agentic-workflow repo</Eyebrow>
+        <h1 className="h-display" style={{maxWidth: 1500}}>
+          Stop letting AI write the wrong code.
+        </h1>
+        <p className="lead" style={{marginTop: 56, maxWidth: 1100}}>
+          Specs first, code second. You decide <em style={{fontStyle: "italic", color: "var(--ink)"}}>what</em> to build; specialist agents handle <em style={{fontStyle: "italic", color: "var(--ink)"}}>how</em>; every decision stays traceable.
+        </p>
+      </div>
+      <SlideFoot
+        left={<span>luis85.github.io/agentic-workflow</span>}
+        right={<span>v0.2 — May 2026</span>}
+      />
+    </section>
+  );
+}
+window.CoverSlide = CoverSlide;

--- a/.claude/skills/specorator-design/slides/ProblemSolutionSlide.jsx
+++ b/.claude/skills/specorator-design/slides/ProblemSolutionSlide.jsx
@@ -1,0 +1,38 @@
+// ProblemSolutionSlide.jsx — two-up colored panels (matches WhyPanels component)
+function ProblemSolutionSlide() {
+  return (
+    <section data-screen-label="02 Problem and solution" className="bg-paper">
+      <SlideCorner kicker="WHY · 02 / 06" />
+      <div className="slide-pad" style={{paddingTop: 160, justifyContent: "center"}}>
+        <div style={{display: "grid", gridTemplateColumns: "1fr 1fr", gap: 48}}>
+          <article style={{background: "var(--soft-yellow)", borderRadius: 8, padding: "72px 64px", border: "1px solid var(--line)"}}>
+            <p className="eyebrow" style={{color: "#8a6309"}}>
+              <span className="dot"></span>
+              <span>The problem</span>
+            </p>
+            <h2 className="h-title" style={{fontSize: 76, marginTop: 16}}>
+              AI coding tools often start in the wrong place.
+            </h2>
+            <p className="lead" style={{marginTop: 40, color: "var(--ink)", fontSize: 28}}>
+              Most assistants jump straight to implementation. That can produce code quickly, but it also bakes in unclear requirements, missing decisions, and late-stage rework.
+            </p>
+          </article>
+          <article style={{background: "var(--soft-green)", borderRadius: 8, padding: "72px 64px", border: "1px solid var(--line)"}}>
+            <p className="eyebrow">
+              <span className="dot"></span>
+              <span>The product</span>
+            </p>
+            <h2 className="h-title" style={{fontSize: 76, marginTop: 16}}>
+              Specs first, code second.
+            </h2>
+            <p className="lead" style={{marginTop: 40, color: "var(--ink)", fontSize: 28}}>
+              Specorator turns software work into staged artifacts, specialist roles, quality gates, and traceable decisions so agents can move fast without guessing what humans meant.
+            </p>
+          </article>
+        </div>
+      </div>
+      <SlideFoot left={<BrandMini />} right={<span>02 / 06</span>} />
+    </section>
+  );
+}
+window.ProblemSolutionSlide = ProblemSolutionSlide;

--- a/.claude/skills/specorator-design/slides/Shared.jsx
+++ b/.claude/skills/specorator-design/slides/Shared.jsx
@@ -1,0 +1,47 @@
+// Shared.jsx — small helpers used across slides
+function BrandMini({ label = "specorator" }) {
+  return (
+    <span className="brand-mini">
+      <span className="glyph">S</span>
+      <span>{label}</span>
+    </span>
+  );
+}
+
+function SlideCorner({ kicker, brand = true }) {
+  return (
+    <div className="slide-corner">
+      {brand ? <BrandMini /> : <span></span>}
+      {kicker ? <span>{kicker}</span> : null}
+    </div>
+  );
+}
+
+function SlideFoot({ left, right }) {
+  return (
+    <div className="slide-foot">
+      <span className="slide-meta">{left}</span>
+      <span className="slide-meta">{right}</span>
+    </div>
+  );
+}
+
+function Eyebrow({ children }) {
+  return (
+    <p className="eyebrow">
+      <span className="dot"></span>
+      <span>{children}</span>
+    </p>
+  );
+}
+
+function StatusPill({ children }) {
+  return (
+    <span className="status-pill">
+      <span className="pill-dot"></span>
+      <span>{children}</span>
+    </span>
+  );
+}
+
+Object.assign(window, { BrandMini, SlideCorner, SlideFoot, Eyebrow, StatusPill });

--- a/.claude/skills/specorator-design/slides/TeamGridSlide.jsx
+++ b/.claude/skills/specorator-design/slides/TeamGridSlide.jsx
@@ -1,0 +1,52 @@
+// TeamGridSlide.jsx — 8 lane-coded team cards
+const TEAM_SLIDE = [
+  ["01", "define", "Analyst", "analyst", "Frames the problem; runs idea capture and research."],
+  ["02", "define", "Product Manager", "pm", "Owns EARS-format requirements and scope."],
+  ["03", "define", "Designer", "ux-designer · ui-designer", "Flows, IA, tokens, microcopy."],
+  ["04", "define", "Architect", "architect", "Files ADRs; produces implementation-ready spec."],
+  ["05", "build",  "Planner", "planner", "Breaks the spec into TDD-ordered tasks."],
+  ["06", "build",  "Developer", "dev", "Implements with TDD discipline; never invents requirements."],
+  ["07", "build",  "QA", "qa", "Test plan + suite; every EARS clause has a test."],
+  ["08", "ship",   "Reviewer & Release", "reviewer · release-manager · retrospective", "Diff review, release readiness, mandatory retro."],
+];
+const LANE_LABEL_S = { define: "Define", build: "Build", ship: "Ship" };
+const LANE_FG = { define: "var(--lane-define)", build: "var(--lane-build)", ship: "var(--lane-ship)" };
+
+function TeamGridSlide() {
+  return (
+    <section data-screen-label="04 Team grid" className="bg-surface2">
+      <SlideCorner kicker="TEAM · 04 / 06" />
+      <div className="slide-pad" style={{paddingTop: 160}}>
+        <Eyebrow>Eight role families</Eyebrow>
+        <h2 className="h-title" style={{maxWidth: 1500, marginBottom: 56}}>
+          A specialist for every stage.
+        </h2>
+
+        <div style={{display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 22, flex: 1}}>
+          {TEAM_SLIDE.map(([num, lane, title, agents, desc]) => (
+            <article key={num} style={{
+              background: "var(--surface)",
+              border: "1px solid var(--line)",
+              borderTop: `4px solid ${LANE_FG[lane]}`,
+              borderRadius: 12,
+              padding: "28px 28px 32px",
+              display: "flex",
+              flexDirection: "column",
+              gap: 14,
+            }}>
+              <header style={{display: "flex", justifyContent: "space-between", alignItems: "center"}}>
+                <span className="mono" style={{fontSize: 18, fontWeight: 800, color: "var(--ink)"}}>{num}</span>
+                <span className={`lane-chip lane-${lane}`} style={{fontSize: 12, padding: "6px 12px"}}>{LANE_LABEL_S[lane]}</span>
+              </header>
+              <h3 style={{fontSize: 28, fontWeight: 760, lineHeight: 1.1, letterSpacing: "-0.01em"}}>{title}</h3>
+              <code className="mono" style={{fontSize: 16, color: "var(--accent-strong)", background: "rgba(23,32,27,0.06)", padding: "4px 8px", borderRadius: 6, alignSelf: "flex-start"}}>{agents}</code>
+              <p style={{fontSize: 18, lineHeight: 1.45, color: "var(--muted)", marginTop: 4}}>{desc}</p>
+            </article>
+          ))}
+        </div>
+      </div>
+      <SlideFoot left={<BrandMini />} right={<span>04 / 06</span>} />
+    </section>
+  );
+}
+window.TeamGridSlide = TeamGridSlide;

--- a/.claude/skills/specorator-design/slides/WorkflowSlide.jsx
+++ b/.claude/skills/specorator-design/slides/WorkflowSlide.jsx
@@ -1,0 +1,84 @@
+// WorkflowSlide.jsx — Discovery + Lifecycle stage rails
+const WF_DISCOVERY = [
+  ["Frame", "product-strategist"],
+  ["Diverge", "divergent-thinker"],
+  ["Converge", "critic"],
+  ["Prototype", "prototyper"],
+  ["Validate", "user-researcher"],
+  ["Brief gate", "human"],
+];
+const WF_LIFECYCLE = [
+  ["1. Idea", "analyst"],
+  ["2. Research", "analyst"],
+  ["3. Requirements", "pm"],
+  ["4. Design", "ux/ui/architect"],
+  ["5. Specification", "architect"],
+  ["6. Tasks", "planner"],
+  ["7. Implementation", "dev"],
+  ["8. Testing", "qa"],
+  ["9. Review", "reviewer"],
+  ["10. Release", "release-manager"],
+  ["11. Retro", "retrospective"],
+];
+
+function WfStage({ name, owner, kind }) {
+  const bg = kind === "discovery" ? "var(--soft-green)" : kind === "gate" ? "var(--soft-yellow)" : "var(--soft-blue)";
+  const fg = kind === "discovery" ? "var(--accent-strong)" : kind === "gate" ? "#8a6309" : "#22397a";
+  return (
+    <div style={{
+      background: bg,
+      borderRadius: 8,
+      padding: "16px 18px",
+      flex: "1 1 0",
+      minWidth: 0,
+      display: "flex",
+      flexDirection: "column",
+      gap: 6,
+    }}>
+      <span style={{fontWeight: 760, fontSize: 19, color: "var(--ink)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis"}}>{name}</span>
+      <span className="mono" style={{fontSize: 14, color: fg, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis"}}>{owner}</span>
+    </div>
+  );
+}
+
+function WorkflowSlide() {
+  return (
+    <section data-screen-label="03 Workflow rails" className="bg-paper">
+      <SlideCorner kicker="WORKFLOW · 03 / 06" />
+      <div className="slide-pad" style={{paddingTop: 140, paddingBottom: 140}}>
+        <Eyebrow>Two tracks, one source of truth</Eyebrow>
+        <h2 className="h-title" style={{maxWidth: 1500, marginBottom: 24, fontSize: 80}}>
+          Discovery creates the brief. The lifecycle ships it.
+        </h2>
+        <p className="lead" style={{marginBottom: 64}}>
+          Each stage produces an artifact, passes a quality gate, and hands off cleanly to the next.
+        </p>
+
+        <div style={{display: "flex", flexDirection: "column", gap: 36}}>
+          <div>
+            <div style={{display: "flex", alignItems: "baseline", gap: 18, marginBottom: 16}}>
+              <span style={{fontSize: 24, fontWeight: 800}}>Discovery</span>
+              <span className="mono" style={{fontSize: 14, color: "var(--muted)", textTransform: "uppercase", letterSpacing: "0.1em"}}>optional</span>
+            </div>
+            <div style={{display: "flex", gap: 12}}>
+              {WF_DISCOVERY.map(([n, o]) => (
+                <WfStage key={n} name={n} owner={o} kind={n === "Brief gate" ? "gate" : "discovery"} />
+              ))}
+            </div>
+          </div>
+          <div>
+            <div style={{display: "flex", alignItems: "baseline", gap: 18, marginBottom: 16}}>
+              <span style={{fontSize: 24, fontWeight: 800}}>Lifecycle</span>
+              <span className="mono" style={{fontSize: 14, color: "var(--muted)", textTransform: "uppercase", letterSpacing: "0.1em"}}>11 stages</span>
+            </div>
+            <div style={{display: "flex", gap: 12}}>
+              {WF_LIFECYCLE.map(([n, o]) => <WfStage key={n} name={n} owner={o} kind="lifecycle" />)}
+            </div>
+          </div>
+        </div>
+      </div>
+      <SlideFoot left={<BrandMini />} right={<span>03 / 06</span>} />
+    </section>
+  );
+}
+window.WorkflowSlide = WorkflowSlide;

--- a/.claude/skills/specorator-design/slides/app.jsx
+++ b/.claude/skills/specorator-design/slides/app.jsx
@@ -1,0 +1,19 @@
+// app.jsx — deck composition
+// 6-slide default. QuoteSlide / SectionDividerSlide / StatsSlide are kept as
+// reusable components for longer decks but excluded from the canonical deck.
+function Deck() {
+  return (
+    <React.Fragment>
+      <CoverSlide />
+      <ProblemSolutionSlide />
+      <WorkflowSlide />
+      <TeamGridSlide />
+      <ArtifactSlide />
+      <ClosingSlide />
+    </React.Fragment>
+  );
+}
+
+const stage = document.querySelector("deck-stage");
+const root = ReactDOM.createRoot(stage);
+root.render(<Deck />);

--- a/.claude/skills/specorator-design/slides/assets/specorator-mark.svg
+++ b/.claude/skills/specorator-design/slides/assets/specorator-mark.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Specorator mark">
+  <rect width="64" height="64" rx="14" fill="#17201B"></rect>
+  <path d="M20 24c0-6 5-10 14-10 6 0 11 2 15 5l-5 6c-3-2-6-3-10-3-4 0-6 1-6 3 0 2 2 3 8 4 10 2 15 5 15 12 0 7-6 11-16 11-7 0-13-2-17-6l5-6c4 3 8 4 13 4 5 0 7-1 7-3 0-2-2-3-8-4-10-2-15-5-15-13Z" fill="#E6FF70"></path>
+</svg>

--- a/.claude/skills/specorator-design/slides/assets/specorator-workflow.svg
+++ b/.claude/skills/specorator-design/slides/assets/specorator-workflow.svg
@@ -1,0 +1,65 @@
+<svg width="1040" height="720" viewBox="0 0 1040 720" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Specorator workflow artifact map</title>
+  <desc id="desc">A product-style workflow visual showing discovery, lifecycle stages, quality gates, and traceability artifacts.</desc>
+  <rect width="1040" height="720" rx="28" fill="#F7F8F4"></rect>
+  <rect x="48" y="44" width="944" height="632" rx="24" fill="#FFFFFF" stroke="#D8DED3" stroke-width="2"></rect>
+  <rect x="84" y="80" width="872" height="88" rx="18" fill="#17201B"></rect>
+  <text x="116" y="119" fill="#FAFBF8" font-family="Inter, Arial, sans-serif" font-size="28" font-weight="700">Specorator</text>
+  <text x="116" y="146" fill="#C7D5CD" font-family="Inter, Arial, sans-serif" font-size="16">Specs first. Agents in lanes. Quality gates before code moves.</text>
+  <rect x="766" y="104" width="154" height="40" rx="20" fill="#E6FF70"></rect>
+  <text x="804" y="130" fill="#17201B" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700">Ready to ship</text>
+
+  <text x="88" y="224" fill="#58635E" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing=".12em">DISCOVERY TRACK</text>
+  <rect x="84" y="244" width="136" height="74" rx="14" fill="#E6F6EF" stroke="#A8D9C4"></rect>
+  <text x="116" y="277" fill="#17201B" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="700">Frame</text>
+  <text x="111" y="299" fill="#59645E" font-family="Inter, Arial, sans-serif" font-size="13">Problem space</text>
+  <rect x="244" y="244" width="136" height="74" rx="14" fill="#E6F6EF" stroke="#A8D9C4"></rect>
+  <text x="275" y="277" fill="#17201B" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="700">Diverge</text>
+  <text x="280" y="299" fill="#59645E" font-family="Inter, Arial, sans-serif" font-size="13">Options</text>
+  <rect x="404" y="244" width="136" height="74" rx="14" fill="#E6F6EF" stroke="#A8D9C4"></rect>
+  <text x="433" y="277" fill="#17201B" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="700">Converge</text>
+  <text x="440" y="299" fill="#59645E" font-family="Inter, Arial, sans-serif" font-size="13">Brief</text>
+  <path d="M220 281H244" stroke="#7EA793" stroke-width="3" stroke-linecap="round"></path>
+  <path d="M380 281H404" stroke="#7EA793" stroke-width="3" stroke-linecap="round"></path>
+
+  <text x="88" y="382" fill="#58635E" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing=".12em">LIFECYCLE TRACK</text>
+  <g fill="#EEF1EA" stroke="#CAD3C7">
+    <rect x="84" y="404" width="96" height="62" rx="13"></rect>
+    <rect x="198" y="404" width="96" height="62" rx="13"></rect>
+    <rect x="312" y="404" width="110" height="62" rx="13"></rect>
+    <rect x="440" y="404" width="96" height="62" rx="13"></rect>
+    <rect x="554" y="404" width="118" height="62" rx="13"></rect>
+    <rect x="690" y="404" width="96" height="62" rx="13"></rect>
+    <rect x="804" y="404" width="108" height="62" rx="13"></rect>
+  </g>
+  <g fill="#17201B" font-family="Inter, Arial, sans-serif" font-size="14" font-weight="700">
+    <text x="118" y="441">Idea</text>
+    <text x="219" y="441">Research</text>
+    <text x="330" y="441">Requirements</text>
+    <text x="471" y="441">Design</text>
+    <text x="580" y="441">Specification</text>
+    <text x="713" y="441">Tasks</text>
+    <text x="828" y="441">Build</text>
+  </g>
+  <g stroke="#9AA89F" stroke-width="3" stroke-linecap="round">
+    <path d="M180 435H198"></path>
+    <path d="M294 435H312"></path>
+    <path d="M422 435H440"></path>
+    <path d="M536 435H554"></path>
+    <path d="M672 435H690"></path>
+    <path d="M786 435H804"></path>
+  </g>
+
+  <rect x="84" y="520" width="250" height="82" rx="16" fill="#FFF8D8" stroke="#E2CF73"></rect>
+  <text x="112" y="553" fill="#17201B" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="700">Quality gate</text>
+  <text x="112" y="579" fill="#59645E" font-family="Inter, Arial, sans-serif" font-size="14">Deterministic checks first, then review.</text>
+  <rect x="388" y="520" width="250" height="82" rx="16" fill="#EBF0FF" stroke="#B9C5ED"></rect>
+  <text x="416" y="553" fill="#17201B" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="700">Traceability</text>
+  <text x="416" y="579" fill="#59645E" font-family="Inter, Arial, sans-serif" font-size="14">Requirement to spec to task to test.</text>
+  <rect x="692" y="520" width="220" height="82" rx="16" fill="#F2E9FF" stroke="#D0B8F0"></rect>
+  <text x="720" y="553" fill="#17201B" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="700">PR discipline</text>
+  <text x="720" y="579" fill="#59645E" font-family="Inter, Arial, sans-serif" font-size="14">Worktree, verify, review, ship.</text>
+
+  <path d="M472 319C472 356 472 369 472 404" stroke="#7EA793" stroke-width="3" stroke-linecap="round" stroke-dasharray="7 8"></path>
+  <path d="M534 466C534 496 534 501 534 520" stroke="#8E98B8" stroke-width="3" stroke-linecap="round"></path>
+</svg>

--- a/.claude/skills/specorator-design/slides/colors_and_type.css
+++ b/.claude/skills/specorator-design/slides/colors_and_type.css
@@ -1,0 +1,238 @@
+/*
+ * Specorator — colors_and_type.css
+ * Foundational tokens lifted from sites/styles.css (the canonical product page).
+ * Brand vocabulary: forest-ink, olive-paper, highlighter-chartreuse, soft pastels for panels.
+ *
+ * Usage:
+ *   <link rel="stylesheet" href="colors_and_type.css">
+ *   <body class="specorator">  // optional; tokens are on :root
+ */
+
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&display=swap");
+
+:root {
+  /* ─────────── Color · Core ─────────── */
+  --ink: #17201b;            /* primary fg, dark-mode bg, brand-mark bg */
+  --ink-soft: #0e1512;       /* deeper terminal black */
+  --muted: #59645e;          /* secondary text */
+  --paper: #fbfcf8;          /* page bg */
+  --surface: #ffffff;        /* card / panel bg */
+  --surface-2: #f5f7f1;      /* alt-band sections (fit, team, scaffolding) */
+  --surface-3: #eef1ea;      /* example section bg */
+  --line: #d8ded3;           /* hairline borders */
+  --line-soft: rgba(216, 222, 211, 0.72);
+
+  /* ─────────── Color · Brand Accents ─────────── */
+  --accent: #1b6f55;         /* primary accent — forest green */
+  --accent-strong: #12543f;  /* darker accent — eyebrow text, links */
+  --highlighter: #e6ff70;    /* signature chartreuse — CTAs, brand mark glyph */
+
+  /* ─────────── Color · Soft Tinted Surfaces ─────────── */
+  --soft-green: #e6f6ef;     /* solution panel, status pill, discovery stage */
+  --soft-blue: #ebf0ff;      /* lifecycle stage, traceability panel */
+  --soft-yellow: #fff8d8;    /* problem panel, gate stage */
+  --soft-orange: #fff5ee;    /* poor-fit panel */
+  --soft-purple: #f2e9ff;    /* PR discipline panel (workflow svg) */
+
+  /* ─────────── Color · Lane Coding ─────────── */
+  --lane-define: #159166;    /* green — Define lane (analyst→architect) */
+  --lane-build:  #365fa3;    /* blue  — Build lane (planner→qa) */
+  --lane-ship:   #d49a14;    /* gold  — Ship lane (review→retro) */
+  --lane-define-soft: #bce5d2;
+  --lane-build-soft:  #cbd9f7;
+  --lane-ship-soft:   #f9e3a0;
+
+  /* ─────────── Color · Inverse / Dark surfaces ─────────── */
+  --on-ink:      #f8faf5;
+  --on-ink-mute: #c7d5cd;
+  --on-ink-dim:  rgba(248, 250, 245, 0.55);
+
+  /* ─────────── Type · Families ─────────── */
+  --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+               "Segoe UI", sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo,
+               Consolas, monospace;
+
+  /* ─────────── Type · Scale (display & body) ─────────── */
+  --fs-display:  clamp(44px, 6.6vw, 84px);  /* h1 hero */
+  --fs-h2:       clamp(34px, 4.4vw, 58px);  /* section h2 */
+  --fs-h2-panel: clamp(28px, 3.0vw, 42px);  /* panel h2 (problem/solution) */
+  --fs-h3-lg:    clamp(26px, 3.0vw, 38px);  /* fit-panel h3 */
+  --fs-h3:       22px;                       /* card h3 */
+  --fs-h3-sm:    20px;                       /* roster h3 */
+  --fs-lead:     clamp(18px, 1.9vw, 24px);  /* hero copy */
+  --fs-body:     16px;
+  --fs-body-lg:  18px;
+  --fs-body-sm:  15px;
+  --fs-caption:  14px;
+  --fs-meta:     13px;
+  --fs-eyebrow:  13px;
+  --fs-micro:    11px;     /* status pill, lane chip */
+  --fs-mono:     12.5px;   /* code in artifacts */
+
+  /* ─────────── Type · Weight ─────────── */
+  --fw-regular: 400;
+  --fw-medium:  500;
+  --fw-semi:    650;       /* nav links */
+  --fw-bold:    700;
+  --fw-strong:  760;       /* button / stage labels */
+  --fw-x:       800;       /* eyebrow, brand */
+  --fw-xx:      850;       /* proof values, audience numerals */
+
+  /* ─────────── Type · Tracking & Leading ─────────── */
+  --tracking-display: -0.015em;
+  --tracking-h2:      0;
+  --tracking-h3:      -0.01em;
+  --tracking-eyebrow: 0.11em;
+  --tracking-pill:    0.08em;
+  --tracking-lane:    0.12em;
+
+  --leading-display:  0.98;
+  --leading-tight:    1.08;
+  --leading-snug:     1.3;
+  --leading-body:     1.5;
+  --leading-relaxed:  1.65;
+
+  /* ─────────── Spacing ─────────── */
+  --gutter-section: clamp(56px, 8vw, 104px);
+  --gutter-page:    clamp(20px, 5vw, 72px);
+  --gap-card:       clamp(20px, 2.4vw, 26px);
+  --gap-panel:      clamp(26px, 4vw, 42px);
+
+  /* ─────────── Radius ─────────── */
+  --r-sm:  6px;    /* code chip */
+  --r-md:  8px;    /* button, stage, panel, terminal pre */
+  --r-lg:  12px;   /* audience-card, team-card, faq-item */
+  --r-xl:  14px;
+  --r-2xl: 28px;   /* hero-visual */
+  --r-pill: 999px;
+
+  /* ─────────── Shadow ─────────── */
+  --shadow-sm:    0 6px 20px rgba(23, 32, 27, 0.04);
+  --shadow-md:    0 12px 30px rgba(23, 32, 27, 0.08);
+  --shadow-hero:  0 24px 70px rgba(23, 32, 27, 0.13);
+  --shadow-term:  0 12px 28px rgba(0, 0, 0, 0.35);
+
+  /* ─────────── Motion ─────────── */
+  --ease-out: cubic-bezier(0.2, 0.8, 0.2, 1);
+  --dur-fast: 0.2s;
+}
+
+/* ═══════════════════════════════════════════════
+   SEMANTIC TYPE — apply these classes/elements
+   ═══════════════════════════════════════════════ */
+
+body, .body {
+  font-family: var(--font-sans);
+  font-size: var(--fs-body);
+  line-height: var(--leading-body);
+  color: var(--ink);
+  background: var(--paper);
+}
+
+.h1, h1.specorator {
+  font-family: var(--font-sans);
+  font-size: var(--fs-display);
+  font-weight: var(--fw-x);
+  line-height: var(--leading-display);
+  letter-spacing: var(--tracking-display);
+  color: var(--ink);
+  max-width: 17ch;
+  margin: 0 0 22px;
+}
+
+.h2, h2.specorator {
+  font-family: var(--font-sans);
+  font-size: var(--fs-h2);
+  font-weight: var(--fw-x);
+  line-height: 1.02;
+  letter-spacing: var(--tracking-h2);
+  color: var(--ink);
+}
+
+.h3, h3.specorator {
+  font-family: var(--font-sans);
+  font-size: var(--fs-h3);
+  font-weight: var(--fw-x);
+  line-height: var(--leading-snug);
+  letter-spacing: var(--tracking-h3);
+  color: var(--ink);
+}
+
+.lead {
+  font-size: var(--fs-lead);
+  line-height: 1.4;
+  color: var(--muted);
+}
+
+.eyebrow {
+  font-size: var(--fs-eyebrow);
+  font-weight: var(--fw-x);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--accent-strong);
+}
+
+.proof-value {
+  font-size: 24px;
+  font-weight: var(--fw-xx);
+  color: var(--ink);
+}
+
+.code, code, kbd, samp, pre {
+  font-family: var(--font-mono);
+  font-size: var(--fs-mono);
+}
+
+.code-chip {
+  display: inline-block;
+  padding: 2px 7px;
+  border-radius: var(--r-sm);
+  background: rgba(23, 32, 27, 0.06);
+  color: var(--ink);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: var(--fw-bold);
+}
+
+.code-chip-dark {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: var(--r-sm);
+  background: rgba(230, 255, 112, 0.1);
+  color: var(--highlighter);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: var(--fw-bold);
+}
+
+.id-token {
+  display: inline-block;
+  padding: 0 5px;
+  border-radius: 3px;
+  background: rgba(27, 111, 85, 0.1);
+  color: var(--accent-strong);
+  font-family: var(--font-mono);
+  font-weight: var(--fw-x);
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: var(--r-pill);
+  background: var(--soft-green);
+  color: var(--accent-strong);
+  font-size: var(--fs-micro);
+  letter-spacing: var(--tracking-pill);
+  font-weight: var(--fw-x);
+  text-transform: uppercase;
+}
+.status-pill::before {
+  content: "";
+  display: inline-block;
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+}

--- a/.claude/skills/specorator-design/slides/deck-stage.js
+++ b/.claude/skills/specorator-design/slides/deck-stage.js
@@ -1,0 +1,619 @@
+/**
+ * <deck-stage> — reusable web component for HTML decks.
+ *
+ * Handles:
+ *  (a) speaker notes — reads <script type="application/json" id="speaker-notes">
+ *      and posts {slideIndexChanged: N} to the parent window on nav.
+ *  (b) keyboard navigation — ←/→, PgUp/PgDn, Space, Home/End, number keys.
+ *  (c) press R to reset to slide 0 (with a tasteful keyboard hint).
+ *  (d) bottom-center overlay showing slide count + hints, fades out on idle.
+ *  (e) auto-scaling — inner canvas is a fixed design size (default 1920×1080)
+ *      scaled with `transform: scale()` to fit the viewport, letterboxed.
+ *      Set the `noscale` attribute to render at authored size (1:1) — the
+ *      PPTX exporter sets this so its DOM capture sees unscaled geometry.
+ *  (f) print — `@media print` lays every slide out as its own page at the
+ *      design size, so the browser's Print → Save as PDF produces a clean
+ *      one-page-per-slide PDF with no extra setup.
+ *
+ * Slides are HIDDEN, not unmounted. Non-active slides stay in the DOM with
+ * `visibility: hidden` + `opacity: 0`, so their state (videos, iframes,
+ * form inputs, React trees) is preserved across navigation.
+ *
+ * Lifecycle event — the component dispatches a `slidechange` CustomEvent on
+ * itself whenever the active slide changes (including the initial mount).
+ * The event bubbles and composes out of shadow DOM, so you can listen on
+ * the <deck-stage> element or on document:
+ *
+ *   document.querySelector('deck-stage').addEventListener('slidechange', (e) => {
+ *     e.detail.index         // new 0-based index
+ *     e.detail.previousIndex // previous index, or -1 on init
+ *     e.detail.total         // total slide count
+ *     e.detail.slide         // the new active slide element
+ *     e.detail.previousSlide // the prior slide element, or null on init
+ *     e.detail.reason        // 'init' | 'keyboard' | 'click' | 'tap' | 'api'
+ *   });
+ *
+ * Persistence: none at the deck level. The host app keeps the current slide
+ * in its own URL (?slide=) and re-delivers it via location.hash on load, so a
+ * bare load with no hash always starts at slide 1.
+ *
+ * Usage:
+ *   <deck-stage width="1920" height="1080">
+ *     <section data-label="Title">...</section>
+ *     <section data-label="Agenda">...</section>
+ *   </deck-stage>
+ *
+ * Slides are the direct element children of <deck-stage>. Each slide is
+ * automatically tagged with:
+ *   - data-screen-label="NN Label"   (1-indexed, for comment flow)
+ *   - data-om-validate="no_overflowing_text,no_overlapping_text,slide_sized_text"
+ */
+
+(() => {
+  const DESIGN_W_DEFAULT = 1920;
+  const DESIGN_H_DEFAULT = 1080;
+  const OVERLAY_HIDE_MS = 1800;
+  const VALIDATE_ATTR = 'no_overflowing_text,no_overlapping_text,slide_sized_text';
+
+  const pad2 = (n) => String(n).padStart(2, '0');
+
+  const stylesheet = `
+    :host {
+      position: fixed;
+      inset: 0;
+      display: block;
+      background: #000;
+      color: #fff;
+      font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", Helvetica, Arial, sans-serif;
+      overflow: hidden;
+    }
+
+    .stage {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .canvas {
+      position: relative;
+      transform-origin: center center;
+      flex-shrink: 0;
+      background: #fff;
+      will-change: transform;
+    }
+
+    /* Slides live in light DOM (via <slot>) so authored CSS still applies.
+       We absolutely position each slotted child to stack them. */
+    ::slotted(*) {
+      position: absolute !important;
+      inset: 0 !important;
+      width: 100% !important;
+      height: 100% !important;
+      box-sizing: border-box !important;
+      overflow: hidden;
+      opacity: 0;
+      pointer-events: none;
+      visibility: hidden;
+    }
+    ::slotted([data-deck-active]) {
+      opacity: 1;
+      pointer-events: auto;
+      visibility: visible;
+    }
+
+    /* Tap zones for mobile — back/forward thirds like Stories.
+       Transparent, no visible UI, don't block the overlay. */
+    .tapzones {
+      position: fixed;
+      inset: 0;
+      display: flex;
+      z-index: 2147482000;
+      pointer-events: none;
+    }
+    .tapzone {
+      flex: 1;
+      pointer-events: auto;
+      -webkit-tap-highlight-color: transparent;
+    }
+    /* Only activate tap zones on coarse pointers (touch devices). */
+    @media (hover: hover) and (pointer: fine) {
+      .tapzones { display: none; }
+    }
+
+    .overlay {
+      position: fixed;
+      left: 50%;
+      bottom: 22px;
+      transform: translate(-50%, 6px) scale(0.92);
+      filter: blur(6px);
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      padding: 4px;
+      background: #000;
+      color: #fff;
+      border-radius: 999px;
+      font-size: 12px;
+      font-feature-settings: "tnum" 1;
+      letter-spacing: 0.01em;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 260ms ease, transform 260ms cubic-bezier(.2,.8,.2,1), filter 260ms ease;
+      transform-origin: center bottom;
+      z-index: 2147483000;
+      user-select: none;
+    }
+    .overlay[data-visible] {
+      opacity: 1;
+      pointer-events: auto;
+      transform: translate(-50%, 0) scale(1);
+      filter: blur(0);
+    }
+
+    .btn {
+      appearance: none;
+      -webkit-appearance: none;
+      background: transparent;
+      border: 0;
+      margin: 0;
+      padding: 0;
+      color: inherit;
+      font: inherit;
+      cursor: default;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      height: 28px;
+      min-width: 28px;
+      border-radius: 999px;
+      color: rgba(255,255,255,0.72);
+      transition: background 140ms ease, color 140ms ease;
+      -webkit-tap-highlight-color: transparent;
+    }
+    .btn:hover { background: rgba(255,255,255,0.12); color: #fff; }
+    .btn:active { background: rgba(255,255,255,0.18); }
+    .btn:focus { outline: none; }
+    .btn:focus-visible { outline: none; }
+    .btn::-moz-focus-inner { border: 0; }
+    .btn svg { width: 14px; height: 14px; display: block; }
+    .btn.reset {
+      font-size: 11px;
+      font-weight: 500;
+      letter-spacing: 0.02em;
+      padding: 0 10px 0 12px;
+      gap: 6px;
+      color: rgba(255,255,255,0.72);
+    }
+    .btn.reset .kbd {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 16px;
+      height: 16px;
+      padding: 0 4px;
+      font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+      font-size: 10px;
+      line-height: 1;
+      color: rgba(255,255,255,0.88);
+      background: rgba(255,255,255,0.12);
+      border-radius: 4px;
+    }
+
+    .count {
+      font-variant-numeric: tabular-nums;
+      color: #fff;
+      font-weight: 500;
+      padding: 0 8px;
+      min-width: 42px;
+      text-align: center;
+      font-size: 12px;
+    }
+    .count .sep { color: rgba(255,255,255,0.45); margin: 0 3px; font-weight: 400; }
+    .count .total { color: rgba(255,255,255,0.55); }
+
+    .divider {
+      width: 1px;
+      height: 14px;
+      background: rgba(255,255,255,0.18);
+      margin: 0 2px;
+    }
+
+    /* ── Print: one page per slide, no chrome ────────────────────────────
+       The screen layout stacks every slide at inset:0 inside a scaled
+       canvas; for print we want them in document flow at the authored
+       design size so the browser paginates one slide per sheet. The
+       @page size is set from the width/height attributes via the inline
+       <style id="deck-stage-print-page"> that connectedCallback injects
+       into <head> (the @page at-rule has no effect inside shadow DOM). */
+    @media print {
+      :host {
+        position: static;
+        inset: auto;
+        background: none;
+        overflow: visible;
+        color: inherit;
+      }
+      .stage { position: static; display: block; }
+      .canvas {
+        transform: none !important;
+        width: auto !important;
+        height: auto !important;
+        background: none;
+        will-change: auto;
+      }
+      ::slotted(*) {
+        position: relative !important;
+        inset: auto !important;
+        width: var(--deck-design-w) !important;
+        height: var(--deck-design-h) !important;
+        box-sizing: border-box !important;
+        opacity: 1 !important;
+        visibility: visible !important;
+        pointer-events: auto;
+        break-after: page;
+        page-break-after: always;
+        break-inside: avoid;
+        overflow: hidden;
+      }
+      ::slotted(*:last-child) {
+        break-after: auto;
+        page-break-after: auto;
+      }
+      .overlay, .tapzones { display: none !important; }
+    }
+  `;
+
+  class DeckStage extends HTMLElement {
+    static get observedAttributes() { return ['width', 'height', 'noscale']; }
+
+    constructor() {
+      super();
+      this._root = this.attachShadow({ mode: 'open' });
+      this._index = 0;
+      this._slides = [];
+      this._notes = [];
+      this._hideTimer = null;
+      this._mouseIdleTimer = null;
+
+      this._onKey = this._onKey.bind(this);
+      this._onResize = this._onResize.bind(this);
+      this._onSlotChange = this._onSlotChange.bind(this);
+      this._onMouseMove = this._onMouseMove.bind(this);
+      this._onTapBack = this._onTapBack.bind(this);
+      this._onTapForward = this._onTapForward.bind(this);
+    }
+
+    get designWidth() {
+      return parseInt(this.getAttribute('width'), 10) || DESIGN_W_DEFAULT;
+    }
+    get designHeight() {
+      return parseInt(this.getAttribute('height'), 10) || DESIGN_H_DEFAULT;
+    }
+
+    connectedCallback() {
+      this._render();
+      this._loadNotes();
+      this._syncPrintPageRule();
+      window.addEventListener('keydown', this._onKey);
+      window.addEventListener('resize', this._onResize);
+      window.addEventListener('mousemove', this._onMouseMove, { passive: true });
+      // Initial collection + layout happens via slotchange, which fires on mount.
+    }
+
+    disconnectedCallback() {
+      window.removeEventListener('keydown', this._onKey);
+      window.removeEventListener('resize', this._onResize);
+      window.removeEventListener('mousemove', this._onMouseMove);
+      if (this._hideTimer) clearTimeout(this._hideTimer);
+      if (this._mouseIdleTimer) clearTimeout(this._mouseIdleTimer);
+    }
+
+    attributeChangedCallback() {
+      if (this._canvas) {
+        this._canvas.style.width = this.designWidth + 'px';
+        this._canvas.style.height = this.designHeight + 'px';
+        this._canvas.style.setProperty('--deck-design-w', this.designWidth + 'px');
+        this._canvas.style.setProperty('--deck-design-h', this.designHeight + 'px');
+        this._fit();
+        this._syncPrintPageRule();
+      }
+    }
+
+    _render() {
+      const style = document.createElement('style');
+      style.textContent = stylesheet;
+
+      const stage = document.createElement('div');
+      stage.className = 'stage';
+
+      const canvas = document.createElement('div');
+      canvas.className = 'canvas';
+      canvas.style.width = this.designWidth + 'px';
+      canvas.style.height = this.designHeight + 'px';
+      canvas.style.setProperty('--deck-design-w', this.designWidth + 'px');
+      canvas.style.setProperty('--deck-design-h', this.designHeight + 'px');
+
+      const slot = document.createElement('slot');
+      slot.addEventListener('slotchange', this._onSlotChange);
+      canvas.appendChild(slot);
+      stage.appendChild(canvas);
+
+      // Tap zones (mobile): left third = back, right third = forward.
+      const tapzones = document.createElement('div');
+      tapzones.className = 'tapzones export-hidden';
+      tapzones.setAttribute('aria-hidden', 'true');
+      tapzones.setAttribute('data-noncommentable', '');
+      const tzBack = document.createElement('div');
+      tzBack.className = 'tapzone tapzone--back';
+      const tzMid = document.createElement('div');
+      tzMid.className = 'tapzone tapzone--mid';
+      tzMid.style.pointerEvents = 'none';
+      const tzFwd = document.createElement('div');
+      tzFwd.className = 'tapzone tapzone--fwd';
+      tzBack.addEventListener('click', this._onTapBack);
+      tzFwd.addEventListener('click', this._onTapForward);
+      tapzones.append(tzBack, tzMid, tzFwd);
+
+      // Overlay: compact, solid black, with clickable controls.
+      const overlay = document.createElement('div');
+      overlay.className = 'overlay export-hidden';
+      overlay.setAttribute('role', 'toolbar');
+      overlay.setAttribute('aria-label', 'Deck controls');
+      overlay.setAttribute('data-noncommentable', '');
+      overlay.innerHTML = `
+        <button class="btn prev" type="button" aria-label="Previous slide" title="Previous (←)">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 3L5 8l5 5"/></svg>
+        </button>
+        <span class="count" aria-live="polite"><span class="current">1</span><span class="sep">/</span><span class="total">1</span></span>
+        <button class="btn next" type="button" aria-label="Next slide" title="Next (→)">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 3l5 5-5 5"/></svg>
+        </button>
+        <span class="divider"></span>
+        <button class="btn reset" type="button" aria-label="Reset to first slide" title="Reset (R)">Reset<span class="kbd">R</span></button>
+      `;
+
+      overlay.querySelector('.prev').addEventListener('click', () => this._go(this._index - 1, 'click'));
+      overlay.querySelector('.next').addEventListener('click', () => this._go(this._index + 1, 'click'));
+      overlay.querySelector('.reset').addEventListener('click', () => this._go(0, 'click'));
+
+      this._root.append(style, stage, tapzones, overlay);
+      this._canvas = canvas;
+      this._slot = slot;
+      this._overlay = overlay;
+      this._countEl = overlay.querySelector('.current');
+      this._totalEl = overlay.querySelector('.total');
+    }
+
+    /** @page must live in the document stylesheet — it's a no-op inside
+     *  shadow DOM. Inject/update a single <head> style tag so the print
+     *  sheet matches the design size and Save-as-PDF yields one slide per
+     *  page with no margins. */
+    _syncPrintPageRule() {
+      const id = 'deck-stage-print-page';
+      let tag = document.getElementById(id);
+      if (!tag) {
+        tag = document.createElement('style');
+        tag.id = id;
+        document.head.appendChild(tag);
+      }
+      tag.textContent =
+        '@page { size: ' + this.designWidth + 'px ' + this.designHeight + 'px; margin: 0; } ' +
+        '@media print { html, body { margin: 0 !important; padding: 0 !important; background: none !important; overflow: visible !important; height: auto !important; } ' +
+        '* { -webkit-print-color-adjust: exact; print-color-adjust: exact; } }';
+    }
+
+    _onSlotChange() {
+      this._collectSlides();
+      this._restoreIndex();
+      this._applyIndex({ showOverlay: false, broadcast: true, reason: 'init' });
+      this._fit();
+    }
+
+    _collectSlides() {
+      const assigned = this._slot.assignedElements({ flatten: true });
+      this._slides = assigned.filter((el) => {
+        // Skip template/style/script nodes even if someone slots them.
+        const tag = el.tagName;
+        return tag !== 'TEMPLATE' && tag !== 'SCRIPT' && tag !== 'STYLE';
+      });
+
+      this._slides.forEach((slide, i) => {
+        const n = i + 1;
+        // Determine a label for comment flow: prefer explicit data-label,
+        // then an existing data-screen-label, then first heading, else "Slide".
+        let label = slide.getAttribute('data-label');
+        if (!label) {
+          const existing = slide.getAttribute('data-screen-label');
+          if (existing) {
+            // Strip any leading number the author may have included.
+            label = existing.replace(/^\s*\d+\s*/, '').trim() || existing;
+          }
+        }
+        if (!label) {
+          const h = slide.querySelector('h1, h2, h3, [data-title]');
+          if (h) label = (h.textContent || '').trim().slice(0, 40);
+        }
+        if (!label) label = 'Slide';
+        slide.setAttribute('data-screen-label', `${pad2(n)} ${label}`);
+
+        // Validation attribute for comment flow / auto-checks.
+        if (!slide.hasAttribute('data-om-validate')) {
+          slide.setAttribute('data-om-validate', VALIDATE_ATTR);
+        }
+
+        slide.setAttribute('data-deck-slide', String(i));
+      });
+
+      if (this._totalEl) this._totalEl.textContent = String(this._slides.length || 1);
+      if (this._index >= this._slides.length) this._index = Math.max(0, this._slides.length - 1);
+    }
+
+    _loadNotes() {
+      const tag = document.getElementById('speaker-notes');
+      if (!tag) { this._notes = []; return; }
+      try {
+        const parsed = JSON.parse(tag.textContent || '[]');
+        if (Array.isArray(parsed)) this._notes = parsed;
+      } catch (e) {
+        console.warn('[deck-stage] Failed to parse #speaker-notes JSON:', e);
+        this._notes = [];
+      }
+    }
+
+    _restoreIndex() {
+      // The host's ?slide= param is delivered as a #<int> hash (1-indexed) on
+      // the iframe src. No hash → slide 1; the deck itself keeps no position
+      // state across loads.
+      const h = (location.hash || '').match(/^#(\d+)$/);
+      if (h) {
+        const n = parseInt(h[1], 10) - 1;
+        if (n >= 0 && n < this._slides.length) this._index = n;
+      }
+    }
+
+    _applyIndex({ showOverlay = true, broadcast = true, reason = 'init' } = {}) {
+      if (!this._slides.length) return;
+      const prev = this._prevIndex == null ? -1 : this._prevIndex;
+      const curr = this._index;
+      // Keep the iframe's own hash in sync so an in-iframe location.reload()
+      // (reload banner path in viewer-handle.ts) lands on the current slide,
+      // not the stale deep-link hash from initial load.
+      try { history.replaceState(null, '', '#' + (curr + 1)); } catch (e) {}
+      this._slides.forEach((s, i) => {
+        if (i === curr) s.setAttribute('data-deck-active', '');
+        else s.removeAttribute('data-deck-active');
+      });
+      if (this._countEl) this._countEl.textContent = String(curr + 1);
+
+      if (broadcast) {
+        // (1) Legacy: host-window postMessage for speaker-notes renderers.
+        try { window.postMessage({ slideIndexChanged: curr }, '*'); } catch (e) {}
+
+        // (2) In-page CustomEvent on the <deck-stage> element itself.
+        //     Bubbles and composes out of shadow DOM so slide code can listen:
+        //       document.querySelector('deck-stage').addEventListener('slidechange', e => {
+        //         e.detail.index, e.detail.previousIndex, e.detail.total, e.detail.slide, e.detail.reason
+        //       });
+        const detail = {
+          index: curr,
+          previousIndex: prev,
+          total: this._slides.length,
+          slide: this._slides[curr] || null,
+          previousSlide: prev >= 0 ? (this._slides[prev] || null) : null,
+          reason: reason, // 'init' | 'keyboard' | 'click' | 'tap' | 'api'
+        };
+        this.dispatchEvent(new CustomEvent('slidechange', {
+          detail,
+          bubbles: true,
+          composed: true,
+        }));
+      }
+
+      this._prevIndex = curr;
+      if (showOverlay) this._flashOverlay();
+    }
+
+    _flashOverlay() {
+      if (!this._overlay) return;
+      this._overlay.setAttribute('data-visible', '');
+      if (this._hideTimer) clearTimeout(this._hideTimer);
+      this._hideTimer = setTimeout(() => {
+        this._overlay.removeAttribute('data-visible');
+      }, OVERLAY_HIDE_MS);
+    }
+
+    _fit() {
+      if (!this._canvas) return;
+      // PPTX export sets noscale so the DOM capture sees authored-size
+      // geometry — the scaled canvas is in shadow DOM, so the exporter's
+      // resetTransformSelector can't reach .canvas.style.transform directly.
+      if (this.hasAttribute('noscale')) {
+        this._canvas.style.transform = 'none';
+        return;
+      }
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+      const s = Math.min(vw / this.designWidth, vh / this.designHeight);
+      this._canvas.style.transform = `scale(${s})`;
+    }
+
+    _onResize() { this._fit(); }
+
+    _onMouseMove() {
+      // Keep overlay visible while mouse moves; hide after idle.
+      this._flashOverlay();
+    }
+
+    _onTapBack(e) {
+      e.preventDefault();
+      this._go(this._index - 1, 'tap');
+    }
+
+    _onTapForward(e) {
+      e.preventDefault();
+      this._go(this._index + 1, 'tap');
+    }
+
+    _onKey(e) {
+      // Ignore when the user is typing.
+      const t = e.target;
+      if (t && (t.isContentEditable || /^(INPUT|TEXTAREA|SELECT)$/.test(t.tagName))) return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+      const key = e.key;
+      let handled = true;
+
+      if (key === 'ArrowRight' || key === 'PageDown' || key === ' ' || key === 'Spacebar') {
+        this._go(this._index + 1, 'keyboard');
+      } else if (key === 'ArrowLeft' || key === 'PageUp') {
+        this._go(this._index - 1, 'keyboard');
+      } else if (key === 'Home') {
+        this._go(0, 'keyboard');
+      } else if (key === 'End') {
+        this._go(this._slides.length - 1, 'keyboard');
+      } else if (key === 'r' || key === 'R') {
+        this._go(0, 'keyboard');
+      } else if (/^[0-9]$/.test(key)) {
+        // 1..9 jump to that slide; 0 jumps to 10.
+        const n = key === '0' ? 9 : parseInt(key, 10) - 1;
+        if (n < this._slides.length) this._go(n, 'keyboard');
+      } else {
+        handled = false;
+      }
+
+      if (handled) {
+        e.preventDefault();
+        this._flashOverlay();
+      }
+    }
+
+    _go(i, reason = 'api') {
+      if (!this._slides.length) return;
+      const clamped = Math.max(0, Math.min(this._slides.length - 1, i));
+      if (clamped === this._index) {
+        this._flashOverlay();
+        return;
+      }
+      this._index = clamped;
+      this._applyIndex({ showOverlay: true, broadcast: true, reason });
+    }
+
+    // Public API ------------------------------------------------------------
+
+    /** Current slide index (0-based). */
+    get index() { return this._index; }
+    /** Total slide count. */
+    get length() { return this._slides.length; }
+    /** Programmatically navigate. */
+    goTo(i) { this._go(i, 'api'); }
+    next() { this._go(this._index + 1, 'api'); }
+    prev() { this._go(this._index - 1, 'api'); }
+    reset() { this._go(0, 'api'); }
+  }
+
+  if (!customElements.get('deck-stage')) {
+    customElements.define('deck-stage', DeckStage);
+  }
+})();

--- a/.claude/skills/specorator-design/slides/deck.css
+++ b/.claude/skills/specorator-design/slides/deck.css
@@ -1,0 +1,187 @@
+/* Specorator deck — 1920×1080 slide system
+ * Imports brand tokens; defines per-slide layout primitives.
+ * No emoji, no icons, em-dashes only, sentence-case headings ending in period.
+ */
+
+@import url("colors_and_type.css");
+
+* { box-sizing: border-box; }
+
+deck-stage { background: #0a0e0c; }
+
+deck-stage > section {
+  width: 1920px;
+  height: 1080px;
+  position: relative;
+  overflow: hidden;
+  font-family: var(--font-sans);
+  color: var(--ink);
+  background: var(--paper);
+  display: flex;
+  flex-direction: column;
+}
+
+/* ─── Surfaces ─── */
+.bg-paper    { background: var(--paper); }
+.bg-surface2 { background: var(--surface-2); }
+.bg-surface3 { background: var(--surface-3); }
+.bg-ink      { background: var(--ink); color: var(--on-ink); }
+
+/* ─── Slide chrome ─── */
+.slide-pad {
+  padding: 96px 128px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.slide-corner {
+  position: absolute;
+  top: 56px; left: 128px; right: 128px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-family: var(--font-mono);
+  font-size: 16px;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+.bg-ink .slide-corner { color: var(--on-ink-dim); }
+
+.brand-mini {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  color: inherit;
+}
+.brand-mini .glyph {
+  width: 28px; height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--ink);
+  color: var(--highlighter);
+  border-radius: 6px;
+  font-family: var(--font-sans);
+  font-weight: 850;
+  font-size: 18px;
+  letter-spacing: -0.02em;
+}
+.bg-ink .brand-mini .glyph {
+  background: var(--highlighter); color: var(--ink);
+}
+
+.slide-foot {
+  position: absolute;
+  bottom: 56px; left: 128px; right: 128px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-family: var(--font-mono);
+  font-size: 14px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.bg-ink .slide-foot { color: var(--on-ink-dim); }
+
+/* ─── Eyebrow ─── */
+.eyebrow {
+  font-family: var(--font-mono);
+  font-size: 18px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent-strong);
+  margin: 0 0 32px;
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
+}
+.bg-ink .eyebrow { color: var(--highlighter); }
+.eyebrow .dot {
+  width: 8px; height: 8px; border-radius: 999px;
+  background: currentColor;
+}
+
+/* ─── Type ─── */
+h1, h2, h3, p { margin: 0; }
+
+.h-display {
+  font-size: 168px;
+  line-height: 0.92;
+  letter-spacing: -0.025em;
+  font-weight: 850;
+  text-wrap: balance;
+}
+.h-section {
+  font-size: 132px;
+  line-height: 0.94;
+  letter-spacing: -0.022em;
+  font-weight: 800;
+  text-wrap: balance;
+}
+.h-title {
+  font-size: 96px;
+  line-height: 0.98;
+  letter-spacing: -0.018em;
+  font-weight: 800;
+  text-wrap: balance;
+}
+.h-sub {
+  font-size: 48px;
+  line-height: 1.1;
+  letter-spacing: -0.012em;
+  font-weight: 700;
+}
+.lead {
+  font-size: 32px;
+  line-height: 1.4;
+  font-weight: 400;
+  color: var(--muted);
+  max-width: 1200px;
+}
+.bg-ink .lead { color: var(--on-ink-mute); }
+
+.mono { font-family: var(--font-mono); }
+
+/* ─── Pills & chips ─── */
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  background: var(--soft-green);
+  color: var(--accent-strong);
+  font-family: var(--font-mono);
+  font-size: 18px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+.status-pill .pill-dot {
+  width: 10px; height: 10px;
+  border-radius: 999px;
+  background: var(--accent);
+}
+
+.lane-chip {
+  display: inline-block;
+  padding: 8px 16px;
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.lane-define { background: var(--lane-define-soft); color: var(--lane-define); }
+.lane-build  { background: var(--lane-build-soft);  color: var(--lane-build); }
+.lane-ship   { background: var(--lane-ship-soft);   color: #8a6309; }
+
+/* ─── Slide-foot navigation ─── */
+.slide-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
+}

--- a/.claude/skills/specorator-design/slides/index.html
+++ b/.claude/skills/specorator-design/slides/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Specorator · Slide system</title>
+    <link rel="icon" href="assets/specorator-mark.svg" type="image/svg+xml">
+    <link rel="stylesheet" href="deck.css">
+    <style>
+      html, body { margin: 0; padding: 0; background: #0a0e0c; min-height: 100vh; }
+    </style>
+  </head>
+  <body>
+    <deck-stage></deck-stage>
+
+    <script src="deck-stage.js"></script>
+    <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+    <script type="text/babel" src="Shared.jsx"></script>
+    <script type="text/babel" src="CoverSlide.jsx"></script>
+    <script type="text/babel" src="ProblemSolutionSlide.jsx"></script>
+    <script type="text/babel" src="WorkflowSlide.jsx"></script>
+    <script type="text/babel" src="TeamGridSlide.jsx"></script>
+    <script type="text/babel" src="ArtifactSlide.jsx"></script>
+    <script type="text/babel" src="ClosingSlide.jsx"></script>
+    <script type="text/babel" src="app.jsx"></script>
+  </body>
+</html>

--- a/.claude/skills/specorator-design/ui_kits/product-page/ArtifactExample.jsx
+++ b/.claude/skills/specorator-design/ui_kits/product-page/ArtifactExample.jsx
@@ -1,0 +1,84 @@
+// ArtifactExample.jsx — 3-card chain of artifacts
+function ArtifactExample() {
+  return (
+    <section className="section example-section" id="example" aria-labelledby="example-title">
+      <div className="section-header">
+        <h2 id="example-title">From a one-line brief to working code.</h2>
+        <p className="section-kicker">A walk-through of the worked CLI todo example &mdash; the smallest realistic feature you can read end to end. Each stage produces a Markdown artifact with stable IDs that flow forward to the next.</p>
+      </div>
+      <div className="artifact-chain" aria-label="Three example artifacts produced in sequence">
+        <figure className="artifact-card">
+          <header className="artifact-card-head">
+            <span className="artifact-step">Stage 1 &middot; Idea</span>
+            <code className="artifact-path">examples/cli-todo/idea.md</code>
+          </header>
+          <pre className="artifact-source"
+               dangerouslySetInnerHTML={{__html:
+`<span class="md-h1"># Idea: CLI todo app</span>
+
+<span class="md-h2">## Brief</span>
+Solo engineers want to capture, list,
+and complete short-lived tasks without
+leaving the shell.
+
+<span class="md-h2">## User</span>
+Terminal-native engineers; contributors
+reading this kit's worked example.
+
+<span class="md-h2">## Outcome</span>
+A \`todo\` binary with add, list, done,
+rm. First add &rarr; list &rarr; done in
+under two minutes.`}} />
+        </figure>
+        <figure className="artifact-card">
+          <header className="artifact-card-head">
+            <span className="artifact-step">Stage 3 &middot; Requirements</span>
+            <code className="artifact-path">examples/cli-todo/requirements.md</code>
+          </header>
+          <pre className="artifact-source"
+               dangerouslySetInnerHTML={{__html:
+`<span class="md-h1"># Requirements: CLI todo app</span>
+
+<span class="md-id">REQ-CLI-001</span>
+<span class="md-em">When</span> the user invokes \`todo add\`
+with a non-empty text argument,
+<span class="md-em">the CLI shall</span> create a new task
+with a unique sequential ID and persist
+it for later \`todo list\` calls.
+
+<span class="md-id">REQ-CLI-002</span>
+<span class="md-em">When</span> the user invokes \`todo list\`,
+<span class="md-em">the CLI shall</span> display every open
+task on its own line.`}} />
+        </figure>
+        <figure className="artifact-card">
+          <header className="artifact-card-head">
+            <span className="artifact-step">Stage 6 &middot; Tasks</span>
+            <code className="artifact-path">examples/cli-todo/tasks.md</code>
+          </header>
+          <pre className="artifact-source"
+               dangerouslySetInnerHTML={{__html:
+`<span class="md-h1"># Tasks: CLI todo app</span>
+
+<span class="md-id">T-CLI-007</span>  Command behavior tests
+  owner: qa    &rarr; <span class="md-id">REQ-CLI-001</span>, <span class="md-id">REQ-CLI-002</span>
+
+<span class="md-id">T-CLI-008</span>  Implement task commands
+  owner: dev   &rarr; <span class="md-id">REQ-CLI-001</span>, <span class="md-id">REQ-CLI-002</span>
+
+<span class="md-id">T-CLI-009</span>  Review and traceability
+  owner: dev   &rarr; <span class="md-id">REQ-CLI-001</span>, <span class="md-id">REQ-CLI-002</span>`}} />
+        </figure>
+      </div>
+      <div className="artifact-meta">
+        <p>Every requirement carries a stable ID that flows forward &mdash; <code>REQ</code> to <code>T</code> to <code>TEST</code>. The traceability matrix is regenerable from the artifacts; nothing ships without a chain.</p>
+        <ul className="artifact-list">
+          <li><a href="https://github.com/Luis85/agentic-workflow/tree/main/examples/cli-todo">Browse every cli-todo artifact &rarr;</a></li>
+          <li><a href="https://github.com/Luis85/agentic-workflow/blob/main/docs/workflow-overview.md">Workflow cheat sheet &rarr;</a></li>
+          <li><a href="https://github.com/Luis85/agentic-workflow/blob/main/docs/quality-framework.md">Quality gates &rarr;</a></li>
+        </ul>
+      </div>
+    </section>
+  );
+}
+window.ArtifactExample = ArtifactExample;

--- a/.claude/skills/specorator-design/ui_kits/product-page/AudienceGrid.jsx
+++ b/.claude/skills/specorator-design/ui_kits/product-page/AudienceGrid.jsx
@@ -1,0 +1,29 @@
+// AudienceGrid.jsx — 4 cards with big numeral watermark
+const AUDIENCES = [
+  { num: "01", title: "Product managers & designers", body: "Run discovery, shape requirements, review designs, and keep intent explicit. No code required.", say: "You'd say", cta: "\u201clet's start a feature: user auth\u201d" },
+  { num: "02", title: "Developers", body: "Implement from clear task specs with TDD discipline. No more reverse-engineering stakeholder intent from a Slack thread.", say: "You'd say", cta: "\u201ccontinue the user-auth feature\u201d" },
+  { num: "03", title: "Team leads", body: "Coordinate humans and agents across a release cycle with visible gates, owned artifacts, and quality checks you can enforce.", say: "You'd type", cta: "/adr:new \"Switch to Postgres\"" },
+  { num: "04", title: "Solo builders", body: "Run the entire workflow yourself. Specialist agents fill every role \u2014 analyst, architect, dev, QA \u2014 while you keep the vision.", say: "You'd say", cta: "\u201cdrive this end-to-end: magic-link login\u201d" },
+];
+
+function AudienceGrid() {
+  return (
+    <section className="section" aria-labelledby="audience-title">
+      <div className="section-header">
+        <h2 id="audience-title">Built for the people who share delivery work.</h2>
+        <p className="section-kicker">The repository gives each role an entry point without turning the process into a separate product to maintain.</p>
+      </div>
+      <div className="audience-grid">
+        {AUDIENCES.map(a => (
+          <article key={a.num} className="audience-card" data-num={a.num}>
+            <h3>{a.title}</h3>
+            <p>{a.body}</p>
+            <p className="audience-say">{a.say}</p>
+            <code className="audience-cta">{a.cta}</code>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+window.AudienceGrid = AudienceGrid;

--- a/.claude/skills/specorator-design/ui_kits/product-page/Faq.jsx
+++ b/.claude/skills/specorator-design/ui_kits/product-page/Faq.jsx
@@ -1,0 +1,35 @@
+// Faq.jsx — 6 Q&A cards
+const FAQS = [
+  ["How is this different from spec-kit, Aider, or Copilot Workspace?",
+   <React.Fragment>They&rsquo;re tools; Specorator is a <strong>process</strong> you can run on top of them. The 11-stage lifecycle, named specialist agents, quality gates, and trace IDs are the real differentiators. Claude Code gets first-class slash commands, but the workflow itself is described in <code>AGENTS.md</code> and works with Codex, Cursor, Aider, Copilot, and Gemini.</React.Fragment>],
+  ["Do I have to use Claude Code?",
+   <React.Fragment>No. Claude Code gets first-class commands and the skills layer is Claude-specific, but the workflow itself is described in <code>AGENTS.md</code> and runs with any agent that can read Markdown. The artifacts, IDs, and quality gates are tool-agnostic.</React.Fragment>],
+  ["Is this a library or a template?",
+   <React.Fragment>A template. Fork the repo, replace <code>docs/steering/</code> with your own product context, adapt <code>memory/constitution.md</code> to your team&rsquo;s principles, and start a feature. The default content is intentionally generic &mdash; every project will overwrite parts of it.</React.Fragment>],
+  ["Can I use it without GitHub?",
+   <React.Fragment>Yes for the lifecycle. Verify gate, agents, skills, and artifacts all run locally. Some optional bits lean on GitHub (Pages deploy, Actions for typos / spell-check / verify CI), but the core workflow doesn&rsquo;t depend on it. Local hooks deny direct <code>main</code> pushes the same way branch protection would.</React.Fragment>],
+  ["Is the 11-stage lifecycle overkill for a one-person project?",
+   <React.Fragment>For a throwaway script, yes. For anything you&rsquo;ll maintain past the first commit, no &mdash; stages move in minutes when there&rsquo;s no stakeholder cycle to run. Solo builders use the <code>orchestrate</code> skill and gate themselves between stages. The mandatory retrospective at the end is what compounds the value over time.</React.Fragment>],
+  ["Do I have to learn the slash commands?",
+   <React.Fragment>No. The conductor skills (<code>orchestrate</code>, <code>discovery-sprint</code>, <code>project-run</code>, etc.) auto-trigger on natural language. Slash commands are the manual escape hatch when you want precise control. Every entry point in the audience cards above shows the natural-language form.</React.Fragment>],
+];
+
+function Faq() {
+  return (
+    <section className="section faq-section" id="faq" aria-labelledby="faq-title">
+      <div className="section-header">
+        <h2 id="faq-title">Questions you probably have.</h2>
+        <p className="section-kicker">Six honest answers for evaluators &mdash; positioning, prerequisites, scope, and friction.</p>
+      </div>
+      <div className="faq-grid">
+        {FAQS.map(([q, a]) => (
+          <article key={q} className="faq-item">
+            <h3>{q}</h3>
+            <p>{a}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+window.Faq = Faq;

--- a/.claude/skills/specorator-design/ui_kits/product-page/FeatureGrid.jsx
+++ b/.claude/skills/specorator-design/ui_kits/product-page/FeatureGrid.jsx
@@ -1,0 +1,32 @@
+// FeatureGrid.jsx — Dark section, 9 feature cards
+const FEATURES = [
+  ["11-stage lifecycle", "Idea, research, requirements, design, specification, tasks, implementation, testing, review, release, and retrospective."],
+  ["Discovery track", "Frame, diverge, converge, prototype, validate, and hand off before a feature brief exists."],
+  ["Specialist agents", "PM, design, architecture, development, QA, review, release, and operations roles stay in their lane."],
+  ["Quality gates", "Each stage has acceptance criteria so defects are caught where they are cheapest to fix."],
+  ["Release readiness", "Stage 10 can collect product perspectives, stakeholder approvals, conditions, and go/no-go evidence before production."],
+  ["Traceability", "Requirements, specs, tasks, code, tests, and findings use stable IDs and link back to source intent."],
+  ["Worktree discipline", "Topic branches live in isolated worktrees, pass verify, and move through PR review before merge."],
+  ["Operational bots", "Review, docs, plan reconciliation, dependency triage, and Actions updates can be automated over time."],
+  ["Tool-agnostic core", "Claude Code gets first-class commands, while Codex, Cursor, Aider, Copilot, and other tools can follow AGENTS.md."],
+];
+
+function FeatureGrid() {
+  return (
+    <section className="section dark" id="features" aria-labelledby="features-title">
+      <div className="section-header">
+        <h2 id="features-title">A workflow that gives agents structure.</h2>
+        <p className="section-kicker">Clone or fork it, adapt the steering docs, and let every feature move through the same visible path.</p>
+      </div>
+      <div className="feature-grid">
+        {FEATURES.map(([title, body]) => (
+          <article className="card" key={title}>
+            <h3>{title}</h3>
+            <p>{body}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+window.FeatureGrid = FeatureGrid;

--- a/.claude/skills/specorator-design/ui_kits/product-page/FitGrid.jsx
+++ b/.claude/skills/specorator-design/ui_kits/product-page/FitGrid.jsx
@@ -1,0 +1,32 @@
+// FitGrid.jsx — Good fit / Probably too much
+function FitGrid() {
+  return (
+    <section className="section fit-section" id="fit" aria-labelledby="fit-title">
+      <div className="section-header">
+        <h2 id="fit-title">Use it when the work needs memory.</h2>
+        <p className="section-kicker">Specorator is for work where context, decisions, and review history matter more than a one-shot code answer.</p>
+      </div>
+      <div className="fit-grid">
+        <article className="fit-panel good-fit">
+          <h3>Good fit</h3>
+          <ul className="fit-list">
+            <li>Features with unclear requirements or multiple stakeholders.</li>
+            <li>Projects where AI agents need bounded roles and durable hand-offs.</li>
+            <li>Teams that want traceability from requirement to test to PR.</li>
+            <li>Long-lived products where decisions should survive the chat window.</li>
+          </ul>
+        </article>
+        <article className="fit-panel poor-fit">
+          <h3>Probably too much</h3>
+          <ul className="fit-list">
+            <li>Throwaway scripts, tiny bug fixes, or one-person spikes.</li>
+            <li>Work where the correct behavior is already fully specified elsewhere.</li>
+            <li>Teams that need only a prompt library, not a delivery workflow.</li>
+            <li>Situations where no one will maintain the specs after the first pass.</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+  );
+}
+window.FitGrid = FitGrid;

--- a/.claude/skills/specorator-design/ui_kits/product-page/Footer.jsx
+++ b/.claude/skills/specorator-design/ui_kits/product-page/Footer.jsx
@@ -1,0 +1,15 @@
+// Footer.jsx
+function Footer() {
+  return (
+    <footer className="site-footer">
+      <span>Specorator is MIT licensed.</span>
+      <div className="footer-links">
+        <a href="https://github.com/Luis85/agentic-workflow">GitHub</a>
+        <a href="https://github.com/Luis85/agentic-workflow/blob/main/README.md">README</a>
+        <a href="https://github.com/Luis85/agentic-workflow/blob/main/docs/specorator.md">Workflow docs</a>
+        <a href="https://github.com/Luis85/agentic-workflow/blob/main/LICENSE">License</a>
+      </div>
+    </footer>
+  );
+}
+window.Footer = Footer;

--- a/.claude/skills/specorator-design/ui_kits/product-page/Header.jsx
+++ b/.claude/skills/specorator-design/ui_kits/product-page/Header.jsx
@@ -1,0 +1,25 @@
+// Header.jsx — sticky brand bar
+function Header() {
+  return (
+    <React.Fragment>
+      <a className="skip-link" href="#main">Skip to content</a>
+      <header className="site-header">
+        <a className="brand" href="#main" aria-label="Specorator home">
+          <span className="brand-mark" aria-hidden="true">S</span>
+          <span>Specorator</span>
+        </a>
+        <nav className="nav-links" aria-label="Primary navigation">
+          <a href="#team">Team</a>
+          <a href="#fit">Fit</a>
+          <a href="#workflow">Workflow</a>
+          <a href="#tracks">Tracks</a>
+          <a href="#roster">Roster</a>
+          <a href="#start">Start</a>
+          <a href="https://github.com/Luis85/agentic-workflow/blob/main/docs/specorator.md">Docs</a>
+          <a href="https://github.com/Luis85/agentic-workflow">GitHub</a>
+        </nav>
+      </header>
+    </React.Fragment>
+  );
+}
+window.Header = Header;

--- a/.claude/skills/specorator-design/ui_kits/product-page/Hero.jsx
+++ b/.claude/skills/specorator-design/ui_kits/product-page/Hero.jsx
@@ -1,0 +1,39 @@
+// Hero.jsx — title + lead + CTAs + proof + workflow art
+function Hero() {
+  return (
+    <section className="hero" aria-labelledby="hero-title">
+      <div>
+        <p className="eyebrow">
+          <span className="status-pill">Open-source template</span>
+          <span className="eyebrow-meta">MIT &middot; the <code>agentic-workflow</code> repo</span>
+        </p>
+        <h1 id="hero-title">Stop letting AI write the wrong code.</h1>
+        <p className="hero-copy">
+          Most AI assistants jump straight to typing. <strong>Specorator</strong> flips it &mdash; specs first, code second. You decide <em>what</em> to build; specialist agents handle <em>how</em>; every decision stays traceable.
+        </p>
+        <div className="hero-actions" aria-label="Primary actions">
+          <a className="button highlight" href="#start">Get started</a>
+          <a className="button secondary" href="https://github.com/Luis85/agentic-workflow/blob/main/docs/specorator.md">Read the workflow</a>
+        </div>
+        <div className="hero-proof" aria-label="At a glance">
+          <span className="proof-item">
+            <span className="proof-value">11</span>
+            <span className="proof-label">stages, idea&nbsp;&rarr;&nbsp;retro</span>
+          </span>
+          <span className="proof-item">
+            <span className="proof-value">10</span>
+            <span className="proof-label">conductor skills, pick your fit</span>
+          </span>
+          <span className="proof-item">
+            <span className="proof-value">6+</span>
+            <span className="proof-label">AI coding tools supported</span>
+          </span>
+        </div>
+      </div>
+      <figure className="hero-visual">
+        <img src="assets/specorator-workflow.svg" alt="Specorator workflow showing discovery, lifecycle stages, quality gates, and traceability." />
+      </figure>
+    </section>
+  );
+}
+window.Hero = Hero;

--- a/.claude/skills/specorator-design/ui_kits/product-page/README.md
+++ b/.claude/skills/specorator-design/ui_kits/product-page/README.md
@@ -1,0 +1,34 @@
+---
+title: "Product Page UI Kit"
+folder: ".claude/skills/specorator-design/ui_kits/product-page"
+description: "High-fidelity React recreation of the live Specorator product page — reference component split per section."
+entry_point: true
+---
+# Product Page UI Kit
+
+High-fidelity React recreation of the [Specorator product page](https://luis85.github.io/agentic-workflow/) — the canonical brand surface. Components are split per section so they can be remixed.
+
+## Files
+
+| File                  | What                                                              |
+| --------------------- | ----------------------------------------------------------------- |
+| `index.html`          | Composed full page, scrolling, all sections wired up              |
+| `Header.jsx`          | Sticky brand bar with skip-link, brand mark, nav, CTAs            |
+| `Hero.jsx`            | Two-column hero: copy + workflow SVG, eyebrow, proof grid         |
+| `WhyPanels.jsx`       | Problem / Solution two-up colored panels                          |
+| `TeamGrid.jsx`        | 8-card lane-coded specialist roles grid                           |
+| `FitGrid.jsx`         | "Good fit / Probably too much" two-up                             |
+| `FeatureGrid.jsx`     | Dark section, 9 feature cards                                     |
+| `AudienceGrid.jsx`    | 4 big-numeral cards with "you'd say" pattern                      |
+| `Workflow.jsx`        | Discovery + Lifecycle stage rails                                 |
+| `TrackGrid.jsx`       | 8 opt-in track cards with phases + commands                       |
+| `Roster.jsx`          | Dark section, 6 roster groups, all 30 agents                      |
+| `RepoGrid.jsx`        | 6 file-tree code chips                                            |
+| `ArtifactExample.jsx` | 3-card artifact chain with markdown specimens                     |
+| `Faq.jsx`             | 6-up Q&A grid                                                     |
+| `StartSteps.jsx`      | Dark section, 4 numbered steps + terminal quickstart              |
+| `Footer.jsx`          | License + footer links                                            |
+| `app.jsx`             | Page composition root                                             |
+| `kit.css`             | Component CSS lifted near-verbatim from `sites/styles.css`        |
+
+The CSS in `kit.css` is a direct import of the live product page styles, with class names preserved so JSX is a 1:1 visual match.

--- a/.claude/skills/specorator-design/ui_kits/product-page/RepoGrid.jsx
+++ b/.claude/skills/specorator-design/ui_kits/product-page/RepoGrid.jsx
@@ -1,0 +1,29 @@
+// RepoGrid.jsx — what's in the repo
+const REPO = [
+  [".claude/",   "Claude Code agents, commands, skills, and operational prompts."],
+  [".codex/",    "Codex-specific delivery workflows for worktrees, verification, PRs, and cleanup."],
+  ["docs/",      "The Specorator method, quality gates, how-to recipes, ADRs, and steering context."],
+  ["templates/", "Reusable Markdown artifact shapes for requirements, design, tasks, tests, release readiness, and release."],
+  ["specs/",     "Per-feature state and traceable artifacts produced as work moves through the lifecycle."],
+  ["sites/",     "The public product page source, kept directly openable and deployable as static files."],
+];
+
+function RepoGrid() {
+  return (
+    <section className="section repo-section" id="repo" aria-labelledby="repo-title">
+      <div className="section-header">
+        <h2 id="repo-title">What you get in the repository.</h2>
+        <p className="section-kicker">The repo is the product: prompts, workflows, templates, checks, and examples that make agentic delivery repeatable.</p>
+      </div>
+      <div className="repo-grid" aria-label="Repository contents">
+        {REPO.map(([code, body]) => (
+          <article key={code} className="repo-item">
+            <code>{code}</code>
+            <p>{body}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+window.RepoGrid = RepoGrid;

--- a/.claude/skills/specorator-design/ui_kits/product-page/Roster.jsx
+++ b/.claude/skills/specorator-design/ui_kits/product-page/Roster.jsx
@@ -1,0 +1,36 @@
+// Roster.jsx — dark section, all 30 agents
+const ROSTER = [
+  { title: "Build a feature", count: "13 agents", desc: "The 11-stage lifecycle, the conductor that drives it, and ops support.",
+    agents: ["analyst","pm","ux-designer","ui-designer","architect","planner","dev","qa","reviewer","release-manager","retrospective","sre","orchestrator"] },
+  { title: "Run a discovery sprint", count: "7 agents", desc: "Frame to validate, before a brief exists.",
+    agents: ["facilitator","product-strategist","user-researcher","game-designer","divergent-thinker","critic","prototyper"] },
+  { title: "Audit a legacy system", count: "1 agent", desc: "Inventory what's already there before changing anything.",
+    agents: ["legacy-auditor"] },
+  { title: "Win a deal", count: "4 agents", desc: "Service-provider opt-in: qualify to order.",
+    agents: ["sales-qualifier","scoping-facilitator","estimator","proposal-writer"] },
+  { title: "Govern delivery", count: "4 agents", desc: "Project, portfolio, roadmap, and source-led onboarding.",
+    agents: ["project-manager","portfolio-manager","roadmap-manager","project-scaffolder"] },
+  { title: "Maintain the kit", count: "1 agent", desc: "Keeps the public product page current.",
+    agents: ["product-page-designer"] },
+];
+
+function Roster() {
+  return (
+    <section className="section dark roster-section" id="roster" aria-labelledby="roster-title">
+      <div className="section-header">
+        <h2 id="roster-title">All 30 agents in the repo.</h2>
+        <p className="section-kicker">The eight roles above are how the team thinks. Here&rsquo;s every agent the workflow actually ships, grouped by what it helps you do.</p>
+      </div>
+      <div className="roster-grid" aria-label="Full agent roster">
+        {ROSTER.map(g => (
+          <article key={g.title} className="roster-group">
+            <header><h3>{g.title}</h3><span className="roster-count">{g.count}</span></header>
+            <p className="roster-desc">{g.desc}</p>
+            <ul className="roster-list">{g.agents.map(a => <li key={a}><code>{a}</code></li>)}</ul>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+window.Roster = Roster;

--- a/.claude/skills/specorator-design/ui_kits/product-page/StartSteps.jsx
+++ b/.claude/skills/specorator-design/ui_kits/product-page/StartSteps.jsx
@@ -1,0 +1,47 @@
+// StartSteps.jsx — dark section with steps + terminal quickstart
+const STEPS = [
+  ["1", "Clone or fork", "Copy the repository into a new workspace, or fork it on GitHub when you want to track changes upstream."],
+  ["2", "Personalize context", "Adapt the constitution and steering docs so agents know your product, stack, and quality bar."],
+  ["3", "Open Claude Code", "Start from a feature idea, a design sprint, or the orchestrated end-to-end workflow."],
+  ["4", "Verify and PR", "Keep every concern on its own branch, run npm run verify, and ship through review."],
+];
+
+function StartSteps() {
+  return (
+    <section className="section dark" id="start" aria-labelledby="start-title">
+      <div className="section-header">
+        <h2 id="start-title">Get started in one repository.</h2>
+        <p className="section-kicker">Clone or fork the repository, fill in the steering context, and start a feature through natural language or slash commands.</p>
+      </div>
+      <div className="steps">
+        {STEPS.map(([n, title, body]) => (
+          <article key={n} className="step">
+            <span className="step-number">{n}</span>
+            <h3>{title}</h3>
+            <p>{body.includes("npm run verify") ? <React.Fragment>Keep every concern on its own branch, run <code>npm run verify</code>, and ship through review.</React.Fragment> : body}</p>
+          </article>
+        ))}
+      </div>
+      <div className="quickstart" aria-label="Quickstart commands">
+        <div className="quickstart-intro">
+          <h3>Quickstart</h3>
+          <p>Install dependencies, run the verify gate, then open Claude Code and start from discovery or a feature brief.</p>
+        </div>
+        <figure className="terminal">
+          <header className="terminal-chrome" aria-hidden="true">
+            <span className="terminal-dot terminal-dot-red"></span>
+            <span className="terminal-dot terminal-dot-yellow"></span>
+            <span className="terminal-dot terminal-dot-green"></span>
+            <span className="terminal-title">my-project &mdash; claude</span>
+          </header>
+          <pre><code>{`git clone https://github.com/Luis85/agentic-workflow.git my-project
+cd my-project
+npm install
+npm run verify
+claude`}</code></pre>
+        </figure>
+      </div>
+    </section>
+  );
+}
+window.StartSteps = StartSteps;

--- a/.claude/skills/specorator-design/ui_kits/product-page/TeamGrid.jsx
+++ b/.claude/skills/specorator-design/ui_kits/product-page/TeamGrid.jsx
@@ -1,0 +1,45 @@
+// TeamGrid.jsx — 8 lane-coded specialist role cards
+const TEAM_ROLES = [
+  { num: "01", lane: "define", title: "Analyst", agents: ["analyst"], desc: "Frames the problem. Runs idea capture, research, and discovery sprints. Produces the brief that seeds everything downstream." },
+  { num: "02", lane: "define", title: "Product Manager", agents: ["pm"], desc: "Owns the requirements. Writes EARS-format specs, manages scope, and keeps intent sharp through the lifecycle." },
+  { num: "03", lane: "define", title: "Designer", agents: ["ux-designer", "ui-designer"], desc: "Shapes the experience. UX produces flows, IA, and state coverage; UI picks tokens, components, and microcopy." },
+  { num: "04", lane: "define", title: "Architect", agents: ["architect"], desc: "Designs the system. Makes structural decisions, files ADRs, and produces the implementation-ready spec." },
+  { num: "05", lane: "build",  title: "Planner", agents: ["planner"], desc: "Breaks work down. Turns the spec into TDD-ordered tasks (\u00bd day each) with dependencies and definitions of done." },
+  { num: "06", lane: "build",  title: "Developer", agents: ["dev"], desc: "Writes the code. Implements from task specs with TDD discipline. Never invents requirements; escalates if a gap appears." },
+  { num: "07", lane: "build",  title: "QA", agents: ["qa"], desc: "Validates the build. Authors the test plan, runs the suite, and checks that every EARS clause has a matching test." },
+  { num: "08", lane: "ship",   title: "Reviewer & Release", agents: ["reviewer", "release-manager", "retrospective"], desc: "Closes the loop. Reviews the diff with traceability, prepares release readiness, drafts release notes, and runs the mandatory retro." },
+];
+const LANE_LABEL = { define: "Define", build: "Build", ship: "Ship" };
+
+function TeamGrid() {
+  return (
+    <section className="section team-section" id="team" aria-labelledby="team-title">
+      <div className="section-header">
+        <h2 id="team-title">A specialist for every stage.</h2>
+        <p className="section-kicker">Eight role families backed by the agents in this repo. Each one owns a stage, produces an artifact, passes a quality gate, and hands off cleanly. You stay in charge of intent.</p>
+      </div>
+      <div className="team-grid" aria-label="Specialist roles">
+        {TEAM_ROLES.map(r => (
+          <article key={r.num} className="team-card" data-lane={r.lane}>
+            <header className="team-card-head">
+              <span className="team-num">{r.num}</span>
+              <span className="team-lane">{LANE_LABEL[r.lane]}</span>
+            </header>
+            <h3>{r.title}</h3>
+            <p className="team-agents">
+              {r.agents.map((a, i) => (
+                <React.Fragment key={a}>
+                  {i > 0 && " \u00b7 "}
+                  <code>{a}</code>
+                </React.Fragment>
+              ))}
+            </p>
+            <p className="team-desc">{r.desc}</p>
+          </article>
+        ))}
+      </div>
+      <p className="team-footnote">Plus an <code>orchestrator</code> that routes between them and an <code>sre</code> for post-release operability. <a href="#roster">See the full 30-agent roster &rarr;</a></p>
+    </section>
+  );
+}
+window.TeamGrid = TeamGrid;

--- a/.claude/skills/specorator-design/ui_kits/product-page/TrackGrid.jsx
+++ b/.claude/skills/specorator-design/ui_kits/product-page/TrackGrid.jsx
@@ -1,0 +1,39 @@
+// TrackGrid.jsx — 8 opt-in tracks
+const TRACKS = [
+  { when: "Pre-brief",     title: "Discovery",            phases: ["Frame","Diverge","Converge","Prototype","Validate"], cmd: "/discovery:start", purpose: "From blank page to validated brief, before any code." },
+  { when: "Legacy systems",title: "Stock-taking",         phases: ["Scope","Audit","Synthesize","Handoff"],               cmd: "/stock:start",     purpose: "Inventory what's already there before changing it." },
+  { when: "Pre-contract",  title: "Sales Cycle",          phases: ["Qualify","Scope","Estimate","Propose","Order"],       cmd: "/sales:start",     purpose: "Win the engagement, then hand off the kickoff brief." },
+  { when: "Post-contract", title: "Project Manager",      phases: ["Initiate","Weekly","Change","Report","Close"],        cmd: "/project:start",   purpose: "Govern client delivery with P3.Express cadence." },
+  { when: "Multi-project", title: "Portfolio",            phases: ["X \u00b7 6-monthly","Y \u00b7 monthly","Z \u00b7 daily"], cmd: "/portfolio:start", purpose: "Manage a portfolio of programs with P5 Express cycles." },
+  { when: "Always-on",     title: "Roadmap Management",   phases: ["Shape","Align","Review","Communicate"],               cmd: "/roadmap:start",   purpose: "Outcome roadmaps that stay current with delivery signals." },
+  { when: "Readiness",     title: "Quality Assurance",    phases: ["Plan","Check","Review","Improve"],                    cmd: "/quality:start",   purpose: "ISO 9001-aligned readiness reviews and corrective actions." },
+  { when: "Onboarding",    title: "Project Scaffolding",  phases: ["Intake","Extract","Assemble","Handoff"],              cmd: "/scaffold:start",  purpose: "Turn folders and Markdown notes into a reviewable starter pack." },
+];
+
+function TrackGrid() {
+  return (
+    <section className="section tracks-section" id="tracks" aria-labelledby="tracks-title">
+      <div className="section-header">
+        <h2 id="tracks-title">Eight more tracks. All opt-in.</h2>
+        <p className="section-kicker">Specorator stays small at the core and grows on demand. Each track is a separate set of slash commands and agents &mdash; invoke the ones that match your context.</p>
+      </div>
+      <div className="track-grid" aria-label="Opt-in workflow tracks">
+        {TRACKS.map(t => (
+          <article key={t.title} className="track-card">
+            <header className="track-card-head">
+              <span className="track-when">{t.when}</span>
+              <h3>{t.title}</h3>
+            </header>
+            <ol className="track-phases">
+              {t.phases.map(p => <li key={p}>{p}</li>)}
+            </ol>
+            <p className="track-purpose">{t.purpose}</p>
+            <code className="track-cmd">{t.cmd}</code>
+          </article>
+        ))}
+      </div>
+      <p className="track-footnote">All eight tracks are optional and pluggable. <a href="#roster">See the agents that drive them &rarr;</a></p>
+    </section>
+  );
+}
+window.TrackGrid = TrackGrid;

--- a/.claude/skills/specorator-design/ui_kits/product-page/WhyPanels.jsx
+++ b/.claude/skills/specorator-design/ui_kits/product-page/WhyPanels.jsx
@@ -1,0 +1,20 @@
+// WhyPanels.jsx — Problem / Solution two-up
+function WhyPanels() {
+  return (
+    <section className="section" aria-labelledby="why-title">
+      <div className="split">
+        <article className="panel problem">
+          <p className="eyebrow">The problem</p>
+          <h2 id="why-title">AI coding tools often start in the wrong place.</h2>
+          <p>Most assistants jump straight to implementation. That can produce code quickly, but it also bakes in unclear requirements, missing decisions, and late-stage rework.</p>
+        </article>
+        <article className="panel solution">
+          <p className="eyebrow">The product</p>
+          <h2>Specs first, code second.</h2>
+          <p>Specorator turns software work into staged artifacts, specialist roles, quality gates, and traceable decisions so agents can move fast without guessing what humans meant.</p>
+        </article>
+      </div>
+    </section>
+  );
+}
+window.WhyPanels = WhyPanels;

--- a/.claude/skills/specorator-design/ui_kits/product-page/Workflow.jsx
+++ b/.claude/skills/specorator-design/ui_kits/product-page/Workflow.jsx
@@ -1,0 +1,57 @@
+// Workflow.jsx — discovery + lifecycle rails
+const DISCOVERY = [
+  ["Frame", "product-strategist", "discovery"],
+  ["Diverge", "divergent-thinker", "discovery"],
+  ["Converge", "critic", "discovery"],
+  ["Prototype", "prototyper", "discovery"],
+  ["Validate", "user-researcher", "discovery"],
+  ["Brief gate", "human", "gate"],
+];
+const LIFECYCLE = [
+  ["1. Idea", "analyst"],
+  ["2. Research", "analyst"],
+  ["3. Requirements", "pm"],
+  ["4. Design", "ux/ui/architect"],
+  ["5. Specification", "architect"],
+  ["6. Tasks", "planner"],
+  ["7. Implementation", "dev"],
+  ["8. Testing", "qa"],
+  ["9. Review", "reviewer"],
+  ["10. Release", "release-manager"],
+  ["11. Retrospective", "retrospective"],
+];
+
+function Stage({ name, owner, kind }) {
+  return (
+    <span className={`stage ${kind || "lifecycle"}`}>
+      <span className="stage-name">{name}</span>
+      <span className="stage-owner">{owner}</span>
+    </span>
+  );
+}
+
+function Workflow() {
+  return (
+    <section className="section" id="workflow" aria-labelledby="workflow-title">
+      <div className="section-header">
+        <h2 id="workflow-title">Two tracks, one source of truth.</h2>
+        <p className="section-kicker">Discovery creates the brief. The lifecycle turns it into tested, reviewed, releasable work.</p>
+      </div>
+      <div className="workflow" aria-label="Specorator workflow stages">
+        <div className="workflow-row">
+          <div className="workflow-label">Discovery <span className="workflow-label-meta">optional</span></div>
+          <div className="workflow-stages discovery-stages">
+            {DISCOVERY.map(([n, o, k]) => <Stage key={n} name={n} owner={o} kind={k} />)}
+          </div>
+        </div>
+        <div className="workflow-row">
+          <div className="workflow-label">Lifecycle <span className="workflow-label-meta">11 stages</span></div>
+          <div className="workflow-stages lifecycle-stages">
+            {LIFECYCLE.map(([n, o]) => <Stage key={n} name={n} owner={o} kind="lifecycle" />)}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+window.Workflow = Workflow;

--- a/.claude/skills/specorator-design/ui_kits/product-page/app.jsx
+++ b/.claude/skills/specorator-design/ui_kits/product-page/app.jsx
@@ -1,0 +1,27 @@
+// app.jsx — composition root
+function App() {
+  return (
+    <React.Fragment>
+      <Header />
+      <main id="main">
+        <Hero />
+        <WhyPanels />
+        <TeamGrid />
+        <FitGrid />
+        <FeatureGrid />
+        <AudienceGrid />
+        <Workflow />
+        <TrackGrid />
+        <Roster />
+        <RepoGrid />
+        <ArtifactExample />
+        <Faq />
+        <StartSteps />
+      </main>
+      <Footer />
+    </React.Fragment>
+  );
+}
+
+const root = ReactDOM.createRoot(document.getElementById("root"));
+root.render(<App />);

--- a/.claude/skills/specorator-design/ui_kits/product-page/assets/specorator-mark.svg
+++ b/.claude/skills/specorator-design/ui_kits/product-page/assets/specorator-mark.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Specorator mark">
+  <rect width="64" height="64" rx="14" fill="#17201B"></rect>
+  <path d="M20 24c0-6 5-10 14-10 6 0 11 2 15 5l-5 6c-3-2-6-3-10-3-4 0-6 1-6 3 0 2 2 3 8 4 10 2 15 5 15 12 0 7-6 11-16 11-7 0-13-2-17-6l5-6c4 3 8 4 13 4 5 0 7-1 7-3 0-2-2-3-8-4-10-2-15-5-15-13Z" fill="#E6FF70"></path>
+</svg>

--- a/.claude/skills/specorator-design/ui_kits/product-page/assets/specorator-workflow.svg
+++ b/.claude/skills/specorator-design/ui_kits/product-page/assets/specorator-workflow.svg
@@ -1,0 +1,65 @@
+<svg width="1040" height="720" viewBox="0 0 1040 720" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Specorator workflow artifact map</title>
+  <desc id="desc">A product-style workflow visual showing discovery, lifecycle stages, quality gates, and traceability artifacts.</desc>
+  <rect width="1040" height="720" rx="28" fill="#F7F8F4"></rect>
+  <rect x="48" y="44" width="944" height="632" rx="24" fill="#FFFFFF" stroke="#D8DED3" stroke-width="2"></rect>
+  <rect x="84" y="80" width="872" height="88" rx="18" fill="#17201B"></rect>
+  <text x="116" y="119" fill="#FAFBF8" font-family="Inter, Arial, sans-serif" font-size="28" font-weight="700">Specorator</text>
+  <text x="116" y="146" fill="#C7D5CD" font-family="Inter, Arial, sans-serif" font-size="16">Specs first. Agents in lanes. Quality gates before code moves.</text>
+  <rect x="766" y="104" width="154" height="40" rx="20" fill="#E6FF70"></rect>
+  <text x="804" y="130" fill="#17201B" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700">Ready to ship</text>
+
+  <text x="88" y="224" fill="#58635E" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing=".12em">DISCOVERY TRACK</text>
+  <rect x="84" y="244" width="136" height="74" rx="14" fill="#E6F6EF" stroke="#A8D9C4"></rect>
+  <text x="116" y="277" fill="#17201B" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="700">Frame</text>
+  <text x="111" y="299" fill="#59645E" font-family="Inter, Arial, sans-serif" font-size="13">Problem space</text>
+  <rect x="244" y="244" width="136" height="74" rx="14" fill="#E6F6EF" stroke="#A8D9C4"></rect>
+  <text x="275" y="277" fill="#17201B" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="700">Diverge</text>
+  <text x="280" y="299" fill="#59645E" font-family="Inter, Arial, sans-serif" font-size="13">Options</text>
+  <rect x="404" y="244" width="136" height="74" rx="14" fill="#E6F6EF" stroke="#A8D9C4"></rect>
+  <text x="433" y="277" fill="#17201B" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="700">Converge</text>
+  <text x="440" y="299" fill="#59645E" font-family="Inter, Arial, sans-serif" font-size="13">Brief</text>
+  <path d="M220 281H244" stroke="#7EA793" stroke-width="3" stroke-linecap="round"></path>
+  <path d="M380 281H404" stroke="#7EA793" stroke-width="3" stroke-linecap="round"></path>
+
+  <text x="88" y="382" fill="#58635E" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing=".12em">LIFECYCLE TRACK</text>
+  <g fill="#EEF1EA" stroke="#CAD3C7">
+    <rect x="84" y="404" width="96" height="62" rx="13"></rect>
+    <rect x="198" y="404" width="96" height="62" rx="13"></rect>
+    <rect x="312" y="404" width="110" height="62" rx="13"></rect>
+    <rect x="440" y="404" width="96" height="62" rx="13"></rect>
+    <rect x="554" y="404" width="118" height="62" rx="13"></rect>
+    <rect x="690" y="404" width="96" height="62" rx="13"></rect>
+    <rect x="804" y="404" width="108" height="62" rx="13"></rect>
+  </g>
+  <g fill="#17201B" font-family="Inter, Arial, sans-serif" font-size="14" font-weight="700">
+    <text x="118" y="441">Idea</text>
+    <text x="219" y="441">Research</text>
+    <text x="330" y="441">Requirements</text>
+    <text x="471" y="441">Design</text>
+    <text x="580" y="441">Specification</text>
+    <text x="713" y="441">Tasks</text>
+    <text x="828" y="441">Build</text>
+  </g>
+  <g stroke="#9AA89F" stroke-width="3" stroke-linecap="round">
+    <path d="M180 435H198"></path>
+    <path d="M294 435H312"></path>
+    <path d="M422 435H440"></path>
+    <path d="M536 435H554"></path>
+    <path d="M672 435H690"></path>
+    <path d="M786 435H804"></path>
+  </g>
+
+  <rect x="84" y="520" width="250" height="82" rx="16" fill="#FFF8D8" stroke="#E2CF73"></rect>
+  <text x="112" y="553" fill="#17201B" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="700">Quality gate</text>
+  <text x="112" y="579" fill="#59645E" font-family="Inter, Arial, sans-serif" font-size="14">Deterministic checks first, then review.</text>
+  <rect x="388" y="520" width="250" height="82" rx="16" fill="#EBF0FF" stroke="#B9C5ED"></rect>
+  <text x="416" y="553" fill="#17201B" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="700">Traceability</text>
+  <text x="416" y="579" fill="#59645E" font-family="Inter, Arial, sans-serif" font-size="14">Requirement to spec to task to test.</text>
+  <rect x="692" y="520" width="220" height="82" rx="16" fill="#F2E9FF" stroke="#D0B8F0"></rect>
+  <text x="720" y="553" fill="#17201B" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="700">PR discipline</text>
+  <text x="720" y="579" fill="#59645E" font-family="Inter, Arial, sans-serif" font-size="14">Worktree, verify, review, ship.</text>
+
+  <path d="M472 319C472 356 472 369 472 404" stroke="#7EA793" stroke-width="3" stroke-linecap="round" stroke-dasharray="7 8"></path>
+  <path d="M534 466C534 496 534 501 534 520" stroke="#8E98B8" stroke-width="3" stroke-linecap="round"></path>
+</svg>

--- a/.claude/skills/specorator-design/ui_kits/product-page/index.html
+++ b/.claude/skills/specorator-design/ui_kits/product-page/index.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Specorator UI Kit · Product Page</title>
+    <link rel="icon" href="assets/specorator-mark.svg" type="image/svg+xml">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&display=swap">
+    <link rel="stylesheet" href="kit.css">
+  </head>
+  <body>
+    <div id="root"></div>
+
+    <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+    <script type="text/babel" src="Header.jsx"></script>
+    <script type="text/babel" src="Hero.jsx"></script>
+    <script type="text/babel" src="WhyPanels.jsx"></script>
+    <script type="text/babel" src="TeamGrid.jsx"></script>
+    <script type="text/babel" src="FitGrid.jsx"></script>
+    <script type="text/babel" src="FeatureGrid.jsx"></script>
+    <script type="text/babel" src="AudienceGrid.jsx"></script>
+    <script type="text/babel" src="Workflow.jsx"></script>
+    <script type="text/babel" src="TrackGrid.jsx"></script>
+    <script type="text/babel" src="Roster.jsx"></script>
+    <script type="text/babel" src="RepoGrid.jsx"></script>
+    <script type="text/babel" src="ArtifactExample.jsx"></script>
+    <script type="text/babel" src="Faq.jsx"></script>
+    <script type="text/babel" src="StartSteps.jsx"></script>
+    <script type="text/babel" src="Footer.jsx"></script>
+    <script type="text/babel" src="app.jsx"></script>
+  </body>
+</html>

--- a/.claude/skills/specorator-design/ui_kits/product-page/kit.css
+++ b/.claude/skills/specorator-design/ui_kits/product-page/kit.css
@@ -1,0 +1,1359 @@
+:root {
+  color-scheme: light;
+  --ink: #17201b;
+  --muted: #59645e;
+  --paper: #fbfcf8;
+  --surface: #ffffff;
+  --line: #d8ded3;
+  --accent: #1b6f55;
+  --accent-strong: #12543f;
+  --highlighter: #e6ff70;
+  --soft-green: #e6f6ef;
+  --soft-blue: #ebf0ff;
+  --soft-yellow: #fff8d8;
+  --shadow: 0 24px 70px rgba(23, 32, 27, 0.13);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.5;
+}
+
+a {
+  color: inherit;
+}
+
+a:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 4px;
+}
+
+.skip-link {
+  position: absolute;
+  left: 16px;
+  top: 12px;
+  z-index: 50;
+  transform: translateY(-140%);
+  padding: 10px 14px;
+  border-radius: 8px;
+  background: var(--ink);
+  color: #fff;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 16px clamp(20px, 5vw, 72px);
+  background: rgba(251, 252, 248, 0.9);
+  border-bottom: 1px solid rgba(216, 222, 211, 0.8);
+  backdrop-filter: blur(16px);
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.brand-mark {
+  display: inline-grid;
+  width: 32px;
+  height: 32px;
+  place-items: center;
+  border-radius: 8px;
+  background: var(--ink);
+  color: var(--highlighter);
+  font-size: 18px;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: clamp(14px, 2.6vw, 30px);
+  color: var(--muted);
+  font-size: 14px;
+  font-weight: 650;
+}
+
+.nav-links a {
+  text-decoration: none;
+}
+
+.nav-links a:hover {
+  color: var(--ink);
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0 18px;
+  border: 1px solid var(--ink);
+  border-radius: 8px;
+  background: var(--ink);
+  color: #fff;
+  font-weight: 760;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.button:hover {
+  background: #0e1512;
+}
+
+.button.secondary {
+  background: transparent;
+  color: var(--ink);
+}
+
+.button.secondary:hover {
+  background: #eef1ea;
+}
+
+.button.highlight {
+  border-color: var(--highlighter);
+  background: var(--highlighter);
+  color: var(--ink);
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 0.82fr) minmax(360px, 1fr);
+  gap: clamp(32px, 6vw, 72px);
+  align-items: center;
+  min-height: calc(100vh - 65px);
+  padding: clamp(44px, 7vw, 92px) clamp(20px, 5vw, 72px) clamp(36px, 5vw, 64px);
+}
+
+.eyebrow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  margin: 0 0 18px;
+  color: var(--accent-strong);
+  font-size: 13px;
+  font-weight: 800;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: var(--soft-green);
+  color: var(--accent-strong);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+}
+
+.status-pill::before {
+  content: "";
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+
+.eyebrow-meta {
+  color: var(--muted);
+  font-weight: 700;
+  text-transform: none;
+  letter-spacing: 0.02em;
+  font-size: 12px;
+}
+
+.eyebrow-meta code {
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: rgba(23, 32, 27, 0.06);
+  color: var(--ink);
+  font-size: 11px;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 17ch;
+  margin-bottom: 22px;
+  font-size: clamp(44px, 6.6vw, 84px);
+  line-height: 0.98;
+  letter-spacing: -0.015em;
+}
+
+.hero-copy {
+  max-width: 640px;
+  color: var(--muted);
+  font-size: clamp(18px, 1.9vw, 24px);
+  line-height: 1.4;
+}
+
+.hero-copy strong {
+  color: var(--ink);
+  font-weight: 800;
+}
+
+.hero-copy em {
+  color: var(--accent-strong);
+  font-style: normal;
+  font-weight: 700;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  margin-top: 28px;
+}
+
+.hero-proof {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  max-width: 720px;
+  margin-top: 42px;
+}
+
+.proof-item {
+  padding-top: 14px;
+  border-top: 1px solid var(--line);
+}
+
+.proof-value {
+  display: block;
+  color: var(--ink);
+  font-size: 24px;
+  font-weight: 850;
+}
+
+.proof-label {
+  display: block;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.hero-visual {
+  margin: 0;
+}
+
+.hero-visual img {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: 28px;
+  box-shadow: var(--shadow);
+}
+
+.section {
+  padding: clamp(56px, 8vw, 104px) clamp(20px, 5vw, 72px);
+}
+
+.section.dark {
+  background: var(--ink);
+  color: #f8faf5;
+}
+
+.section-header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 34px;
+}
+
+.section-header h2 {
+  max-width: 760px;
+  margin-bottom: 0;
+  font-size: clamp(34px, 4.4vw, 58px);
+  line-height: 1.02;
+  letter-spacing: 0;
+}
+
+.section-kicker {
+  max-width: 410px;
+  color: var(--muted);
+  font-size: 18px;
+}
+
+.dark .section-kicker,
+.dark .card p,
+.dark .step p {
+  color: #c7d5cd;
+}
+
+.split {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 24px;
+}
+
+.panel {
+  min-height: 310px;
+  padding: clamp(26px, 4vw, 42px);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.panel.problem {
+  background: #fff8d8;
+}
+
+.panel.solution {
+  background: #e6f6ef;
+}
+
+.panel h2,
+.panel h3 {
+  margin-bottom: 16px;
+  font-size: clamp(28px, 3vw, 42px);
+  line-height: 1.08;
+}
+
+.panel p {
+  max-width: 680px;
+  color: var(--muted);
+  font-size: 18px;
+}
+
+.fit-section {
+  background: #f5f7f1;
+}
+
+.fit-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.fit-panel {
+  min-height: 340px;
+  padding: clamp(24px, 3.5vw, 38px);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.fit-panel.good-fit {
+  background: var(--soft-green);
+}
+
+.fit-panel.poor-fit {
+  background: #fff5ee;
+}
+
+.fit-panel h3 {
+  margin-bottom: 18px;
+  font-size: clamp(26px, 3vw, 38px);
+  line-height: 1.08;
+}
+
+.fit-list {
+  display: grid;
+  gap: 14px;
+  margin: 0;
+  padding-left: 20px;
+  color: var(--muted);
+  font-size: 17px;
+}
+
+.feature-grid,
+.audience-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.card {
+  min-height: 170px;
+  padding: 22px;
+  border: 1px solid rgba(216, 222, 211, 0.72);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.card.light {
+  background: var(--surface);
+}
+
+.card h3 {
+  margin-bottom: 10px;
+  font-size: 19px;
+}
+
+.card p {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 15px;
+}
+
+.audience-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: clamp(26px, 3.4vw, 36px);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--surface);
+  overflow: hidden;
+  transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.audience-card:hover {
+  border-color: var(--ink);
+  transform: translateY(-2px);
+  box-shadow: 0 12px 30px rgba(23, 32, 27, 0.07);
+}
+
+.audience-card::before {
+  content: attr(data-num);
+  position: absolute;
+  top: 12px;
+  right: 22px;
+  color: rgba(23, 32, 27, 0.06);
+  font-size: clamp(56px, 7vw, 84px);
+  font-weight: 850;
+  line-height: 1;
+  letter-spacing: -0.04em;
+  pointer-events: none;
+}
+
+.audience-card h3 {
+  position: relative;
+  margin: 0;
+  font-size: 20px;
+  letter-spacing: -0.01em;
+}
+
+.audience-card > p {
+  position: relative;
+  margin: 0;
+  color: var(--muted);
+  font-size: 15px;
+  line-height: 1.6;
+}
+
+.audience-say {
+  position: relative;
+  margin: 6px 0 0 !important;
+  color: var(--muted) !important;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 11px !important;
+  font-weight: 700 !important;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.audience-cta {
+  position: relative;
+  display: block;
+  padding: 10px 14px;
+  border-radius: 8px;
+  background: rgba(27, 111, 85, 0.08);
+  color: var(--accent-strong);
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 13px;
+  font-weight: 700;
+  word-break: break-word;
+}
+
+.workflow {
+  display: grid;
+  gap: 18px;
+}
+
+.workflow-row {
+  display: grid;
+  grid-template-columns: 190px 1fr;
+  gap: 18px;
+  align-items: stretch;
+}
+
+.workflow-label {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 20px;
+  border-radius: 8px;
+  background: var(--ink);
+  color: #fff;
+  font-weight: 800;
+}
+
+.workflow-label-meta {
+  margin-top: 6px;
+  color: rgba(248, 250, 245, 0.65);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.workflow-stages {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.stage {
+  display: flex;
+  flex: 1 1 140px;
+  flex-direction: column;
+  gap: 4px;
+  min-height: 64px;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 10px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 760;
+  text-align: center;
+}
+
+.lifecycle-stages .stage {
+  flex: 1 1 130px;
+  font-size: 12px;
+}
+
+.stage-name {
+  display: block;
+  line-height: 1.15;
+}
+
+.stage-owner {
+  display: block;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--muted);
+  letter-spacing: 0;
+  line-height: 1.2;
+}
+
+.stage.gate .stage-owner {
+  color: #6b5400;
+}
+
+.stage.gate {
+  background: var(--soft-yellow);
+}
+
+.stage.discovery {
+  background: var(--soft-green);
+}
+
+.stage.lifecycle {
+  background: var(--soft-blue);
+}
+
+.team-section {
+  background: #f5f7f1;
+}
+
+.team-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.team-card {
+  position: relative;
+  padding: clamp(22px, 2.6vw, 28px);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--surface);
+  transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+  overflow: hidden;
+}
+
+.team-card::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: var(--accent);
+}
+
+.team-card[data-lane="define"]::before {
+  background: #159166;
+}
+
+.team-card[data-lane="build"]::before {
+  background: #365fa3;
+}
+
+.team-card[data-lane="ship"]::before {
+  background: #d49a14;
+}
+
+.team-card:hover {
+  border-color: var(--ink);
+  transform: translateY(-2px);
+  box-shadow: 0 12px 30px rgba(23, 32, 27, 0.08);
+}
+
+.team-card-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 14px;
+}
+
+.team-num {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+}
+
+.team-lane {
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent-strong);
+  padding: 3px 9px;
+  border-radius: 999px;
+  background: #bce5d2;
+}
+
+.team-card[data-lane="build"] .team-lane {
+  color: #2d4a73;
+  background: #cbd9f7;
+}
+
+.team-card[data-lane="ship"] .team-lane {
+  color: #6b5400;
+  background: #f9e3a0;
+}
+
+.team-card h3 {
+  margin: 0 0 8px;
+  font-size: 22px;
+  letter-spacing: -0.01em;
+}
+
+.team-agents {
+  margin: 0 0 14px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.team-agents code {
+  display: inline-block;
+  padding: 2px 7px;
+  border-radius: 5px;
+  background: rgba(23, 32, 27, 0.06);
+  color: var(--ink);
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.team-desc {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.team-footnote {
+  margin: 28px 0 0;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.team-footnote code {
+  padding: 2px 7px;
+  border-radius: 5px;
+  background: rgba(23, 32, 27, 0.06);
+  color: var(--ink);
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.team-footnote a {
+  color: var(--accent-strong);
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.team-footnote a:hover {
+  color: var(--ink);
+}
+
+.tracks-section {
+  background: var(--paper);
+}
+
+.track-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.track-card {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: clamp(20px, 2.4vw, 26px);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--surface);
+  transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.track-card:hover {
+  border-color: var(--ink);
+  transform: translateY(-2px);
+  box-shadow: 0 12px 30px rgba(23, 32, 27, 0.07);
+}
+
+.track-card-head {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.track-when {
+  align-self: flex-start;
+  padding: 3px 9px;
+  border-radius: 999px;
+  background: var(--soft-green);
+  color: var(--accent-strong);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.track-card h3 {
+  margin: 0;
+  font-size: 20px;
+  letter-spacing: -0.01em;
+}
+
+.track-phases {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.track-phases li {
+  display: inline-flex;
+  align-items: center;
+}
+
+.track-phases li::after {
+  content: "\2027";
+  margin: 0 8px;
+  color: rgba(89, 100, 94, 0.45);
+}
+
+.track-phases li:last-child::after {
+  content: "";
+  margin: 0;
+}
+
+.track-purpose {
+  margin: 0;
+  flex: 1 1 auto;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.track-cmd {
+  align-self: flex-start;
+  padding: 5px 10px;
+  border-radius: 6px;
+  background: rgba(27, 111, 85, 0.08);
+  color: var(--accent-strong);
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 12.5px;
+  font-weight: 800;
+}
+
+.track-footnote {
+  margin: 28px 0 0;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.track-footnote a {
+  color: var(--accent-strong);
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.track-footnote a:hover {
+  color: var(--ink);
+}
+
+.roster-section {
+  background: var(--ink);
+}
+
+.roster-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.roster-group {
+  padding: clamp(22px, 3vw, 30px);
+  border: 1px solid rgba(248, 250, 245, 0.08);
+  border-radius: 12px;
+  background: rgba(248, 250, 245, 0.03);
+}
+
+.roster-group header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 6px;
+}
+
+.roster-group h3 {
+  margin: 0;
+  color: #f8faf5;
+  font-size: 20px;
+  letter-spacing: -0.01em;
+}
+
+.roster-count {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 12px;
+  color: rgba(248, 250, 245, 0.55);
+  letter-spacing: 0.04em;
+}
+
+.roster-desc {
+  margin: 0 0 16px;
+  font-size: 14px;
+  color: rgba(248, 250, 245, 0.7);
+}
+
+.roster-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.roster-list li {
+  margin: 0;
+}
+
+.roster-list code {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 6px;
+  background: rgba(230, 255, 112, 0.1);
+  color: var(--highlighter);
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.repo-section {
+  background: var(--paper);
+}
+
+.repo-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.repo-item {
+  min-height: 170px;
+  padding: 22px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.repo-item code {
+  display: inline-flex;
+  margin-bottom: 16px;
+  padding: 6px 9px;
+  border-radius: 6px;
+  background: var(--ink);
+  color: var(--highlighter);
+  font-size: 14px;
+  font-weight: 800;
+}
+
+.repo-item p {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 15px;
+}
+
+.example-section {
+  background: #eef1ea;
+}
+
+.faq-section {
+  background: var(--paper);
+}
+
+.faq-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(20px, 3vw, 32px);
+}
+
+.faq-item {
+  padding: clamp(22px, 3vw, 28px);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--surface);
+  transition: border-color 0.2s ease;
+}
+
+.faq-item:hover {
+  border-color: var(--ink);
+}
+
+.faq-item h3 {
+  margin: 0 0 12px;
+  font-size: 17px;
+  letter-spacing: -0.01em;
+  line-height: 1.3;
+}
+
+.faq-item p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14.5px;
+  line-height: 1.65;
+}
+
+.faq-item p code {
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: rgba(23, 32, 27, 0.06);
+  color: var(--ink);
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 12.5px;
+  font-weight: 700;
+}
+
+.faq-item p strong {
+  color: var(--ink);
+  font-weight: 800;
+}
+
+.artifact-chain {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+  margin-bottom: 28px;
+}
+
+.artifact-card {
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--surface);
+  overflow: hidden;
+  box-shadow: 0 6px 20px rgba(23, 32, 27, 0.04);
+}
+
+.artifact-card-head {
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--line);
+  background: rgba(23, 32, 27, 0.04);
+}
+
+.artifact-step {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--accent-strong);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.artifact-path {
+  padding: 0;
+  background: transparent;
+  color: var(--muted);
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.artifact-source {
+  flex: 1 1 auto;
+  margin: 0;
+  padding: 18px 20px;
+  background: var(--surface);
+  color: var(--ink);
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 12.5px;
+  line-height: 1.65;
+  white-space: pre-wrap;
+  overflow-x: auto;
+}
+
+.artifact-source .md-h1 {
+  color: var(--ink);
+  font-weight: 800;
+}
+
+.artifact-source .md-h2 {
+  color: var(--accent-strong);
+  font-weight: 700;
+}
+
+.artifact-source .md-id {
+  display: inline-block;
+  padding: 0 5px;
+  border-radius: 3px;
+  background: rgba(27, 111, 85, 0.1);
+  color: var(--accent-strong);
+  font-weight: 800;
+}
+
+.artifact-source .md-em {
+  color: #8a4a00;
+  font-weight: 700;
+}
+
+.artifact-meta {
+  display: grid;
+  grid-template-columns: minmax(0, 1.3fr) minmax(0, 1fr);
+  gap: clamp(20px, 4vw, 44px);
+  align-items: start;
+  padding: clamp(20px, 3vw, 28px);
+  border: 1px dashed var(--line);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.55);
+}
+
+.artifact-meta p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 16px;
+  line-height: 1.6;
+}
+
+.artifact-meta p code {
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: rgba(23, 32, 27, 0.06);
+  color: var(--ink);
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.artifact-list {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.artifact-list a {
+  display: inline-flex;
+  align-items: center;
+  color: var(--accent-strong);
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.artifact-list a:hover {
+  color: var(--ink);
+}
+
+.steps {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.step {
+  min-height: 220px;
+  padding: 24px;
+  border: 1px solid rgba(216, 222, 211, 0.22);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.step-number {
+  display: inline-grid;
+  width: 34px;
+  height: 34px;
+  margin-bottom: 22px;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--highlighter);
+  color: var(--ink);
+  font-weight: 850;
+}
+
+.step code {
+  color: #f8faf5;
+  font-size: 0.92em;
+}
+
+.quickstart {
+  display: grid;
+  grid-template-columns: minmax(240px, 0.8fr) minmax(0, 1.2fr);
+  gap: 20px;
+  align-items: center;
+  margin-top: 22px;
+  padding: 24px;
+  border: 1px solid rgba(216, 222, 211, 0.22);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.quickstart h3 {
+  margin-bottom: 8px;
+  font-size: 24px;
+}
+
+.quickstart p {
+  margin-bottom: 0;
+  color: #c7d5cd;
+}
+
+.terminal {
+  margin: 0;
+  border: 1px solid rgba(216, 222, 211, 0.18);
+  border-radius: 10px;
+  overflow: hidden;
+  background: #0e1512;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+}
+
+.terminal-chrome {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 10px 14px;
+  border-bottom: 1px solid rgba(216, 222, 211, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.terminal-dot {
+  display: inline-block;
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+}
+
+.terminal-dot-red {
+  background: #ff5f57;
+}
+
+.terminal-dot-yellow {
+  background: #febc2e;
+}
+
+.terminal-dot-green {
+  background: #28c840;
+}
+
+.terminal-title {
+  margin-left: 10px;
+  color: rgba(248, 250, 245, 0.55);
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 12px;
+  letter-spacing: 0;
+}
+
+.terminal pre,
+.quickstart pre {
+  margin: 0;
+  overflow-x: auto;
+  padding: 18px 20px;
+  background: #0e1512;
+  color: #f8faf5;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.terminal pre {
+  border-radius: 0;
+}
+
+.site-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 28px clamp(20px, 5vw, 72px);
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.footer-links a {
+  color: var(--ink);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+@media (max-width: 980px) {
+  .hero,
+  .split,
+  .fit-grid,
+  .artifact-chain,
+  .artifact-meta,
+  .quickstart,
+  .workflow-row {
+    grid-template-columns: 1fr;
+  }
+
+  .feature-grid,
+  .audience-grid,
+  .repo-grid,
+  .steps,
+  .team-grid,
+  .track-grid,
+  .faq-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .roster-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .section-header {
+    display: block;
+  }
+
+  .section-kicker {
+    margin-top: 14px;
+  }
+}
+
+@media (max-width: 720px) {
+  .site-header {
+    position: static;
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .nav-links {
+    width: 100%;
+    overflow-x: auto;
+    padding-bottom: 4px;
+  }
+
+  .hero {
+    min-height: auto;
+  }
+
+  h1 {
+    font-size: 46px;
+  }
+
+  .eyebrow {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .hero-proof,
+  .feature-grid,
+  .audience-grid,
+  .repo-grid,
+  .steps,
+  .team-grid,
+  .track-grid,
+  .faq-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .panel,
+  .card,
+  .fit-panel,
+  .repo-item,
+  .step {
+    min-height: auto;
+  }
+
+  .site-footer {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+  }
+}

--- a/docs/adr/0016-design-system-as-skill.md
+++ b/docs/adr/0016-design-system-as-skill.md
@@ -1,0 +1,109 @@
+---
+id: ADR-0016
+title: Adopt the specorator-design skill as the canonical brand source
+status: proposed
+date: 2026-05-01
+deciders:
+  - human
+consulted:
+  - product-page-designer
+  - reviewer
+informed:
+  - all stage agents
+  - operational bot owners
+supersedes: []
+superseded-by: []
+tags: [design-system, brand, skill, sites, tokens]
+---
+
+# ADR-0016 — Adopt the specorator-design skill as the canonical brand source
+
+## Status
+
+Proposed
+
+## Context
+
+Specorator's only user-visible surface today is the public product page at `sites/index.html`. Brand decisions — colors, type, spacing, radii, shadows, motion, voice, iconography rules, lane coding — currently live as raw values inside `sites/styles.css` and as implicit conventions in `sites/index.html`. There is no token file, no design-system documentation, and no way for an agent generating a new mock, slide, or future surface to consume the brand without re-deriving it from the rendered page.
+
+This produces three concrete failure modes:
+
+1. **Drift.** Each new HTML artifact (a deck, a doc preview, a future dashboard) re-invents `#17201b`, `#fbfcf8`, `#1b6f55`, `#e6ff70` from screenshots or memory. Small variations creep in.
+2. **Lost intent.** The non-negotiable rules — no emoji, no icons, cream paper not white, chartreuse as a pop not a wash, sentence-case headlines that end with a period, lane coding (Define = green, Build = blue, Ship = gold) — are not codified anywhere an agent can read. They live in the head of whoever last edited the product page.
+3. **No leverage when a second surface lands.** The moment a docs site, dashboard, onboarding flow, or printable artifact appears, the brand has to be re-exhumed from `sites/styles.css` rather than imported.
+
+A complete design system has been built externally: token CSS, brand README, asset pack, 22 preview specimen cards, a high-fidelity React UI kit, and a 6-slide reference deck. It is cross-compatible with the Claude Code skill format and is ready to drop into `.claude/skills/`.
+
+## Decision
+
+We adopt the **`specorator-design`** skill as the canonical source of truth for the Specorator brand and visual system.
+
+1. The skill ships under `.claude/skills/specorator-design/` as a peer to `.claude/skills/product-page/` and the other lifecycle/operational skills already in the tree.
+2. `colors_and_type.css` is the canonical token file. Every color, type, spacing, radius, shadow, and motion value used anywhere in the repo's UI surfaces derives from a `var(--token)` defined here.
+3. The `product-page-designer` agent gains a hard dependency on the skill: before editing `sites/`, it invokes `specorator-design`, lifts values from `colors_and_type.css`, and never invents new colors or weights. If a token is missing, the agent proposes an addition via PR before using it.
+4. The skill is `user-invocable: true` so humans (and other agents) can ask "design X with the Specorator brand" and get the right answer without having to spelunk `sites/styles.css`.
+5. Future surfaces (docs site, dashboard, decks, onboarding) consume the same skill. The brand is owned in one place.
+
+This ADR covers Phase 0 + Phase 1 of `docs/integration-plan-design-system.md`. Phase 2 (flipping `sites/styles.css` to consume the tokens) and Phase 3 (a brand-review gate at Stage 9) are explicitly out of scope for this ADR and will ship as separate, independently-reviewable PRs.
+
+## Considered options
+
+### Option A — Skill as the canonical brand source (chosen)
+
+- Pros: Cheap, reversible, matches how every other cross-cutting concern in the repo is codified (skills + agents + ADRs). Zero new dependencies. The skill is a folder of plain text and CSS; `git diff` works; humans and agents read the same files. Future surfaces inherit the brand for free. The `user-invocable` flag makes it discoverable.
+- Cons: Relies on agent discipline to actually invoke the skill before editing `sites/`. Token consolidation in `sites/styles.css` is deferred to Phase 2 — until then, the skill and `sites/styles.css` carry the same values in two places (intentional, but a small duplication tax during the transition).
+
+### Option B — Vendor a CSS-only build inside `sites/`
+
+- Pros: One file, no skill machinery; `sites/styles.css` imports it directly.
+- Cons: Duplicates the source of truth (the README, asset pack, UI kit, preview cards have nowhere to live). Future non-`sites/` surfaces (decks, dashboard, docs) have no clean way to consume it. Misses the point — the value isn't the CSS file alone, it's the bundle of tokens + rules + reference implementations.
+
+### Option C — Ship as an external npm package
+
+- Pros: Versioned, semver, can be consumed outside the repo.
+- Cons: Massive overhead at this scale (one product page, no current second surface). Adds a publish step, a release cadence, and a dependency on npm tooling that the rest of the repo doesn't need. Defer until there's a concrete external consumer.
+
+We choose Option A now. Option B is rejected because it discards the README, UI kit, and preview cards. Option C is rejected because the overhead doesn't pay back at this scale.
+
+## Consequences
+
+### Positive
+
+- One place to change a color. Every surface picks it up.
+- The non-negotiable brand rules (no emoji, no icons, cream not white, chartreuse as a pop, sentence-case headlines) are codified where agents and humans can read them.
+- Future surfaces get a working starting point: tokens, assets, components, a deck system.
+- The `product-page-designer` agent is no longer the sole keeper of brand intent.
+- The skill is `user-invocable`, so a human can ask "make me a slide with the Specorator brand" and get the right answer.
+
+### Negative
+
+- Until Phase 2 lands, `sites/styles.css` still carries literal color values alongside the token file — duplication during the transition.
+- The `product-page-designer` agent's preamble grows by one paragraph (the dependency on the skill). Forgetting to invoke it stalls the brand-consistency benefit.
+- One more skill to keep in sync with the live product page when the page evolves. Mitigated by Phase 2 (flip the dependency direction so `sites/styles.css` imports the tokens).
+
+### Neutral
+
+- The skill folder is read-only reference material from the perspective of most agents — only the `product-page-designer` and a future `brand-reviewer` (Phase 3) write to it.
+- No CI surface ships with this ADR. Phase 3 introduces the gate.
+- `sites/` is unchanged in this PR. Visual output is byte-identical.
+
+## Compliance
+
+- `.claude/skills/specorator-design/` carries the canonical brand assets, tokens, rules, and reference implementations.
+- `.claude/agents/product-page-designer.md` is updated to invoke the skill before editing `sites/`.
+- `docs/integration-plan-design-system.md` carries the staged rollout (Phases 0–4); this ADR covers Phases 0 + 1.
+- No new CI surface ships with this ADR. A follow-up ADR will introduce the brand-review gate (Phase 3) once the skill has been in use long enough to know what the gate should check.
+
+## References
+
+- [`.claude/skills/specorator-design/README.md`](../../.claude/skills/specorator-design/README.md)
+- [`.claude/skills/specorator-design/SKILL.md`](../../.claude/skills/specorator-design/SKILL.md)
+- [`.claude/skills/specorator-design/colors_and_type.css`](../../.claude/skills/specorator-design/colors_and_type.css)
+- [`.claude/agents/product-page-designer.md`](../../.claude/agents/product-page-designer.md)
+- [`docs/integration-plan-design-system.md`](../integration-plan-design-system.md)
+- Live site — <https://luis85.github.io/agentic-workflow/>
+- Constitution Article IV (Quality Gates), Article IX (Reversibility).
+
+---
+
+> **ADR bodies are immutable.** To change a decision, supersede it with a new ADR; only the predecessor's `status` and `superseded-by` pointer fields may be updated.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -28,6 +28,7 @@ Records of architecturally significant decisions. Format follows Michael Nygard'
 | [0013](0013-add-obsidian-as-ui-layer.md) | Add Obsidian as an opt-in UI layer | Proposed |
 | [0014](0014-shard-log-shaped-artifacts-for-bases.md) | Shard log-shaped artifacts for Bases | Proposed |
 | [0015](0015-codify-codex-pr-review-loop.md) | Codify a bounded Codex review loop on every pull request | Proposed |
+| [0016](0016-design-system-as-skill.md) | Adopt the specorator-design skill as the canonical brand source | Proposed |
 <!-- END GENERATED: adr-index -->
 
 ## Conventions

--- a/docs/integration-plan-design-system.md
+++ b/docs/integration-plan-design-system.md
@@ -1,0 +1,214 @@
+# Integration plan — Specorator design system → `agentic-workflow` repo
+
+> A staged, reviewable rollout of the Specorator design system into the `Luis85/agentic-workflow` repository. Each phase is independently shippable, leaves the repo in a working state, and produces an artifact you can review.
+>
+> Follow Specorator's own conventions: branch per phase, ADR for any structural decision, retro after the rollout completes.
+
+**Owner:** TBD (suggest: the `product-page-designer` agent + a human reviewer)
+**Estimated total effort:** ~6 hours across four PRs, spread over a week.
+
+---
+
+## Phase 0 — Decide, then commit
+
+Before any file moves, ratify the direction with a single ADR so future agents understand the intent.
+
+**Branch:** `design-system/adr-tokens-source-of-truth`
+
+**Files:**
+- `docs/adr/0016-design-system-as-skill.md`
+
+**ADR template content:**
+- **Status:** Proposed → Accepted
+- **Context:** The product page (`sites/`) is the only user-visible surface today. Brand decisions live as raw values in `sites/styles.css` and are re-derived ad-hoc whenever an agent generates a mock or slide.
+- **Decision:** Adopt the `specorator-design` skill as the canonical brand source. Promote `colors_and_type.css` to a token file consumed by `sites/styles.css`. The skill is a peer to `.claude/agents/`, not a sub-folder of `sites/`.
+- **Consequences:** New surfaces (docs, app, decks) inherit the brand for free. The `product-page-designer` agent gains a hard dependency. One change for one color, everywhere.
+- **Alternatives considered:** Vendor a CSS-only build inside `sites/` (rejected — duplicates the source); ship as an external npm package (rejected — overhead doesn't pay back at this scale).
+
+**Acceptance:** ADR merged to `main`. No code changes in this PR.
+
+---
+
+## Phase 1 — Drop the skill in (lightest touch, biggest unlock)
+
+The skill is already cross-compatible. Copy it in and wire one agent to consume it. Nothing else changes.
+
+**Branch:** `design-system/skill-drop-in`
+
+**File moves:**
+
+```
+.claude/
+  skills/
+    specorator-design/
+      SKILL.md
+      README.md
+      colors_and_type.css
+      assets/
+        specorator-mark.svg
+        specorator-workflow.svg
+      ui_kits/product-page/      ← reference impl, lift snippets from
+      preview/                   ← specimen cards
+      slides/                    ← deck system
+```
+
+**Steps:**
+1. `git checkout -b design-system/skill-drop-in`
+2. Download this project as a zip → unzip into `.claude/skills/specorator-design/`
+3. Delete `.claude/skills/specorator-design/sites/` — duplicates the live source; keep the skill lean.
+4. Delete `.claude/skills/specorator-design/INTEGRATION_PLAN.md` (this file) — it lives in `docs/`, not the skill.
+5. Add `.claude/skills/specorator-design/CHANGELOG.md` with `## 0.1.0 — Initial import`
+6. Update `.claude/agents/product-page-designer.md` — add to its preamble:
+
+   > Before editing `sites/`, invoke the `specorator-design` skill. Lift values from `colors_and_type.css`; never invent new colors or weights. If a token is missing, propose an addition via PR before using it.
+
+7. Add the skill to `docs/specorator.md` under "Skills" so humans discover it too.
+
+**Acceptance:**
+- `tree -L 2 .claude/skills/specorator-design/` shows the expected layout
+- `npm run verify` passes
+- A spot-check ask to the `product-page-designer` agent ("regenerate the hero CTA") references tokens by name, not hex codes.
+
+**PR description should link:** ADR-0016, the live preview of the skill's `ui_kits/product-page/index.html`, and a screenshot of any specimen card.
+
+---
+
+## Phase 2 — Make `sites/styles.css` consume the tokens
+
+Flip the relationship so `colors_and_type.css` is the source of truth. Backward-compatible — visual output is byte-identical.
+
+**Branch:** `design-system/sites-uses-tokens`
+
+**Steps:**
+1. `git checkout -b design-system/sites-uses-tokens`
+2. At the top of `sites/styles.css`, add:
+
+   ```css
+   @import url("../.claude/skills/specorator-design/colors_and_type.css");
+   ```
+
+3. Walk through `sites/styles.css` and replace literals with the `var(--token)` they correspond to:
+   - `#17201b` → `var(--ink)`
+   - `#fbfcf8` → `var(--paper)`
+   - `#1b6f55` → `var(--accent)`
+   - `#e6ff70` → `var(--highlighter)`
+   - …etc, one block at a time
+4. Keep the original `:root { ... }` block in `sites/styles.css` for now — it's a no-op once everything references vars, and removing it is a separate cleanup.
+5. Diff the rendered page against `main` (Percy, Playwright snapshot, or a manual side-by-side) to prove zero visual drift.
+6. **Optional cleanup commit:** delete the now-redundant `:root` declarations from `sites/styles.css`.
+
+**Acceptance:**
+- Visual diff: 0 pixel changes against `main`.
+- `grep -c "#17201b" sites/styles.css` returns `0`
+- `npm run verify` passes
+- Lighthouse / Pages deploy succeeds
+
+**Risk:** Relative `@import` from `sites/styles.css` to `.claude/skills/...` works locally and in GitHub Pages because both are static. Confirm by previewing the Pages deploy from the PR branch before merging.
+
+---
+
+## Phase 3 — Add a brand-review gate
+
+Specorator's value is *gates*. Give the design system one too.
+
+**Branch:** `design-system/brand-review-gate`
+
+**Files:**
+
+```
+.claude/agents/
+  brand-reviewer.md                ← new agent
+templates/
+  brand-review-checklist.md        ← new
+docs/
+  quality-framework.md             ← edit: add brand-review row
+  specorator.md                    ← edit: mention in Stage 9
+```
+
+**`brand-reviewer.md` responsibilities:**
+
+The agent runs at Stage 9 (Review) for any feature whose diff touches:
+- `sites/`
+- `.claude/skills/specorator-design/`
+- any new HTML / CSS / JSX file producing user-visible UI
+
+Its mechanical checklist (drives the agent's output):
+
+1. ✅ Imports `colors_and_type.css` rather than redefining tokens
+2. ✅ Uses `var(--paper)` for page backgrounds (never `#fff`)
+3. ✅ Zero emoji in copy or markup
+4. ✅ Zero icon imports unless an ADR justifies the addition
+5. ✅ Headlines are sentence-case and end with a period
+6. ✅ Em-dashes (`—`) used for asides; no en-dashes (`–`)
+7. ✅ `--highlighter` used only for: brand mark, primary CTA, step numbers, code chips on dark backgrounds
+8. ✅ Lane coding intact: Define = green, Build = blue, Ship = gold
+9. ✅ Sentence-case mono used for slash commands and IDs
+10. ✅ No new color introduced without addition to `colors_and_type.css`
+
+The agent **delegates to** `reviewer` (doesn't replace it) and posts findings as PR review comments with file/line citations.
+
+**Acceptance:**
+- A deliberately broken PR (e.g. `background: #fff` in a new component) gets caught
+- A clean PR passes silently
+- `docs/quality-framework.md` lists "Brand review" as a Stage 9 gate with link to checklist
+
+---
+
+## Phase 4 — Promote design to a first-class track *(deferred)*
+
+Open `/design:start` as an opt-in track alongside Discovery, Stock-taking, etc. Worth doing **only when a second user-visible surface exists** (docs site, app dashboard, onboarding flow). Until then, the skill + brand-reviewer cover the load.
+
+**When to revisit:** the moment you have a second surface to design.
+
+**Sketch:**
+
+```
+Phases: Frame → Sketch → Spec → Mock → Handoff
+Agents: ux-designer, ui-designer, + specorator-design skill
+Command: /design:start
+```
+
+Slot it into `docs/specorator.md` "Eight more tracks" → it becomes "Nine".
+
+---
+
+## Workflow conformance
+
+This rollout itself follows the Specorator method. Each phase produces:
+
+| Phase | Stage | Artifact                                                |
+| ----- | ----- | ------------------------------------------------------- |
+| 0     | 5     | `0016-design-system-as-skill.md`                        |
+| 1     | 6→9   | `.claude/skills/specorator-design/` + agent prompt edit |
+| 2     | 6→9   | `sites/styles.css` consumes tokens                      |
+| 3     | 5+6→9 | `brand-reviewer` agent + checklist                      |
+| 4     | TBD   | `/design:start` track                                   |
+
+**Mandatory retro after Phase 3 merges.** Capture: what worked, where the brand-reviewer false-positives, whether the token consolidation surfaced inconsistencies the design system itself should resolve.
+
+---
+
+## Quick-reference: what to copy from this project
+
+When you run Phase 1, these are the files that move into `.claude/skills/specorator-design/`:
+
+```
+README.md                          → skill README (already complete)
+SKILL.md                           → skill descriptor (already cross-compatible)
+colors_and_type.css                → root tokens
+assets/                            → 2 svgs
+preview/                           → 22 specimen cards (optional but useful)
+ui_kits/product-page/              → reference React kit (read-only example)
+slides/                            → 9-slide deck system + deck-stage.js
+```
+
+These do **not** move (project-only, not part of the skill):
+- `sites/`           — duplicates what's already in the repo
+- `INTEGRATION_PLAN.md` (this file)  — lives in `docs/` instead
+- `.claude/`         — n/a, this project has no `.claude/`
+
+---
+
+## What I'd do first, if I were you
+
+If you only have an hour: **Phase 0 + Phase 1.** Ship the ADR, drop the skill into `.claude/skills/`, wire one agent to consume it. Everything else is incremental polish on top.

--- a/tools/automation-registry.yml
+++ b/tools/automation-registry.yml
@@ -628,6 +628,15 @@ entries:
     emits_json: false
     used_by: [agent]
     rerun_command: open .claude/skills/sales-cycle/SKILL.md
+  - id: skill:specorator-design
+    kind: skill
+    path: .claude/skills/specorator-design/SKILL.md
+    purpose: Agent-facing brand and design system skill — canonical tokens, voice, iconography rules, UI kit components.
+    read_only: true
+    safe_to_run_locally: true
+    emits_json: false
+    used_by: [agent]
+    rerun_command: open .claude/skills/specorator-design/SKILL.md
   - id: skill:specorator-improvement
     kind: skill
     path: .claude/skills/specorator-improvement/SKILL.md


### PR DESCRIPTION
## Summary

Phase 0 + Phase 1 of [`docs/integration-plan-design-system.md`](docs/integration-plan-design-system.md) in a single, reviewable PR. **No visual changes to `sites/`** — Phase 2 is a follow-up.

- **Phase 0 — ratify the direction.** Adds [ADR-0016](docs/adr/0016-design-system-as-skill.md). Decides that `specorator-design` is the canonical brand source, ships under `.claude/skills/`, and that the `product-page-designer` agent depends on it.
- **Phase 1 — drop the skill in.** Adds `.claude/skills/specorator-design/` (SKILL.md, README, CHANGELOG, `colors_and_type.css` tokens, asset pack, 22 preview specimen cards, product-page UI kit, 6-slide deck system) and patches [`product-page-designer`](.claude/agents/product-page-designer.md) to invoke the skill before editing `sites/`.
- Registers the skill in [`tools/automation-registry.yml`](tools/automation-registry.yml) and refreshes [`docs/adr/README.md`](docs/adr/README.md) via `npm run fix`.

## What this PR explicitly does **not** do

- Does **not** modify `sites/index.html` or `sites/styles.css`. Visual output byte-identical to `main`.
- Does **not** flip `sites/styles.css` to import the tokens — Phase 2, separate PR.
- Does **not** add a brand-review gate — Phase 3, separate PR.
- Does **not** touch any other agent or skill. Only `product-page-designer` gains the brand dependency.

## Acceptance checks

- [x] `npm run verify` passes
- [x] `git diff main -- sites/` is empty
- [x] ADR-0016 renders in the ADR index
- [x] Skill registered in `tools/automation-registry.yml`
- [ ] Spot-check: ask `product-page-designer` to "regenerate the hero CTA" — response references tokens by name (`var(--ink)`, `var(--highlighter)`), not raw hex codes.

## Why this matters

Brand decisions for `sites/` currently live as raw values in `sites/styles.css` and as implicit conventions. New surfaces re-derive colors, type, and rules ad-hoc. The non-negotiable rules (no emoji, no icons, cream paper not white, chartreuse as a pop, sentence-case headlines, lane coding) live nowhere an agent can read. This PR fixes both: one source of truth for tokens, one place where the rules are written down, and one agent wired up to consume them. See [ADR-0016](docs/adr/0016-design-system-as-skill.md) for full rationale.

## Follow-up PRs

- **Phase 2** — flip `sites/styles.css` to `@import` the tokens; replace literal hex codes with `var(--token)`. Visual diff: 0 pixels.
- **Phase 3** — add a `brand-reviewer` agent + checklist as a Stage 9 gate.
- **Phase 4** *(deferred)* — promote design to a first-class `/design:start` track once a second user-visible surface exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)