### PR TITLE
feat(v04): T-V04-009 substantive pickup of release notes

### DIFF
--- a/specs/version-0-4-plan/release-notes.md
+++ b/specs/version-0-4-plan/release-notes.md
@@ -16,43 +16,46 @@ updated: 2026-05-01
 
 # Release notes — v0.4 (CI quality gates, metrics, maturity model)
 
-> **Status: starter draft.** This file is a starter created to unblock T-V04-009. Sections marked **TODO** need to be filled by the release-manager once the remaining tasks (T-V04-006 qa tests, T-V04-010 product page, T-V04-011 release readiness, T-V04-012 v0.5 handoff) land. Issue #89 tracks state.
+> **Status: in-progress draft.** Substantive editing has begun. Sections that depend on still-open tasks (T-V04-006 qa tests, T-V04-010 product page, T-V04-011 release readiness, T-V04-012 v0.5 handoff) remain marked TODO and will be finished by their owners before the release ships. Issue #89 tracks state.
 
 ## Summary
 
-TODO — one paragraph for end users / stakeholders. Recommended frame: v0.4 promotes the v0.3 hard-fail validators into a required PR CI quality gate (full `npm run verify` runs on every PR — CI ≡ local), adds a workflow metrics report with stage-aware scoring + trend snapshots + machine-readable JSON for v0.5 release-readiness consumption, and ships a five-level evidence-backed maturity model. Non-breaking; no new lifecycle stage; no constitution change.
+v0.4 promotes the v0.3 hard-fail validators into a required PR CI quality gate. Every pull request and every push to `main` now runs the full `npm run verify` composite on a fresh `npm ci` checkout — the same command contributors run locally, so any CI failure reproduces 1:1 on a developer machine (CI ≡ local). The release also adds a stage-aware workflow metrics report with optional trend snapshots and a machine-readable JSON output that v0.5 release-readiness can consume without re-implementing metric collection, plus a five-level evidence-backed maturity model surfaced in both the rendered metrics report and the JSON. v0.4 is non-breaking: no new lifecycle stage, no constitution change, no template / agent / skill / command rename.
 
 ## Changes
 
 ### New
 
 - **PR CI quality gate** — `.github/workflows/verify.yml` enforces full `npm run verify` on every PR (T-V04-001 / T-V04-002 / T-V04-003, PRs #137 / #138 / #148). Workflow file contract published in `docs/pr-ci-gate.md`.
-- **CI readiness checks** — `scripts/lib/doctor.ts` `workflowReadinessChecks` enforces the verify.yml contract markers: `pull_request:` trigger, `- main` push branch, SHA-pinned `actions/checkout` + `actions/setup-node` (T-V04-004, PR #149).
+- **CI readiness checks** — `scripts/lib/doctor.ts` `workflowReadinessChecks` enforces the verify.yml contract markers from `docs/pr-ci-gate.md` §Workflow file contract: trigger keys (`pull_request:`, `push:`), a YAML-parser-backed evaluator that confirms the `push:` trigger covers the `main` branch (handles block-list `- main` and flow-list `[main]` forms equivalently), and verify-job-scoped SHA-pin evaluators for `actions/checkout` + `actions/setup-node` that walk `jobs.verify.steps` so a sibling pinned job cannot mask an unpinned verify-job step (T-V04-004, PR #149).
 - **Workflow metrics report** — stage-aware scoring with optional `--save` / `--compare` trend snapshots; `/quality:status` workflow-native command; agent prompt hooks across orchestration / QA / review / release / retrospective / project / roadmap / portfolio (T-V04-005).
 - **Metrics interpretation guide** — `docs/quality-metrics.md` documents each metric's meaning, supported decisions, misuse warnings, and typical actions; linked from `docs/quality-framework.md`, `scripts/README.md`, and the `quality-metrics` skill (T-V04-007).
 - **Five-level maturity model** — evidence-backed maturity assessment with gaps and next-step guidance, surfaced in both `npm run quality:metrics` rendered output and the JSON output v0.5 release-readiness will consume (T-V04-008).
 
 ### Improved
 
-- TODO — fill once T-V04-006 (qa tests) and T-V04-011 (release readiness) verify the cross-cutting impact.
+- **Stage-aware quality scoring.** `scripts/lib/quality-metrics.ts` excludes future-stage evidence from the current-stage score and renders test / EARS coverage as `not expected yet` for workflows that have not reached the relevant stage. Replaces the previous all-or-nothing artifact gating (T-V04-005).
+- **Trend snapshots.** `npm run quality:metrics --save` and `--compare` persist metric runs under `quality/metrics/<scope>/` and report deltas across score, maturity, blockers, clarifications, frontmatter gaps, and QA checklist gaps cycle-over-cycle (T-V04-005).
+- **Workflow-native quality reporting.** `/quality:status` is the workflow-native command entry point; orchestration, QA, review, release, retrospective, project, roadmap, and portfolio agent guidance all surface the metrics report at handoff (T-V04-005).
+- **Doctor reads the contract.** `npm run doctor` now reads the verify.yml contract directly from `docs/pr-ci-gate.md`-style structured contracts, so contract drift surfaces locally before CI rather than landing as a CI surprise (T-V04-004).
 
 ### Fixed
 
-- TODO.
+- None — v0.4 introduces the PR CI gate, the doctor contract surface, and the stage-aware metrics surface for the first time. Refinements landed during v0.4 development (PR #149 rounds 2 + 3) are captured in the implementation log under T-V04-004; nothing previously released needed correction.
 
 ### Deprecated
 
-- None expected.
+- None.
 
 ### Removed
 
-- None expected.
+- None.
 
 ## User-visible impact
 
-- **Who is affected:** TODO — every contributor whose PRs run through GitHub Actions; every operator running `npm run quality:metrics`.
-- **Action required:** TODO — confirm in T-V04-011 whether existing PRs need any change (expected: none, since CI ≡ local).
-- **Breaking changes:** TODO — none expected at the workflow / template level; the PR CI gate is the formalisation of `npm run verify` which contributors already run locally.
+- **Who is affected:** every contributor whose PRs run through GitHub Actions; every operator running `npm run quality:metrics` or `npm run doctor`; every adopter of this template who copies the workflow / scripts into a downstream project.
+- **Action required:** none. CI ≡ local — if `npm run verify` was already part of the pre-PR habit (per [`docs/verify-gate.md`](../../docs/verify-gate.md)), behaviour is unchanged. Contributors who were not running verify locally now see the same exit code and diagnostics in CI; the local-reproduction path is `npm ci && npm run verify`. T-V04-011 will re-confirm no action is required for in-flight PRs at release time.
+- **Breaking changes:** none. v0.4 ships only new optional surfaces (the PR CI workflow, the doctor contract extension, the stage-aware metrics report, the maturity assessment); no template, agent, skill, command, or convention is renamed or removed.
 
 ## Readiness summary
 
@@ -62,8 +65,10 @@ TODO — one paragraph for end users / stakeholders. Recommended frame: v0.4 pro
 
 ## Known limitations
 
-- TODO — surface the false-positive risks documented in `docs/pr-ci-gate.md` §False-positive guidance: cross-feature ID rule (correct enforcement; phrase via PR numbers / file paths / prose) and IDs-in-fenced-code (zero today; future-template risk).
-- TODO — note that the REQ/NFR → TEST forward-coverage check is **deferred** to v0.5 (CLAR-V03-002 carryover; gated on test-plan format lock).
+- **Cross-feature ID references are flagged in narrative artifacts.** `scripts/lib/traceability.ts` `validateIdAreas` flags any traceability ID in an artifact body whose area code differs from the workflow's area. This is correct enforcement — cross-area IDs cross traceability namespaces — but contributors who quote another feature's IDs in `implementation-log.md`, `release-notes.md`, or `retrospective.md` will trip the rule. Use PR numbers, file paths, or prose instead. See [`docs/pr-ci-gate.md`](../../docs/pr-ci-gate.md) §Cross-feature ID references in narrative.
+- **Traceability IDs in fenced code blocks could become a false-positive in future.** `idsIn` matches IDs anywhere in a line, including inside fenced code blocks. No template artifact embeds raw IDs in code today, so the risk is zero; if a future template change introduces raw IDs in a code example, the validator will need a code-block skip. See [`docs/pr-ci-gate.md`](../../docs/pr-ci-gate.md) §Traceability IDs in fenced code blocks.
+- **REQ/NFR → TEST forward-coverage is deferred.** The advisory check that every `REQ-*` / `NFR-*` has at least one covering `TEST-*` is **not** part of v0.4. It is deferred until the test-plan format is locked enough to avoid false positives (CLAR-V03-002 carryover; v0.4-cycle action assigned to analyst). v0.5 should re-evaluate. See [`docs/pr-ci-gate.md`](../../docs/pr-ci-gate.md) §Deferred.
+- **Doctor's substring markers are file-scoped.** The verify-job-scoped SHA-pin evaluators added in T-V04-004 (PR #149) close the bypass path for action references, but the existing substring markers (`actions/checkout`, `cache: npm`, `npm ci`, `npm run verify`) still scan the whole workflow file rather than `jobs.verify.steps`. In practice the SHA-pin evaluator catches the verify-job-empty case (returns false on zero references); tightening the substring markers to verify-job scope is a follow-up beyond v0.4's flagged findings (PR #149 commit 7809347 commit message).
 
 ## Verification steps
 
@@ -95,23 +100,23 @@ After pulling v0.4:
 
 ## Validation baseline for v0.5
 
-This subsection feeds T-V04-012 (v0.5 release-quality handoff).
+This subsection feeds T-V04-012 (v0.5 release-quality handoff). v0.5 release-readiness should consume the JSON / exit-code surfaces below rather than re-implement metric collection (per SPEC-V04-008).
 
-- TODO — list machine-readable quality signals v0.5 should consume before GitHub Release / Package publication. Source list:
-  - `npm run quality:metrics` JSON output (score, maturity assessment, trend deltas).
-  - `npm run quality:metrics --save` snapshots under `quality/metrics/<scope>/`.
-  - `npm run doctor` CI readiness check exit code.
-- TODO — confirm whether the deferred CLAR-V03-002 advisory check (REQ/NFR → TEST forward coverage) lands as a v0.5 hard-fail gate or is deferred again.
+- **`npm run quality:metrics` JSON output** — score, five-level maturity assessment with evidence / gaps / next-step guidance, blocker count, open-clarification count, frontmatter / QA checklist gap counts, optional trend deltas when a prior `--save` snapshot exists. Documented in [`docs/quality-metrics.md`](../../docs/quality-metrics.md).
+- **`npm run quality:metrics --save` snapshots** — each run persists state under `quality/metrics/<scope>/`. Together with `--compare` this gives v0.5 a cycle-over-cycle drift signal.
+- **`npm run doctor` exit code** — covers the verify.yml workflow contract (trigger keys, push-covers-main, verify-job-scoped SHA-pin), dependency readiness, branch readiness, and worktree hygiene. Documented in [`docs/pr-ci-gate.md`](../../docs/pr-ci-gate.md) §Workflow file contract.
+- **`npm run verify` exit code** — the canonical PR CI gate; CI ≡ local. Documented in [`docs/pr-ci-gate.md`](../../docs/pr-ci-gate.md) §Required gate.
+- **Deferred CLAR-V03-002** — the REQ/NFR → TEST forward-coverage check is **not** part of the v0.4 baseline (see §Known limitations). Re-evaluation is a v0.5-cycle decision; v0.5 should confirm whether to promote, keep deferred, or drop based on the test-plan format lock outcome.
 
 ---
 
 ## Quality gate
 
-- [ ] Summary written for the audience (users / stakeholders, not engineers).
-- [ ] User-visible impact stated.
-- [ ] Readiness conditions and approvals summarized, or guide marked not used.
-- [ ] Known limitations disclosed.
-- [ ] Verification steps documented.
-- [ ] Rollback plan documented.
-- [ ] Observability hooks in place.
-- [ ] Communication plan ready.
+- [x] Summary written for the audience (users / stakeholders, not engineers).
+- [x] User-visible impact stated.
+- [ ] Readiness conditions and approvals summarized, or guide marked not used. *(T-V04-011)*
+- [x] Known limitations disclosed.
+- [x] Verification steps documented (T-V04-011 may add more).
+- [x] Rollback plan documented.
+- [x] Observability hooks in place (or correctly marked N/A).
+- [ ] Communication plan ready. *(External-announcement decision pending T-V04-010.)*

--- a/specs/version-0-4-plan/release-notes.md
+++ b/specs/version-0-4-plan/release-notes.md
@@ -37,7 +37,7 @@ v0.4 promotes the v0.3 hard-fail validators into a required PR CI quality gate. 
 - **Stage-aware quality scoring.** `scripts/lib/quality-metrics.ts` excludes future-stage evidence from the current-stage score and renders test / EARS coverage as `not expected yet` for workflows that have not reached the relevant stage. Replaces the previous all-or-nothing artifact gating (T-V04-005).
 - **Trend snapshots.** `npm run quality:metrics --save` and `--compare` persist metric runs under `quality/metrics/<scope>/` and report deltas across score, maturity, blockers, clarifications, frontmatter gaps, and QA checklist gaps cycle-over-cycle (T-V04-005).
 - **Workflow-native quality reporting.** `/quality:status` is the workflow-native command entry point; orchestration, QA, review, release, retrospective, project, roadmap, and portfolio agent guidance all surface the metrics report at handoff (T-V04-005).
-- **Doctor reads the contract.** `npm run doctor` now reads the verify.yml contract directly from `docs/pr-ci-gate.md`-style structured contracts, so contract drift surfaces locally before CI rather than landing as a CI surprise (T-V04-004).
+- **Doctor enforces the verify.yml contract locally.** `npm run doctor` now runs the `workflowContracts` readiness checks in `scripts/lib/doctor.ts` against `.github/workflows/verify.yml`, so contract drift surfaces locally before CI rather than landing as a CI surprise (T-V04-004). The executable contract in `scripts/lib/doctor.ts` mirrors the human-readable contract in [`docs/pr-ci-gate.md`](../../docs/pr-ci-gate.md) §Workflow file contract; keeping the two in sync is a reviewer responsibility, not an automated bind.
 
 ### Fixed
 

--- a/specs/version-0-4-plan/workflow-state.md
+++ b/specs/version-0-4-plan/workflow-state.md
@@ -17,7 +17,7 @@ artifacts:
   test-report.md: pending
   review.md: pending
   traceability.md: pending
-  release-notes.md: pending
+  release-notes.md: in-progress
   retrospective.md: pending
 ---
 
@@ -36,7 +36,7 @@ artifacts:
 | 7. Implementation | `implementation-log.md` + code | in-progress |
 | 8. Testing | `test-plan.md`, `test-report.md` | pending |
 | 9. Review | `review.md`, `traceability.md` | pending |
-| 10. Release | `release-notes.md` | pending |
+| 10. Release | `release-notes.md` | in-progress |
 | 11. Learning | `retrospective.md` | pending |
 
 ## Skips
@@ -61,6 +61,7 @@ artifacts:
 - 2026-05-01 (claude, T-V04-005 closeout): Completed T-V04-005 workflow metrics report. Substantive work shipped in codex hand-offs 2026-04-28 / 2026-04-30 and is recorded in `implementation-log.md` §Task T-V04-005: stage-aware scoring in `scripts/lib/quality-metrics.ts`, optional `--save` / `--compare` trend snapshots under `quality/metrics/<scope>/`, trend deltas across score / maturity / blockers / clarifications / frontmatter gaps / QA checklist gaps, `/quality:status` workflow-native command, and agent prompt hooks across orchestration / QA / review / release / retrospective / project / roadmap / portfolio. Satisfies REQ-V04-003, REQ-V04-004, REQ-V04-009, NFR-V04-002, NFR-V04-003, NFR-V04-005, SPEC-V04-003, SPEC-V04-008. With T-V04-004 (closed above) now landed, this closure fully unblocks T-V04-006 (qa — tests for readiness + metrics). T-V04-007 and T-V04-009 also list T-V04-005 as a prerequisite; their unblock state is recorded in the closeout notes below.
 - 2026-05-01 (claude, T-V04-007 closeout): Completed T-V04-007 metrics interpretation documentation. Substantive work shipped in earlier codex hand-offs and is recorded in `implementation-log.md` §Task T-V04-007: `docs/quality-metrics.md` documents each metric's meaning, supported decisions, misuse warnings, and typical actions; linked from `docs/quality-framework.md`, `scripts/README.md`, and the `quality-metrics` skill. Satisfies REQ-V04-004, NFR-V04-003, SPEC-V04-004. T-V04-007's only prerequisite was T-V04-005 (closed above), so this closure fully unblocks T-V04-007 itself. T-V04-007 is in turn a prerequisite for T-V04-011 (qa — release readiness verification).
 - 2026-05-01 (claude, T-V04-008 closeout): Completed T-V04-008 maturity model documentation. Substantive work shipped in codex hand-off 2026-04-29 and is recorded in `implementation-log.md` §Task T-V04-008: five-level evidence-backed maturity assessment in `npm run quality:metrics` with maturity evidence, gaps, and next-step guidance in both rendered and JSON output; documented in `docs/quality-metrics.md`; the `quality-metrics` skill reports maturity without presenting it as certification or people scoring. Satisfies REQ-V04-005, REQ-V04-006, NFR-V04-004, SPEC-V04-005. T-V04-008 has no prerequisites itself. With T-V04-003 (closed earlier 2026-05-01), T-V04-005 (closed above), and now T-V04-008 all closed, T-V04-009 (release-manager — public release documentation) is fully unblocked. T-V04-008 is also a prerequisite for T-V04-011 (qa — release readiness verification).
+- 2026-05-01 (claude, T-V04-009 pickup): Started substantive T-V04-009 work on `release-notes.md`. Picked up the starter draft authored in PR #163 / #164 (per the pickup checklist in PR #163). Filled non-blocked TODO sections — §Summary (drafted clean prose, no longer "starter draft"), §Improved (stage-aware scoring, trend snapshots, workflow-native quality reporting, doctor reads contract), §Fixed (none — first cycle for these surfaces), §User-visible impact (no action required, no breaking changes), §Known limitations (cross-feature ID rule, IDs-in-fenced-code risk, deferred CLAR-V03-002, doctor substring-marker scope follow-up), §Validation baseline for v0.5 (machine-readable JSON / exit-code surface contract for v0.5 consumption). Updated the §Changes T-V04-004 entry to describe what actually landed via PR #149 (`requiredEvaluators`, YAML-parser-backed push-covers-main, verify-job-scoped SHA-pin) instead of the round-1 description. Quality-gate checklist marked `[x]` for the items now drafted; `[ ]` retained for §Readiness summary (T-V04-011) and §Communication external announcement (T-V04-010). `release-notes.md` flipped from `pending` to `in-progress`; status banner reframed from "starter draft" to "in-progress draft". Remaining T-V04-009 work for the release-manager: cross-check §Changes against the final list of merged PRs at release time, and update README.md §Roadmap row v0.4 from "Planned" to "Done" + `docs/specorator.md` v0.4 references when the release ships (per v0.3 pattern). Closes the bulk of T-V04-009 substantive editing; final close gates on T-V04-010 / T-V04-011.
 
 ## Open clarifications
 


### PR DESCRIPTION
## Summary

Pick up the T-V04-009 starter authored in PR #163/#164 per its pickup checklist. Fill all non-blocked TODOs in `specs/version-0-4-plan/release-notes.md`. Flip `workflow-state.md` artifacts.release-notes.md from `pending` to `in-progress`.

PR #163 (the unmerged duplicate of merged #164) was closed earlier today as superseded.

## What's drafted now

| Section | State |
|---|---|
| §Summary | clean prose, no longer "starter draft" |
| §Improved | stage-aware quality scoring, trend snapshots, `/quality:status` + agent prompt hooks, doctor reads contract |
| §Fixed | explicitly "none" with rationale (in-cycle refinements live in implementation-log.md) |
| §User-visible impact | no action required, no breaking changes, audience listed |
| §Known limitations | cross-feature ID rule, IDs-in-fenced-code risk, deferred CLAR-V03-002, doctor substring-marker scope follow-up |
| §Validation baseline for v0.5 | machine-readable JSON / exit-code surface contract for v0.5 consumption |
| §Changes / T-V04-004 entry | refreshed to describe what actually landed via PR #149 (`requiredEvaluators`, YAML push-covers-main, verify-job-scoped SHA-pin) |

## What's still TODO (deliberately deferred)

- §Readiness summary — T-V04-011 deliverable.
- §Communication external announcement — gated on T-V04-010 product-page positioning decision.
- Quality-gate `[ ]` items mapped to the above.
- Cross-check §Changes against the final list of merged PRs at release time (release-manager, when v0.4 ships).
- README.md §Roadmap row v0.4 flip from "Planned" to "Done" and `docs/specorator.md` v0.4 references (release-manager, when v0.4 ships, per v0.3 pattern).

## Workflow-state diff

- `artifacts.release-notes.md`: pending → in-progress
- Stage 10 Release row: pending → in-progress
- New hand-off note documenting the pickup

## Trace

- Refs #89 (T-V04-009 tracking).
- Satisfies (partial): REQ-V04-007 (public release documentation), SPEC-V04-006.

Final T-V04-009 close gates on T-V04-010 + T-V04-011.

## Test plan

- [x] `npm run verify` green locally (worktree)
- [x] Stage progress table consistent with frontmatter (`check:specs` passes)
- [ ] CI `verify` job green on this PR
- [ ] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)