### PR TITLE
feat(v04): close T-V04-003 PR CI quality gate

### DIFF
--- a/docs/pr-ci-gate.md
+++ b/docs/pr-ci-gate.md
@@ -9,7 +9,7 @@ entry_point: false
 
 Defines what runs on every pull request and what blocks merge. Companion to [`verify-gate.md`](verify-gate.md) (local source of truth) and [`ci-automation.md`](ci-automation.md) (PR-hygiene tooling — title check, typos, Dependabot).
 
-This contract is the architecture output of T-V04-002. It consumes the v0.3 validation baseline confirmation produced by T-V04-001 and feeds the workflow file authored in T-V04-003 and the readiness check in T-V04-004.
+This contract is the architecture output of T-V04-002. It consumes the v0.3 validation baseline confirmation produced by T-V04-001 and is satisfied by the existing `.github/workflows/verify.yml` (confirmed in T-V04-003) and codified by the readiness check in T-V04-004.
 
 ## Principle
 
@@ -82,7 +82,7 @@ Affected when an `implementation-log.md`, `release-notes.md`, or `retrospective.
 
 ## Workflow file contract
 
-The PR CI workflow file lives at `.github/workflows/verify.yml`. T-V04-003 authors it; T-V04-004 verifies presence and markers via `npm run doctor`.
+The PR CI workflow file lives at `.github/workflows/verify.yml`. T-V04-003 confirms the existing workflow satisfies this contract; T-V04-004 verifies presence and markers via `npm run doctor`.
 
 Required structure:
 
@@ -91,10 +91,10 @@ Required structure:
 | Trigger | `pull_request` (any branch) and `push: branches: [main]` |
 | Runner | `ubuntu-latest` |
 | Step 1 | `actions/checkout@<SHA>` (SHA-pinned per [`security-ci.md`](security-ci.md)) |
-| Step 2 | `actions/setup-node@<SHA>` with `node-version: '20'` (or `node-version-file` if a `.nvmrc` is added) |
+| Step 2 | `actions/setup-node@<SHA>` with `node-version: 24` (the project's current Node target; bumps follow the existing CI policy and may use `node-version-file` if a `.nvmrc` is added) |
 | Step 3 | `npm ci` |
 | Step 4 | `npm run verify` |
-| Concurrency | `group: verify-${{ github.ref }}`, `cancel-in-progress: true` |
+| Concurrency | `cancel-in-progress: true`, group keyed per workflow + PR-or-ref so PR runs and branch runs are scoped separately (current implementation: `${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`) |
 | Permissions | `contents: read` (least privilege) |
 
 Fail-fast is implicit: any non-zero exit fails the job. `npm run verify` is configured to stop at the first failing check (per [`scripts/lib/tasks.ts`](../scripts/lib/tasks.ts) and the runner's behaviour) and print the reproduction command.

--- a/specs/version-0-4-plan/implementation-log.md
+++ b/specs/version-0-4-plan/implementation-log.md
@@ -69,6 +69,43 @@ Resolves CLAR-V04-002.
 - **T-V04-003 (dev — `.github/workflows/verify.yml`)** — author the workflow per `docs/pr-ci-gate.md` §Workflow file contract. SHA-pin actions per `docs/security-ci.md`. Single PR.
 - **T-V04-004 (dev — extend doctor)** — extend `scripts/doctor.ts` with a check that asserts the workflow file's presence and the markers listed in §Workflow file contract. Add focused tests under `tests/scripts/`. Depends on T-V04-003 landing.
 
+## Task T-V04-003 - PR CI quality gate
+
+`.github/workflows/verify.yml` already existed in the repository before T-V04-002 contract authorship; it was authored alongside earlier CI hardening (`2a56ce8 chore: add JavaScript integrity checks`) and tightened over time (`d322108 chore(ci): bump GitHub Actions to Node 24-compatible majors`, `f4335ab chore(ci): pin all action references to commit SHA`, `3a701c9 ci: resolve code scanning workflow alerts`). This task confirms the existing workflow satisfies the §Workflow file contract published in T-V04-002 and reconciles two intentional drifts back into the contract.
+
+### Workflow file vs §Workflow file contract
+
+| Slot | Required | Existing `.github/workflows/verify.yml` | Status |
+|---|---|---|---|
+| Trigger | `pull_request` (any branch) and `push: branches: [main]` | `pull_request:` + `push: branches: [main]` | satisfied |
+| Runner | `ubuntu-latest` | `ubuntu-latest` | satisfied |
+| Step 1 | `actions/checkout@<SHA>` (SHA-pinned) | `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2` | satisfied |
+| Step 2 | `actions/setup-node@<SHA>` with Node 24 | `actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0` with `node-version: 24` and `cache: npm` | satisfied |
+| Step 3 | `npm ci` | `npm ci` | satisfied |
+| Step 4 | `npm run verify` | `npm run verify` | satisfied |
+| Concurrency | `cancel-in-progress: true`, group keyed per workflow + PR-or-ref | `${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`, `cancel-in-progress: true` | satisfied |
+| Permissions | `contents: read` | `contents: read` | satisfied |
+
+### Reconciliation back into the contract
+
+T-V04-002 was authored without reading the existing workflow, so it specified two values that diverged from what already shipped. Both existing values are intentional and better; this task updates `docs/pr-ci-gate.md` rather than the workflow:
+
+- **Node version.** Contract said Node 20; existing workflow uses Node 24 from PR #38 (`d322108 chore(ci): bump GitHub Actions to Node 24-compatible majors`). Node 24 is the project's current target. Contract updated to Node 24.
+- **Concurrency expression.** Contract said `verify-${{ github.ref }}`; existing workflow uses `${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`. The existing form scopes PR runs (keyed by PR number) separately from branch runs (keyed by ref), so a force-push to a branch only cancels its own in-flight runs and a PR push only cancels prior runs of the same PR. Contract updated to describe the existing pattern.
+
+Neither change widens the contract's intent (a single-job, single-composite, fail-fast PR gate) or weakens the markers T-V04-004 will codify in `npm run doctor`: workflow file presence, trigger contains `pull_request` + `push: main`, steps include `npm ci` + `npm run verify`, `actions/checkout` and `actions/setup-node` SHA-pinned. Node version and concurrency-group shape are deliberately not in T-V04-004's marker set.
+
+Resolves SPEC-V04-001 (PR CI gate). Satisfies REQ-V04-001 (PR CI gates), REQ-V04-002 (preserve local-first), NFR-V04-001 (deterministic, low-noise).
+
+### Verification
+
+- `npm run verify` (full composite, run from worktree against repo root)
+- Manual cross-check of `.github/workflows/verify.yml` against `docs/pr-ci-gate.md` §Workflow file contract
+
+### Handoff to T-V04-004
+
+The contract is now aligned with the shipped workflow. T-V04-004 (dev — extend `scripts/doctor.ts`) implements the readiness check listed under §Workflow file contract: file presence, trigger markers, step markers, SHA-pin pattern. Add focused tests under `tests/scripts/`.
+
 ## Task T-V04-005 - Workflow metrics report
 
 - Extended `scripts/lib/quality-metrics.ts` with stage-aware scoring.

--- a/specs/version-0-4-plan/workflow-state.md
+++ b/specs/version-0-4-plan/workflow-state.md
@@ -56,6 +56,7 @@ artifacts:
 - 2026-04-30 (codex): Added `/quality:status` and agent prompt hooks so quality metrics are visible at orchestration, QA, review, release, retrospective, project, roadmap, and portfolio handoffs.
 - 2026-05-01 (claude): Completed T-V04-001 v0.3 validation baseline confirmation. 6 of 7 baseline checks classified `required` for PR CI promotion; 1 (every `REQ-*`/`NFR-*` covered by `TEST-*`) remains `deferred` pending test-plan format lock. Classification + handoff lives in `implementation-log.md` §Task T-V04-001. CLAR-V04-001 resolved. Unblocks T-V04-002 (architect — CI gate contract).
 - 2026-05-01 (claude): Completed T-V04-002 PR CI gate contract. Authored `docs/pr-ci-gate.md` — full `npm run verify` on PR (CI ≡ local), no advisory tier, 1 deferred check, false-positive guidance, workflow file contract markers for T-V04-004 doctor. CLAR-V04-002 resolved (scheduled health reporting deferred to v0.5+). Unblocks T-V04-003 (dev — `.github/workflows/verify.yml`) and T-V04-004 (dev — extend doctor).
+- 2026-05-01 (claude): Completed T-V04-003 PR CI quality gate. Confirmed existing `.github/workflows/verify.yml` satisfies `docs/pr-ci-gate.md` §Workflow file contract on every slot. Reconciled two contract values (Node 24, current concurrency expression) back into the contract; existing workflow values left unchanged because they are intentional and better. Resolves SPEC-V04-001. Unblocks T-V04-004 (dev — extend doctor).
 
 ## Open clarifications
 


### PR DESCRIPTION
## Summary

- Confirms existing `.github/workflows/verify.yml` satisfies `docs/pr-ci-gate.md` §Workflow file contract on every slot.
- Reconciles two contract values back into the contract (Node 24, current concurrency expression). Existing workflow values left unchanged — both are intentional and better than what the freshly-authored contract specified.
- Logs T-V04-003 in `specs/version-0-4-plan/implementation-log.md` and updates the feature handoff notes.

## Why

T-V04-002 authored the contract without reading the existing workflow, so it specified Node 20 and a simpler concurrency expression. The existing workflow uses Node 24 (from PR #38, the project's current Node target) and `${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}` (which scopes PR runs separately from branch runs, so a force-push to a branch only cancels that branch's runs and a PR push only cancels prior runs of the same PR). Both are better; updating the contract is the right direction. Neither change weakens the markers T-V04-004 will codify in `npm run doctor` (file presence, trigger markers, step markers, SHA-pin pattern).

## Trace

- Closes T-V04-003.
- Resolves SPEC-V04-001 (PR CI gate).
- Satisfies REQ-V04-001 (PR CI gates), REQ-V04-002 (preserve local-first), NFR-V04-001 (deterministic, low-noise).
- Unblocks T-V04-004 (dev — extend `scripts/doctor.ts`).

## Test plan

- [x] `npm run verify` green locally (worktree)
- [x] Manual cross-check of `.github/workflows/verify.yml` against the updated `docs/pr-ci-gate.md` §Workflow file contract
- [ ] CI `verify` job green on this PR
- [ ] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)