### PR TITLE
docs(templates): add meta-feature guidance to §Skips

### DIFF
--- a/templates/_shared/state-file-sections.md
+++ b/templates/_shared/state-file-sections.md
@@ -10,6 +10,8 @@ Per-artifact `status` (used in `artifacts:` map and progress tables): `pending` 
 
 Document any skipped phases / stages and why. Trivial work (cosmetic fixes, doc-only changes) may legitimately skip phases. The retrospective phase is never skipped. Phases may be skipped only when the engagement is compressed (e.g., a 1-day "Lightning" Discovery sprint that collapses Frame+Diverge); document the trade-off so a reader knows what was sacrificed.
 
+**Meta-features.** A "meta-feature" is a plan-level feature whose implementation is a sequence of sub-task PRs rather than a single source tree (e.g., a release plan that ships through eight independent feature PRs). Meta-features may legitimately skip Stage 7-9 artifacts — `implementation-log.md`, `test-plan.md`, `test-report.md`, `review.md`, `traceability.md` — when each sub-task PR carries its own implementation evidence, tests, review, and trace links. When skipping these for a meta-feature, the `## Skips` block must list each artifact filename with a one-line rationale plus a pointer to where the evidence lives (per-PR descriptions, commit messages, or the `Satisfies:` blocks in `tasks.md`). For a worked example, see [`specs/version-0-3-plan/workflow-state.md`](../../specs/version-0-3-plan/workflow-state.md) §Skips.
+
 ## Blocks section
 
 Anything currently blocking progress. One bullet per blocker — name the artifact, the blocker, and the responsible party where known. Move to closed once unblocked; the section is a live signal, not an audit log.


### PR DESCRIPTION
## Summary

Closes the **§Skips meta-feature template guidance** action inherited from the v0.3 retrospective (RETRO-V03-001) onto the v0.4 cycle (issue #89).

The Stages 1–11 lifecycle assumes one feature → one set of artifacts. A &#34;meta-feature&#34; — a plan-level feature whose implementation is a sequence of sub-task PRs rather than a single source tree — is many features → one plan. v0.3 was the first meta-feature in the repo: it shipped through eight per-task PRs, then had to mark five Stage 7–9 artifacts (`implementation-log.md`, `test-plan.md`, `test-report.md`, `review.md`, `traceability.md`) as `skipped` with rationale. The template did not anticipate this case, so the retrospective filed an action.

## What changed

`templates/_shared/state-file-sections.md` — added a one-paragraph &#34;Meta-features&#34; subsection inside §Skips. Says:

- A meta-feature may legitimately skip Stage 7–9 artifacts when each sub-task PR carries its own implementation, tests, review, and trace evidence.
- The `## Skips` block must list each skipped artifact with a one-line rationale plus a pointer to where the evidence lives (per-PR descriptions, commit messages, or `Satisfies:` blocks in `tasks.md`).
- Pointer to the worked example in `specs/version-0-3-plan/workflow-state.md` §Skips.

The shared file is loaded by every state-file template (lifecycle, discovery, project, portfolio, etc.), so this guidance is available wherever meta-features apply.

## What&#39;s left to a future contributor

Optional polish (not in this PR — keeps it independent from sibling drafts):

- A pointer or call-out from `docs/specorator.md` referencing the new subsection. *(Branch D — `feat/retro-tasks-may-slice` — also touches `docs/specorator.md`; deferring to avoid a merge conflict between sibling draft PRs.)*
- A short paragraph in the v0.4 release notes mentioning the template clarification.

## Verification

- [x] `npm run verify` — `ok in 14.3s`
- [x] CI `verify` job green on this PR
- [ ] Codex review

## Trace

- Refs: #89 (inherited v0.3 retro action — `§Skips template guidance`)
- Related: [RETRO-V03-001 §Actions row 2](https://github.com/Luis85/agentic-workflow/blob/main/specs/version-0-3-plan/retrospective.md#actions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7CkUv6iGonpyzrGrSSLFw)_