### PR TITLE
feat(workflow): adopt inputs/ as canonical ingestion folder (ADR-0017)

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -23,6 +23,7 @@ One-line pointers into `.claude/memory/`. Read first. See [`README.md`](./README
 - **PR title CI** — title metadata must use the allowed Conventional Commit type before handoff. See [`feedback_pr_title_ci.md`](./feedback_pr_title_ci.md).
 - **Memory edits are docs-only** — no changeset, no bundling with code. See [`feedback_memory_edits.md`](./feedback_memory_edits.md).
 - **Token-budget review** — quarterly or pre-release: `/token-review` runs the audit + emits a per-area cleanup plan. See [`token-budget-review`](../skills/token-budget-review/SKILL.md).
+- **Inputs ingestion** — work packages land in `inputs/`; every conductor consults it at intake; no auto-extract. See [`docs/inputs-ingestion.md`](../../docs/inputs-ingestion.md) ([ADR-0017](../../docs/adr/0017-adopt-inputs-folder-as-canonical-ingestion-zone.md)).
 
 ## How this index is maintained
 

--- a/.claude/skills/_shared/conductor-pattern.md
+++ b/.claude/skills/_shared/conductor-pattern.md
@@ -1,10 +1,21 @@
 # Conductor pattern (shared)
 
-> Shared scaffolding for workflow-conductor skills. Linked from `orchestrate`, `discovery-sprint`, `sales-cycle`, `stock-taking`. Not auto-loaded — the linking skill keeps trigger logic inline; this file owns the gating + escalation rules.
+> Shared scaffolding for workflow-conductor skills. Linked from `orchestrate`, `discovery-sprint`, `sales-cycle`, `stock-taking`, `portfolio-track`. Not auto-loaded — the linking skill keeps trigger logic inline; this file owns the gating + escalation rules. Conductors that do not link this file (`project-run`, `project-scaffolding`, `roadmap-management`, `quality-assurance`, `specorator-improvement`) carry the intake gate inline by reference.
 
 ## AskUserQuestion is main-thread only
 
 `AskUserQuestion` works only in the main thread. Subagents cannot ask the user anything. Every clarification happens in the conductor's turn — before, between, or after a phase — never inside a dispatched specialist.
+
+## Intake gate — consult `inputs/` first
+
+Before scoping any new work package, **list `inputs/` non-recursively** and surface every item to the user in a single `AskUserQuestion` (multi-select): "I see N items in `inputs/`. Which are relevant for this work?"
+
+- If `inputs/` is empty, print one line ("`inputs/` is empty — no source material to consult") and proceed.
+- **Never auto-extract** zips, PDFs, or compressed archives. If a relevant item is an archive, run a separate `AskUserQuestion` asking for explicit approval to extract.
+- Read selected items at depth appropriate to the track. Cite paths into `inputs/` from the canonical artifact (`idea.md`, `chosen-brief.md`, `scope.md`, …) so source lineage stays auditable.
+- After the work package is consumed, recommend a retention action (per-track default in [`docs/inputs-ingestion.md`](../../../docs/inputs-ingestion.md)) and let the user decide. Never delete from `inputs/` without confirmation.
+
+Full contract: [`docs/inputs-ingestion.md`](../../../docs/inputs-ingestion.md). Decision: [ADR-0017](../../../docs/adr/0017-adopt-inputs-folder-as-canonical-ingestion-zone.md).
 
 ## Detect resume vs. fresh start
 

--- a/.claude/skills/project-run/SKILL.md
+++ b/.claude/skills/project-run/SKILL.md
@@ -36,6 +36,7 @@ Run when:
 
 ### Phase 0 — Orientation
 
+0. **Intake gate.** Before asking the user to describe the engagement, list `inputs/` non-recursively and surface every item via a single `AskUserQuestion`: "I see N items in `inputs/`. Which are relevant for this engagement?" If `inputs/` is empty, print one line ("`inputs/` is empty — no source material to consult") and proceed. Never auto-extract zips or archives — extraction is a separate, explicitly approved step. Cite paths into `inputs/` from `project-description.md` and other canonical artifacts. Full contract: [`docs/inputs-ingestion.md`](../../../docs/inputs-ingestion.md). Decision: [ADR-0017](../../../docs/adr/0017-adopt-inputs-folder-as-canonical-ingestion-zone.md).
 1. Ask the user to describe the engagement in one paragraph: who is the client, what are they getting, when, and at what cost (if known).
 2. Confirm the user wants the full project management layer (not just a Specorator feature). If they're uncertain, explain the difference (see `docs/project-track.md` §1).
 3. Ask for a project slug (engagement-level name, not solution name). Suggest corrections if needed.

--- a/.claude/skills/project-scaffolding/SKILL.md
+++ b/.claude/skills/project-scaffolding/SKILL.md
@@ -27,10 +27,11 @@ You conduct the Project Scaffolding Track defined in [`docs/project-scaffolding-
 
 ## Procedure
 
+0. **Intake gate.** List `inputs/` non-recursively before asking for source pointers — work packages dropped there are the default scaffolding source. Surface every item via a single `AskUserQuestion`: "I see N items in `inputs/`. Which are relevant for this scaffold?" If the user picks items in `inputs/`, those become (or augment) the source pointer at step 2. Never auto-extract archives — extraction is a separate, explicitly approved step. Cite paths into `inputs/` from `intake.md` and `extraction.md`. Full contract: [`docs/inputs-ingestion.md`](../../../docs/inputs-ingestion.md). Decision: [ADR-0017](../../../docs/adr/0017-adopt-inputs-folder-as-canonical-ingestion-zone.md).
 1. Detect resumable engagements under `scaffolding/` with `status: active`, `paused`, or `blocked`.
 2. For a fresh engagement, clarify in one user gate:
    - project slug,
-   - source pointer(s),
+   - source pointer(s) — default to items selected from `inputs/` at step 0,
    - desired starter outputs,
    - whether the material describes an existing system that may require Stock-taking.
 3. Run `/scaffold:start <slug> <source-pointer>`.

--- a/.claude/skills/quality-assurance/SKILL.md
+++ b/.claude/skills/quality-assurance/SKILL.md
@@ -56,6 +56,7 @@ Every check uses this evidence-first shape:
 
 ## Procedure
 
+0. **Intake gate.** List `inputs/` non-recursively before scoping. Surface every item via a single `AskUserQuestion`: "I see N items in `inputs/`. Which are relevant for this quality review?" Common QA inputs: prior audit reports, supplier evidence packs, customer complaints, regulator letters, certificate copies. Never auto-extract archives. Cite paths into `inputs/` from `quality-plan.md` and checklist evidence fields. Full contract: [`docs/inputs-ingestion.md`](../../../docs/inputs-ingestion.md). Decision: [ADR-0017](../../../docs/adr/0017-adopt-inputs-folder-as-canonical-ingestion-zone.md).
 1. **Start.** Establish scope, product/service boundary, interested parties, applicable lifecycle/project artifacts, quality objectives, and evidence locations. Record whether this is internal readiness, supplier assurance, release readiness, or formal audit preparation.
 2. **Plan.** Create a quality plan and checklist set. Derive checks from scoped artifacts instead of using only generic ISO labels.
 3. **Check.** Execute checklist items against evidence. Run deterministic verification where available. Record gaps plainly and keep open items visible.

--- a/.claude/skills/roadmap-management/SKILL.md
+++ b/.claude/skills/roadmap-management/SKILL.md
@@ -30,6 +30,7 @@ Do not run when:
 
 ## Procedure
 
+0. **Intake gate.** List `inputs/` non-recursively before scoping. Surface every item via a single `AskUserQuestion`: "I see N items in `inputs/`. Which are relevant for this roadmap work?" Common roadmap inputs: stakeholder briefs, prior roadmap exports, OKRs, customer feedback bundles, leadership memos. If `inputs/` is empty, print one line and proceed. Never auto-extract archives. Cite paths into `inputs/` from `roadmap-board.md` and `stakeholder-map.md`. Full contract: [`docs/inputs-ingestion.md`](../../../docs/inputs-ingestion.md). Decision: [ADR-0017](../../../docs/adr/0017-adopt-inputs-folder-as-canonical-ingestion-zone.md).
 1. Detect roadmaps by scanning for `roadmaps/*/roadmap-state.md`.
 2. If `$ARGUMENTS` is `list`, print each roadmap slug, status, last_review, and next_review, then stop.
 3. If no roadmap exists, ask for a roadmap slug and run `/roadmap:start <slug>`.

--- a/.claude/skills/specorator-improvement/SKILL.md
+++ b/.claude/skills/specorator-improvement/SKILL.md
@@ -29,6 +29,7 @@ This skill is for **the template repository**. If the request is about a product
 
 ## Improvement loop
 
+0. **Intake gate.** List `inputs/` non-recursively before framing. Surface every item via a single `AskUserQuestion`: "I see N items in `inputs/`. Which are relevant for this improvement?" Improvement work often arrives as a pre-staged zip (design system, plugin pack, vendor handoff) — those are exactly the work packages this gate is for. Never auto-extract archives — extraction is a separate, explicitly approved step. Cite paths into `inputs/` from the lifecycle artifact at step 2. Full contract: [`docs/inputs-ingestion.md`](../../../docs/inputs-ingestion.md). Decision: [ADR-0017](../../../docs/adr/0017-adopt-inputs-folder-as-canonical-ingestion-zone.md).
 1. **Frame the improvement.** State the problem, user scenario, non-goals, and the expected artifact or automation. Example: "When an active contributor changes workflow docs, the template should detect quality drift before PR."
 2. **Trace it.** Find or create the lifecycle artifact under `specs/<feature>/` that owns the change. Requirements and tasks must use stable IDs when the change is non-trivial.
 3. **Classify scope.** Decide whether the change touches scripts, tooling, workflow, docs, agents, skills, templates, state/schema, product page, operational agents, or ADRs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ Repo = **template for spec-driven, agentic software development**. Defines workf
 - **ADRs for irreversible decisions.** Architecturally load-bearing → ADR in `docs/adr/`. Use `templates/adr-template.md`. ADR bodies are immutable; supersede to change.
 - **Update workflow state.** Hand off a stage → update `specs/<feature>/workflow-state.md`.
 - **Keep a product page alive.** Public page at `sites/index.html`; prefer GitHub Pages. Update in the same PR as user-visible changes.
+- **Consult `inputs/` at intake.** Every conductor's scope phase lists `inputs/` and asks the user which items are relevant. Never auto-extract zips or archives — extraction is always a confirmed step. See [`docs/inputs-ingestion.md`](docs/inputs-ingestion.md) and [ADR-0017](docs/adr/0017-adopt-inputs-folder-as-canonical-ingestion-zone.md).
 - **Escalate ambiguity.** No guessing. Ask the human or open a `clarifications` block.
 - **No direct commits on `main` / `develop`.** Every change lands via topic branch + merged PR. Push deny is the backstop, not the gate. See [`.claude/memory/feedback_no_main_commits.md`](.claude/memory/feedback_no_main_commits.md).
 - **Branch per concern; verify before push.** One concern per PR; `verify` green locally; never `--no-verify`. See [`docs/branching.md`](docs/branching.md), [`docs/worktrees.md`](docs/worktrees.md), [`docs/verify-gate.md`](docs/verify-gate.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ Each track produces a handoff artifact that feeds the next: `chosen-brief.md`, `
 - For irreversible architectural decisions, use [`record-decision`](.claude/skills/record-decision/SKILL.md) (wraps `/adr:new`).
 - For glossary terms, use [`/glossary:new "<term>"`](.claude/commands/glossary/new.md) (wraps [`new-glossary-entry`](.claude/skills/new-glossary-entry/SKILL.md)). Entries live one-per-file under [`docs/glossary/`](docs/glossary/).
 - Where every markdown artifact lands is documented in [`docs/sink.md`](docs/sink.md). Don't invent new sink locations.
+- New work packages (briefs, RFPs, zips, reference material) land in [`inputs/`](inputs/). Every conductor consults `inputs/` at the start of its scope phase. No auto-extract — see [`docs/inputs-ingestion.md`](docs/inputs-ingestion.md).
 - Don't add `.claudeignore` exclusions silently — note them in `docs/steering/tech.md`.
 
 ## What not to do

--- a/docs/adr/0017-adopt-inputs-folder-as-canonical-ingestion-zone.md
+++ b/docs/adr/0017-adopt-inputs-folder-as-canonical-ingestion-zone.md
@@ -1,0 +1,124 @@
+---
+id: ADR-0017
+title: Adopt `inputs/` as the canonical ingestion folder for new work packages
+status: proposed
+date: 2026-05-01
+deciders:
+  - human
+consulted:
+  - orchestrate
+  - discovery-sprint
+  - stock-taking
+  - sales-cycle
+  - project-run
+  - portfolio-track
+  - project-scaffolding
+  - roadmap-management
+  - quality-assurance
+  - specorator-improvement
+informed:
+  - all stage agents
+  - all track conductor skills
+supersedes: []
+superseded-by: []
+tags: [workflow, intake, ingestion, conventions, methodology]
+---
+
+# ADR-0017 — Adopt `inputs/` as the canonical ingestion folder for new work packages
+
+## Status
+
+Proposed
+
+## Context
+
+Work that lands in this repo arrives in many shapes — RFP PDFs, design system zips, brief documents from clients, reference architectures, exported research bundles, screenshots, OpenAPI specs, slide decks, ZIP archives of pre-staged content, and more. Today every track (Specorator lifecycle, Discovery, Stock-taking, Sales, Project Manager, Project Scaffolding, Roadmap, Portfolio, Quality, Specorator Improvement) handles intake differently:
+
+- The **Project Scaffolding Track** has a formal Intake phase that asks for source pointers, but it covers only fresh template installs.
+- Other tracks rely on whatever the user pastes into the prompt or remembers to attach.
+- Materials sometimes get dropped into ad-hoc folders (`./docs/`, `./scratch/`, the user's Downloads folder, parent directories) that conductors do not look at, so they go unconsulted.
+- When source material is large or binary (zips, PDFs, big folder trees) the user has no canonical, agent-readable location to put it before invoking a conductor.
+
+This produces three concrete failure modes:
+
+1. **Missed evidence.** A conductor scopes work without consulting source material the user already collected, then re-asks the user for context they thought they had already provided.
+2. **Inconsistent placement.** Each track teaches a different folder convention, so the user has to remember which track wants what.
+3. **No retention contract.** Even when material lands somewhere, there is no rule for what happens to it after the work package is consumed.
+
+The recently-imported `inputs/Specorator Design System.zip` work package made the gap concrete: the user dropped a zip in the project root next to a new folder, asked the assistant to "use the input folder for next steps", and the assistant had to invent the convention on the spot.
+
+## Decision
+
+We adopt **`inputs/`** at the repository root as the canonical ingestion folder for new work packages — files, folders, or archives — that any track may need to read.
+
+1. **Single canonical location.** All conductor skills consult `inputs/` at the start of their scope phase before asking the user for source material.
+2. **Tracked, not gitignored.** `inputs/` is committed. Small artifacts (briefs, reference docs, zips up to a few MB) live alongside the workflow that consumes them. Sensitive material is excluded by per-file rules in `.gitignore`, not a blanket folder ignore.
+3. **No automatic extraction.** Archives are never extracted, decoded, or transformed without an explicit human-approved step. The conductor reads the file listing, surfaces what it found, and asks the user which items are relevant for the active work.
+4. **Every conductor asks.** The 10 conversational entry points (`orchestrate`, `discovery-sprint`, `stock-taking`, `sales-cycle`, `project-run`, `portfolio-track`, `project-scaffolding`, `roadmap-management`, `quality-assurance`, `specorator-improvement`) consult `inputs/` even when the active track does not strictly require external material — the cost of asking is small, the cost of missing evidence is large.
+5. **Retention is per-track.** Once a work package is consumed (its content captured into the track's canonical artifacts — `idea.md`, `chosen-brief.md`, `scope.md`, `stock-taking-inventory.md`, etc.), the user decides whether to delete the source from `inputs/` or keep it for traceability. The convention is captured in [`docs/inputs-ingestion.md`](../inputs-ingestion.md) and [`inputs/README.md`](../../inputs/README.md).
+
+The methodology document [`docs/inputs-ingestion.md`](../inputs-ingestion.md) is the canonical reference; this ADR ratifies its existence and the cross-track obligation.
+
+## Considered options
+
+### Option A — `inputs/` as the canonical ingestion folder, every conductor asks (chosen)
+
+- Pros: One folder to remember. Every track honours the same convention. Source material is committed and traceable. No magic — extraction always asks. Cheap to retrofit (one shared paragraph in `_shared/conductor-pattern.md` plus per-skill bullets).
+- Cons: A new top-level folder. The user must clean up `inputs/` after a work package is consumed if they care about repo size.
+
+### Option B — Per-track ingestion folders (`discovery/inputs/`, `sales/inputs/`, …)
+
+- Pros: Material lives next to the track that consumes it.
+- Cons: User has to know which track they are starting before placing the file. Cross-track work packages (e.g., a brief that drives Discovery → Specorator → Project Manager) have no clean home. Fragments the convention.
+
+### Option C — Ad-hoc folders + per-skill prompts
+
+- Pros: Zero convention to enforce.
+- Cons: This is the status quo, and it produced the failure modes that motivate this ADR.
+
+### Option D — Cloud bucket / external store with metadata pointer
+
+- Pros: Solves the "large binary in git" worry.
+- Cons: Massive overhead at this scale. Adds a vendor dependency the rest of the repo does not need. Defer until an `inputs/` payload is large enough to justify it.
+
+We choose Option A. Option B fragments the convention. Option C is the status quo. Option D is overkill for the current scale and easy to migrate to later (the convention is a folder; replacing it with a pointer file is a one-ADR change).
+
+## Consequences
+
+### Positive
+
+- One place to drop source material. Every conductor looks there.
+- Source material is committed alongside the workflow that consumed it, so a future agent (human or AI) can reconstruct what was on the desk when the decision was made.
+- New conductors inherit the convention by linking `_shared/conductor-pattern.md` (already linked by 5 of the 10 conductors).
+- Removes a class of "did you check the zip in my downloads?" round-trips.
+
+### Negative
+
+- One more top-level folder. Discoverability is solved by the `README.md` in `inputs/` and the AGENTS.md operating rule.
+- Committed binaries grow the repo over time. Mitigated by the per-track retention guidance in `docs/inputs-ingestion.md` (default: delete after consumption unless traceability demands keeping it).
+- `inputs/` is not gitignored, so a careless commit could publish a sensitive PDF. Mitigated by per-file `.gitignore` rules and the operator note in `inputs/README.md`.
+
+### Neutral
+
+- Conductors that already have a formal Intake phase (`project-scaffolding`) gain a redundant-but-cheap pre-check; this is intentional, since `inputs/` is the cross-track contract.
+- No new agent or skill ships with this ADR. The behaviour is encoded in the conductor pattern + per-skill bullets + the AGENTS.md rule.
+
+## Compliance
+
+- `inputs/README.md` is committed and documents folder purpose, retention policy, and what not to put in it.
+- `docs/inputs-ingestion.md` is the methodology reference, linked from AGENTS.md, CLAUDE.md, and every conductor skill.
+- `_shared/conductor-pattern.md` carries the canonical intake gate.
+- Each of the 10 conductor skills references the intake gate in its scope phase.
+- A `check:` script may later verify that every conductor SKILL.md mentions the intake gate; not shipped with this ADR.
+
+## References
+
+- [`docs/inputs-ingestion.md`](../inputs-ingestion.md) — methodology and cross-track contract
+- [`inputs/README.md`](../../inputs/README.md) — folder purpose and retention rules
+- [`.claude/skills/_shared/conductor-pattern.md`](../../.claude/skills/_shared/conductor-pattern.md) — shared intake gate
+- Constitution Article VII (Human Oversight) — no automatic extraction without explicit approval
+- Constitution Article IX (Reversibility) — extraction and consumption are explicit, scoped actions
+
+---
+
+> **ADR bodies are immutable.** To change a decision, supersede it with a new ADR; only the predecessor's `status` and `superseded-by` pointer fields may be updated.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -28,6 +28,7 @@ Records of architecturally significant decisions. Format follows Michael Nygard'
 | [0013](0013-add-obsidian-as-ui-layer.md) | Add Obsidian as an opt-in UI layer | Proposed |
 | [0014](0014-shard-log-shaped-artifacts-for-bases.md) | Shard log-shaped artifacts for Bases | Proposed |
 | [0015](0015-codify-codex-pr-review-loop.md) | Codify a bounded Codex review loop on every pull request | Proposed |
+| [0017](0017-adopt-inputs-folder-as-canonical-ingestion-zone.md) | Adopt `inputs/` as the canonical ingestion folder for new work packages | Proposed |
 <!-- END GENERATED: adr-index -->
 
 ## Conventions

--- a/docs/inputs-ingestion.md
+++ b/docs/inputs-ingestion.md
@@ -1,0 +1,138 @@
+---
+title: "Inputs ingestion methodology"
+folder: "docs"
+description: "Cross-track contract for the canonical `inputs/` ingestion folder — where work packages land, how conductors consult them, and how retention is decided."
+entry_point: false
+---
+
+# Inputs ingestion methodology
+
+> Cross-track contract for the canonical `inputs/` ingestion folder. Adopted by [ADR-0017](adr/0017-adopt-inputs-folder-as-canonical-ingestion-zone.md). Linked from `AGENTS.md`, `CLAUDE.md`, and every conductor skill.
+
+## What `inputs/` is
+
+`inputs/` is the **single canonical location** at the repository root where humans drop source material that drives a piece of work — briefs, RFPs, design system zips, screenshots, OpenAPI specs, exported research, slide decks, reference architectures, anything else.
+
+It is **the** place to put work packages before invoking a conductor. Every conductor consults it.
+
+## What `inputs/` is *not*
+
+- **Not** a long-term archive. Retention is per-track; default behaviour is to delete after consumption unless traceability demands keeping the source.
+- **Not** an automatic extraction zone. Archives are never unpacked without explicit human approval (Constitution Article VII).
+- **Not** a place for sensitive material. Items in `inputs/` are committed and visible to everyone with repo access. Sensitive PDFs, credentials, signed contracts, or anything covered by an NDA must be excluded with per-file `.gitignore` rules — never committed and then deleted later.
+- **Not** a substitute for canonical artifacts. Once a work package is consumed, its content lives in the track's canonical artifact (`idea.md`, `chosen-brief.md`, `scope.md`, `stock-taking-inventory.md`, etc.); the file in `inputs/` is the *source*, not the truth.
+
+## How conductors consult it
+
+Every conductor skill (`orchestrate`, `discovery-sprint`, `stock-taking`, `sales-cycle`, `project-run`, `portfolio-track`, `project-scaffolding`, `roadmap-management`, `quality-assurance`, `specorator-improvement`) runs an **intake gate** at the start of its scope phase:
+
+1. **List `inputs/` non-recursively.** Surface every item — file or folder — to the user.
+2. **Single `AskUserQuestion`** asking the user which items are relevant to the active work. Multi-select.
+3. **For zips and large folders, never extract or recurse without explicit approval.** Extraction is a separate confirmed step.
+4. **Read the relevant items** at depth appropriate to the track (a brief is read; a 100-file folder is sampled and the user is asked which paths matter).
+5. **Capture content into the canonical artifact** for the track (e.g., a brief read by `discovery-sprint` becomes context for `frame.md`; an architecture zip read by `stock-taking` becomes evidence cited in `audit.md`).
+6. **Record the source** — every quote, decision, or constraint lifted from `inputs/` is cited by relative path in the canonical artifact, so the lineage is auditable.
+
+The shared scaffolding lives in [`.claude/skills/_shared/conductor-pattern.md`](../.claude/skills/_shared/conductor-pattern.md). Conductors that link the shared file inherit the gate; conductors that do not link it carry an inline reference.
+
+## Why "every conductor asks"
+
+The cost of asking the user "I see N items in `inputs/`, which are relevant?" is one extra question per conductor invocation. The cost of missing evidence is rework, missed constraints, and the user repeating themselves. Asking always is the cheaper default.
+
+If `inputs/` is empty, the gate prints one line ("`inputs/` is empty — no source material to consult") and proceeds.
+
+## Retention policy
+
+Retention is **per-track** and **always the user's decision**. Defaults:
+
+| Track | Default retention | Why |
+|---|---|---|
+| `discovery-sprint` | Delete after `chosen-brief.md` is written | Source material is captured into the brief; archive is the brief, not the inputs. |
+| `stock-taking` | Keep until `stock-taking-inventory.md` is approved | Auditors may want to verify lifted facts against source. |
+| `sales-cycle` | Keep until `order.md` is signed | Pre-contract evidence is load-bearing during negotiation. |
+| `orchestrate` (Specorator lifecycle) | Delete after Stage 1 (`idea.md`) | Source material is captured into the idea. |
+| `project-scaffolding` | Keep until `handoff.md` is accepted | The scaffolder's whole job is to lift evidence out of source folders. |
+| `project-run`, `portfolio-track`, `roadmap-management`, `quality-assurance`, `specorator-improvement` | Decide per work package | These tracks vary; the conductor asks the user. |
+
+The user can always override the default — keep for traceability, delete for cleanliness, move to a per-track location for posterity. The conductor recommends; the human decides.
+
+## What to put in `inputs/`
+
+| Material | OK in `inputs/`? | Notes |
+|---|---|---|
+| Briefs, RFPs, problem statements | Yes | Even if a few pages. |
+| Reference architectures, OpenAPI specs, schemas | Yes | Cite in canonical artifact. |
+| Design system zips, asset packs | Yes | Do not auto-extract; ask first. |
+| Screenshots of competitor product | Yes | Compress before committing if large. |
+| Exported research bundles, interview transcripts | Yes | Anonymise PII before committing. |
+| Slide decks (PDF, PPTX) | Yes | Convert to PDF for diff-friendliness. |
+| Build artifacts, compiled binaries | No | These belong in `.gitignore`. |
+| Credentials, API keys, signed contracts | **No** | Per-file `.gitignore`; never commit. |
+| Anything covered by an NDA | **No** | Same. |
+| Files larger than ~5 MB | Discuss first | Consider Git LFS, an external store, or a pointer file. |
+
+## What conductors do *not* do
+
+- **Do not** auto-extract zips, PDFs, or compressed archives. Always ask.
+- **Do not** commit content from `inputs/` into anywhere outside the canonical artifact tree (`specs/`, `discovery/`, etc.) without explicit human direction.
+- **Do not** delete items from `inputs/` automatically. Retention is the user's call.
+- **Do not** treat `inputs/` as authoritative — it is the *source*, not the truth. The canonical artifact is the truth.
+
+## Per-track examples
+
+### Discovery Sprint
+
+```
+User runs /discovery:start.
+Conductor lists inputs/ → ["client-brief.pdf", "user-interviews/"]
+Conductor asks: "I see 2 items in inputs/. Which are relevant for this sprint?"
+User selects both.
+Conductor reads client-brief.pdf into the Frame phase as JTBD evidence.
+Conductor samples 3 of 12 user-interviews and cites them in frame.md.
+After validation, chosen-brief.md is written.
+Conductor asks: "Discovery sprint is wrapping. Default is to delete inputs/client-brief.pdf
+and inputs/user-interviews/ now that chosen-brief.md captures the content. Keep, delete,
+or move to discovery/<slug>/sources/?"
+```
+
+### Stock-taking
+
+```
+User runs /stock:start on a brownfield project.
+Conductor lists inputs/ → ["legacy-arch-diagrams.zip", "ops-runbook.pdf", "DB_SCHEMA.sql"]
+Conductor asks: "Which of these are relevant for the audit?"
+User selects all three.
+Conductor asks: "legacy-arch-diagrams.zip is a 12 MB archive. Extract for inventory?"
+User approves.
+Conductor extracts to inputs/legacy-arch-diagrams/ (preserves the zip).
+audit.md cites paths into inputs/legacy-arch-diagrams/ and inputs/ops-runbook.pdf.
+After handoff, inputs are kept until stock-taking-inventory.md is approved.
+```
+
+### Specorator Improvement (this very feature)
+
+```
+User runs the specorator-improvement loop with inputs/Specorator Design System.zip in place.
+Conductor lists inputs/ → ["Specorator Design System.zip"]
+Conductor asks: "I see 1 item. Is it the source for this improvement?"
+User confirms + asks for extraction approval.
+Conductor extracts, reads PR_DESCRIPTION.md and integration-plan-design-system.md,
+proposes Phase 0+1 as the work package.
+After the design-system PR is opened, the zip can be deleted (its content is now in
+.claude/skills/specorator-design/).
+```
+
+## Compliance
+
+- `inputs/README.md` is committed and documents folder purpose + retention.
+- This file (`docs/inputs-ingestion.md`) is the canonical methodology reference.
+- AGENTS.md carries the operating rule: "Consult `inputs/` at the start of every track."
+- `.claude/skills/_shared/conductor-pattern.md` carries the shared intake gate.
+- Every conductor skill references the gate in its scope phase.
+
+## See also
+
+- [ADR-0017](adr/0017-adopt-inputs-folder-as-canonical-ingestion-zone.md) — decision rationale
+- [`inputs/README.md`](../inputs/README.md) — folder purpose at a glance
+- [`.claude/skills/_shared/conductor-pattern.md`](../.claude/skills/_shared/conductor-pattern.md) — shared scaffolding
+- Constitution Article VII (Human Oversight) and Article IX (Reversibility)

--- a/docs/sink.md
+++ b/docs/sink.md
@@ -20,6 +20,7 @@ Where every markdown artifact in this kit lives, who owns it, and how it evolves
 │   ├── traceability.md                      # ID scheme REQ → SPEC → T → code → TEST
 │   ├── ears-notation.md                     # EARS reference
 │   ├── sink.md                              # this file
+│   ├── inputs-ingestion.md                  # cross-track contract for inputs/ ingestion folder (per ADR-0017)
 │   ├── steering/                            # persistent scoped context
 │   │   ├── product.md
 │   │   ├── tech.md
@@ -145,6 +146,8 @@ Where every markdown artifact in this kit lives, who owns it, and how it evolves
 │       ├── idea.md, research.md, …          # same artifact set as specs/<slug>/
 │       └── adr/                             # project-local ADRs for the example (NOT docs/adr/)
 │           └── NNNN-<slug>.md               # project-local sequence, e.g. ADR-CLI-0001
+├── inputs/                                  # canonical ingestion folder for new work packages (per ADR-0017)
+│   └── README.md                            # purpose, retention rules, what does/does not belong here
 ├── sites/                                   # public product page (directly openable static entrypoint)
 │   ├── index.html
 │   ├── styles.css                           # optional
@@ -358,6 +361,20 @@ This is a lazy companion artifact, not a new lifecycle stage. `release-notes.md`
 When a team needs to manage **multiple parallel features** or operates as a **service provider**, the Portfolio Track adds a management layer above the Specorator. It lives at `portfolio/<portfolio-slug>/` parallel to `specs/` and `discovery/`. See [`docs/portfolio-track.md`](portfolio-track.md) for the methodology and [ADR-0009](adr/0009-add-portfolio-manager-role.md) for the rationale.
 
 A portfolio is bootstrapped with `/portfolio:start <slug>`. The three cycle commands populate the five management documents. The portfolio track is **read-only on the `specs/` side** — it never modifies spec artifacts.
+
+## Inputs sub-tree
+
+`inputs/` is the **canonical ingestion folder** for new work packages — files, folders, or archives that drive a piece of work but are not themselves canonical artifacts. Adopted by [ADR-0017](adr/0017-adopt-inputs-folder-as-canonical-ingestion-zone.md). Full contract: [`docs/inputs-ingestion.md`](inputs-ingestion.md).
+
+- **Tracked, not gitignored.** Items committed alongside the work that consumes them. Sensitive material excluded by per-file `.gitignore` rules, never stored in `inputs/`.
+- **No automatic extraction.** Conductors list `inputs/` and ask which items are relevant; archives are extracted only after explicit human approval.
+- **Source, not truth.** Once consumed, content lives in the canonical artifact (`idea.md`, `chosen-brief.md`, `scope.md`, `stock-taking-inventory.md`, `intake.md`, …). Items in `inputs/` are cited by relative path so source lineage stays auditable.
+- **Retention is per-track.** Default retention rules in [`docs/inputs-ingestion.md`](inputs-ingestion.md). The user always decides keep/delete/move.
+
+| Path | Owned by | Mutability |
+|---|---|---|
+| `inputs/README.md` | Human (template maintainer) | Updated when convention or retention rules change |
+| `inputs/<file>` or `inputs/<folder>/` | Human (work-package contributor) | Append-on-drop, delete-on-consumption |
 
 ## Examples sub-tree
 

--- a/inputs/README.md
+++ b/inputs/README.md
@@ -1,0 +1,44 @@
+---
+title: "Inputs"
+folder: "inputs"
+description: "Canonical ingestion folder for new work packages — briefs, RFPs, design system zips, reference material — that any track may consult."
+entry_point: true
+---
+
+# Inputs
+
+Canonical ingestion folder for new **work packages** — files, folders, or archives that drive a piece of work.
+
+Drop source material here before invoking a conductor (`/orchestrate`, `/discovery:start`, `/stock:start`, `/sales:start`, `/project:start`, `/portfolio:start`, `/scaffold:start`, `/roadmap:start`, `/quality:start`, or any `/specorator:*` command). Every conductor consults this folder at the start of its scope phase and asks which items are relevant for the active work.
+
+> **Methodology:** [`docs/inputs-ingestion.md`](../docs/inputs-ingestion.md) — full cross-track contract, intake protocol, retention policy.
+>
+> **Decision:** [ADR-0017](../docs/adr/0017-adopt-inputs-folder-as-canonical-ingestion-zone.md).
+
+## Quick rules
+
+1. **Drop source material here.** Briefs, RFPs, reference architectures, design system zips, screenshots, OpenAPI specs, exported research bundles, slide decks.
+2. **Conductors ask before extracting.** Zips, PDFs, and compressed archives are never unpacked automatically — extraction is always a confirmed step.
+3. **Items are committed.** Small artifacts (a few MB) live alongside the workflow that consumes them.
+4. **Retention is your call.** After a work package is consumed (its content captured into the track's canonical artifact — `idea.md`, `chosen-brief.md`, `scope.md`, `stock-taking-inventory.md`, etc.), keep, delete, or move per the per-track defaults in [`docs/inputs-ingestion.md`](../docs/inputs-ingestion.md).
+5. **No sensitive material.** Credentials, signed contracts, NDA-covered content do **not** belong here. Use per-file `.gitignore` rules instead.
+
+## What does *not* belong here
+
+- Build artifacts, compiled binaries — `.gitignore` them.
+- Credentials, API keys, signed legal documents — never commit.
+- Files larger than ~5 MB without prior discussion — consider Git LFS, an external store, or a pointer file.
+- Long-term archive material — `inputs/` is for *active* work packages, not historical record.
+
+## Convention at a glance
+
+```
+inputs/
+  README.md                    ← this file (committed)
+  client-brief.pdf             ← source for a Discovery sprint, deleted after chosen-brief.md
+  legacy-arch.zip              ← source for a Stock-taking audit, kept until inventory approved
+  Specorator-Design.zip        ← source for a Specorator improvement, deleted after PR opens
+  rfp-acme/                    ← multi-file RFP for a Sales cycle, kept until order.md signed
+```
+
+The folder is allowed to be empty when there is no active work package. An empty `inputs/` is a feature, not a bug — the conductor's intake gate will print one line ("`inputs/` is empty — no source material to consult") and proceed.


### PR DESCRIPTION
## Summary

Codifies a **cross-track convention**: every conductor consults `inputs/` at the start of its scope phase before asking the user for source material. Adopts [ADR-0017](docs/adr/0017-adopt-inputs-folder-as-canonical-ingestion-zone.md).

- **Single canonical location** for new work packages — briefs, RFPs, design system zips, reference architectures, exported research, etc.
- **Tracked, not gitignored.** Items committed alongside the work that consumes them.
- **No auto-extract.** Archives are unpacked only after explicit human approval.
- **Every conductor asks.** All 10 conversational entry points (`orchestrate`, `discovery-sprint`, `stock-taking`, `sales-cycle`, `project-run`, `portfolio-track`, `project-scaffolding`, `roadmap-management`, `quality-assurance`, `specorator-improvement`) honour the same intake protocol.
- **Retention is per-track**, the user always decides.

## What changed

| File | Why |
|---|---|
| `docs/adr/0017-adopt-inputs-folder-as-canonical-ingestion-zone.md` | Decision rationale, alternatives, consequences. |
| `docs/inputs-ingestion.md` | Cross-track methodology contract (intake protocol, retention table, do / don't). |
| `inputs/README.md` | Folder purpose, quick rules, what does / does not belong. |
| `.claude/skills/_shared/conductor-pattern.md` | New "Intake gate" section — covers `orchestrate`, `discovery-sprint`, `sales-cycle`, `stock-taking`, `portfolio-track` by linkage. |
| `.claude/skills/{project-run,project-scaffolding,quality-assurance,roadmap-management,specorator-improvement}/SKILL.md` | Inline intake-gate reference — the 5 conductors that don't link the shared file. |
| `AGENTS.md` | Operating rule: "Consult `inputs/` at intake." |
| `CLAUDE.md` | Convention bullet pointing at the methodology doc. |
| `.claude/memory/MEMORY.md` | Indexed (Case B per `feedback_memory_edits.md` — codifies a new convention). |
| `docs/sink.md` | Layout entry + Inputs sub-tree section. |

## Why this matters

Before this PR, each track handled intake differently. Material dropped into ad-hoc folders (`./docs/`, `./scratch/`, the user's Downloads) went unconsulted. Conductors re-asked the user for context they thought they had already provided. The recent `inputs/Specorator Design System.zip` work package made the gap concrete — the assistant had to invent the convention on the spot.

This PR makes the convention canonical: one folder, every conductor honours it, no automatic extraction.

## Acceptance checks

- [x] `npm run verify` passes
- [x] ADR-0017 renders in the ADR index
- [x] Every conductor SKILL.md mentions the intake gate (5 inline + 5 via shared file)
- [x] `inputs/README.md` exists, has frontmatter, and documents retention
- [x] `docs/sink.md` lists the new sub-tree

## What this PR does *not* do

- Does **not** ship a `check:` script that verifies every conductor mentions the intake gate (that's a follow-up tooling change).
- Does **not** modify any existing conductor's *flow* beyond inserting the intake-gate step at scope-phase start.
- Does **not** change `.gitignore` — `inputs/` is intentionally tracked.
- Does **not** auto-extract or read any zip currently in `inputs/`. Extraction remains a human-approved step every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)