### PR TITLE
feat(scripts): add npm test alias for test:scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "roadmap:digest": "tsx scripts/roadmap-digest.ts",
     "roadmap:evidence": "tsx scripts/roadmap-evidence.ts",
     "typecheck:scripts": "tsc --project tsconfig.scripts.json --noEmit",
+    "test": "npm run test:scripts",
     "test:scripts": "tsx scripts/test-scripts.ts",
     "check:fast": "tsx scripts/check-fast.ts",
     "check:content": "tsx scripts/check-content.ts",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "roadmap:digest": "tsx scripts/roadmap-digest.ts",
     "roadmap:evidence": "tsx scripts/roadmap-evidence.ts",
     "typecheck:scripts": "tsc --project tsconfig.scripts.json --noEmit",
-    "test": "npm run test:scripts",
+    "test": "npm run test:scripts --",
     "test:scripts": "tsx scripts/test-scripts.ts",
     "check:fast": "tsx scripts/check-fast.ts",
     "check:content": "tsx scripts/check-content.ts",

--- a/tools/automation-registry.yml
+++ b/tools/automation-registry.yml
@@ -109,6 +109,16 @@ entries:
     emits_json: false
     used_by: [human, agent, ci]
     rerun_command: npm run typecheck:scripts
+  - id: script:test
+    kind: check
+    command: npm run test
+    path: scripts/test-scripts.ts
+    purpose: Standard npm test idiom alias delegating to test:scripts.
+    read_only: true
+    safe_to_run_locally: true
+    emits_json: false
+    used_by: [human, agent, ci]
+    rerun_command: npm run test
   - id: script:test-scripts
     kind: check
     command: npm run test:scripts


### PR DESCRIPTION
## Summary

Closes the **`test` alias** action inherited from the v0.3 retrospective (RETRO-V03-001) onto the v0.4 cycle (issue #89).

`npm test` now works as a standard idiom and delegates to `npm run test:scripts`. The retrospective filed this after PR #110 had to be patched when its release notes referenced `npm test -- --test ...` (the standard Node convention) instead of the repo's custom `test:scripts` script.

## What changed

- `package.json` — adds `"test": "npm run test:scripts"`
- `tools/automation-registry.yml` — adds a sibling `script:test` entry next to `script:test-scripts`, pointing at the same path. Required because `tests/scripts/automation-registry.test.ts` enforces that every npm script in `package.json` has a corresponding registry entry.

## Verification

- [x] `npm test` — passes locally
- [x] `npm run verify` — `ok in 14.9s`
- [ ] CI `verify` job green on this PR
- [ ] Codex review

## Trace

- Refs: #89 (inherited v0.3 retro action — `test alias`)
- Related: [RETRO-V03-001 §Actions row 1](https://github.com/Luis85/agentic-workflow/blob/main/specs/version-0-3-plan/retrospective.md#actions)

## Optional follow-up (not in this PR)

The retrospective action also mentions updating `templates/release-notes-template.md` Verification steps to mention `npm test`. The current template uses generic `1. …` placeholders without specific commands, so no concrete edit is required there. If we ever populate the template with example commands, `npm test` should be the one named.

## Pickup-ability

This PR is small and complete — opening as Draft per the issue #89 chunking thread, but it can be marked ready and merged as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7CkUv6iGonpyzrGrSSLFw)_