### PR TITLE
docs(product-box): bump ADR slot 0017 -> 0019

### DIFF
--- a/docs/superpowers/plans/2026-05-01-product-box.md
+++ b/docs/superpowers/plans/2026-05-01-product-box.md
@@ -35,7 +35,7 @@ sites/box/styles.css                               box-page styles (lifts brand 
 sites/box/og-card.svg                              static social-share image
 sites/box/README.md                                folder entry doc
 docs/product-box.md                                methodology doc
-docs/adr/0017-add-product-box-feature.md           ADR
+docs/adr/0019-add-product-box-feature.md           ADR
 
 scripts/lib/product-box/types.ts                   TypeScript types for box.yml
 scripts/lib/product-box/validate.ts                schema validator
@@ -121,15 +121,15 @@ Expected: both paths exist. No copy or restore needed — these are tracked on `
 
 If either file is missing, the design PR has not yet merged; abort and wait for it to land before continuing.
 
-### Task 1.2: File ADR-0017
+### Task 1.2: File ADR-0019
 
 **Files:**
-- Create: `docs/adr/0017-add-product-box-feature.md`
+- Create: `docs/adr/0019-add-product-box-feature.md`
 
 - [ ] **Step 1: Run the new-adr skill or copy the template**
 
 ```bash
-cp templates/adr-template.md docs/adr/0017-add-product-box-feature.md
+cp templates/adr-template.md docs/adr/0019-add-product-box-feature.md
 ```
 
 - [ ] **Step 2: Fill ADR content**
@@ -138,7 +138,7 @@ Replace the template body with:
 
 ```markdown
 ---
-id: ADR-0017
+id: ADR-0019
 title: Add product-box feature for early-stage envisioned-product visualization
 status: accepted
 date: 2026-05-01
@@ -153,7 +153,7 @@ superseded-by: []
 tags: [product-page, visualization, agent, skill]
 ---
 
-# ADR-0017 — Add product-box feature for early-stage envisioned-product visualization
+# ADR-0019 — Add product-box feature for early-stage envisioned-product visualization
 
 ## Status
 
@@ -242,7 +242,7 @@ Cons: no agent judgment for tone or brand voice; hard to extend; contradicts exi
 npm run fix:adr-index
 ```
 
-Expected: `docs/adr/README.md` regenerated with ADR-0017 entry.
+Expected: `docs/adr/README.md` regenerated with ADR-0019 entry.
 
 - [ ] **Step 4: Verify ADR check passes**
 
@@ -255,8 +255,8 @@ Expected: exit 0, no output errors.
 - [ ] **Step 5: Commit**
 
 ```bash
-git add docs/adr/0017-add-product-box-feature.md docs/adr/README.md
-git commit -m "docs(adr): file ADR-0017 for product-box feature"
+git add docs/adr/0019-add-product-box-feature.md docs/adr/README.md
+git commit -m "docs(adr): file ADR-0019 for product-box feature"
 ```
 
 ### Task 1.3: Write methodology doc
@@ -323,7 +323,7 @@ The box agent owns this slot. The product-page agent must not strip or rewrite c
 
 ## See also
 
-- ADR-0017 — `docs/adr/0017-add-product-box-feature.md`
+- ADR-0019 — `docs/adr/0019-add-product-box-feature.md`
 - Spec — `docs/superpowers/specs/2026-05-01-product-box-design.md`
 - Plan — `docs/superpowers/plans/2026-05-01-product-box.md`
 - Skill — `.claude/skills/product-box/SKILL.md`
@@ -1497,7 +1497,7 @@ You do **not** resolve sources, prompt the user, or write `box.yml`. Those are t
 - `.claude/skills/product-box/SKILL.md` (contract).
 - `.claude/skills/specorator-design/SKILL.md` (brand tokens).
 - `docs/superpowers/specs/2026-05-01-product-box-design.md` (spec).
-- `docs/adr/0017-add-product-box-feature.md` (decision).
+- `docs/adr/0019-add-product-box-feature.md` (decision).
 
 ## Brand dependency
 
@@ -1636,7 +1636,7 @@ The `orchestrate` skill calls `/product:box` after `/spec:idea`, `/discovery:han
 - Don't strip or rewrite `sites/index.html` content outside the slot markers.
 - Don't invent tokens, customer logos, integrations, metrics, or roadmap commitments.
 - Don't bypass the schema. Box is concept-tier but still bounded.
-- Don't carry feature-level scope. One box per repo, project-level only (per ADR-0017).
+- Don't carry feature-level scope. One box per repo, project-level only (per ADR-0019).
 ```
 
 - [ ] **Step 2: Write `README.md`**
@@ -1654,7 +1654,7 @@ entry_point: false
 See `SKILL.md` (this folder) for the contract and procedure. Pairs with `.claude/agents/product-box-designer.md` (rendering) and `scripts/lib/product-box/` (libs).
 
 Spec: `docs/superpowers/specs/2026-05-01-product-box-design.md`.
-ADR: `docs/adr/0017-add-product-box-feature.md`.
+ADR: `docs/adr/0019-add-product-box-feature.md`.
 Methodology: `docs/product-box.md`.
 ```
 
@@ -2104,7 +2104,7 @@ Standalone, deployable visualization of the envisioned product. Owned by the `pr
 
 Do not edit the HTML, CSS, or SVG by hand — they are regenerated from `box.yml` by the agent. Edit `box.yml`, then run `/product:box`.
 
-See `docs/product-box.md` for the methodology, `docs/adr/0017-add-product-box-feature.md` for the decision, and `docs/superpowers/specs/2026-05-01-product-box-design.md` for the spec.
+See `docs/product-box.md` for the methodology, `docs/adr/0019-add-product-box-feature.md` for the decision, and `docs/superpowers/specs/2026-05-01-product-box-design.md` for the spec.
 ```
 
 - [ ] **Step 3: Compute skill hash and patch box.yml**
@@ -2253,7 +2253,7 @@ Under `## Workflow rules` (or a new `## Public surface` section if it makes more
 In the existing skills/track table, add:
 
 ```markdown
-| **Product box** | new project, brief written, envisioned product visualization | `.claude/skills/product-box/SKILL.md` | `/product:box` | `docs/product-box.md` (ADR-0017) |
+| **Product box** | new project, brief written, envisioned product visualization | `.claude/skills/product-box/SKILL.md` | `/product:box` | `docs/product-box.md` (ADR-0019) |
 ```
 
 - [ ] **Step 4: docs/sink.md — register destinations**

--- a/docs/superpowers/specs/2026-05-01-product-box-design.md
+++ b/docs/superpowers/specs/2026-05-01-product-box-design.md
@@ -3,7 +3,7 @@
 **Status:** Draft for review.
 **Date:** 2026-05-01.
 **Author:** Brainstorming session, Specorator template repo.
-**Related ADR:** `docs/adr/0017-add-product-box-feature.md` (to be filed alongside implementation).
+**Related ADR:** `docs/adr/0019-add-product-box-feature.md` (to be filed alongside implementation).
 **Pairs with:** [`product-page` skill](../../../.claude/skills/product-page/SKILL.md), [`product-page-designer` agent](../../../.claude/agents/product-page-designer.md).
 
 ---
@@ -45,7 +45,7 @@ sites/box/styles.css                        box-specific styles (lifts specorato
 sites/box/og-card.svg                       static SVG mirror of the box front face for og:image
 sites/index.html                            product page; gets <!-- product-box-embed --> slot + card link
 docs/product-box.md                         methodology doc
-docs/adr/0017-add-product-box-feature.md    decision record
+docs/adr/0019-add-product-box-feature.md    decision record
 ```
 
 ### 4.2 Skill-orchestrates / agent-renders split
@@ -243,7 +243,7 @@ sites/box/index.html
 sites/box/styles.css
 sites/box/og-card.svg
 docs/product-box.md
-docs/adr/0017-add-product-box-feature.md
+docs/adr/0019-add-product-box-feature.md
 tests/scripts/product-box/fixtures/*.yml
 tests/scripts/product-box/snapshots/*.html
 tests/scripts/product-box/README.md
@@ -266,7 +266,7 @@ docs/sink.md                           + sites/box/ + box.yml destinations
 
 ## 11. ADR
 
-ADR-0017 records:
+ADR-0019 records:
 
 - Rationale — early-stage envisioned-product visualization fills the gap before product page is grounded.
 - New agent role + new slash namespace `product:box` (load-bearing per AGENTS.md).


### PR DESCRIPTION
## Summary

Bump all `ADR-0017` references in the merged product-box spec and plan to **`ADR-0019`** because slots 0017 and 0018 were claimed by other PRs that merged in parallel.

- ADR-0017 → `adopt-inputs-folder-as-canonical-ingestion-zone`
- ADR-0018 → `sites-consumes-tokens`
- ADR-0019 → free slot for product-box

Without this fix, an implementer following the merged plan's Chunk 1 Task 1.2 would try to create `docs/adr/0017-add-product-box-feature.md` — a path that already exists with unrelated content — and stall.

## What changed

- `docs/superpowers/specs/2026-05-01-product-box-design.md` — 4 references rewritten.
- `docs/superpowers/plans/2026-05-01-product-box.md` — 15 references rewritten (numbers, filenames, table row, ADR body draft, etc.).

No semantic changes; just renumbering. The ADR file itself does not exist yet — it will be created in Chunk 1 of the implementation, now under the new number.

## Verify gate

`npm run verify` is green locally on this branch.

## Tracking issue

Refs #145 — pickup point for the product-box implementation. The issue body still references ADR-0017; that will be updated separately so adopters reading the issue don't get confused.

## Test plan

- [ ] Spot-check that `0017-add-product-box-feature.md` no longer appears in spec or plan.
- [ ] Confirm `0019-add-product-box-feature.md` appears consistently in both files.
- [ ] After merge: tracking issue #145 body updated to reference ADR-0019.

🤖 Generated with [Claude Code](https://claude.com/claude-code)