### PR TITLE
feat(v04): T-V04-011 release readiness verification

### DIFF
--- a/specs/version-0-4-plan/implementation-log.md
+++ b/specs/version-0-4-plan/implementation-log.md
@@ -247,3 +247,105 @@ Satisfies T-V04-010 release task; satisfies the §Communication TODO that the v0
 - `npm run quality:metrics`
 - `npm run quality:metrics -- --feature=version-0-4-plan`
 - `npm run verify`
+
+## Task T-V04-011 - Verify v0.4 release readiness
+
+Source: tasks.md T-V04-011 DoD ("Run targeted tests, CI-readiness checks, metrics
+checks, link checks, and `npm run verify`; document skipped checks and any deferred
+scheduled automation.") and the session pickup brief.
+
+Resolves the bulk of T-V04-009's final close gate (release-manager retains the
+T-V04-009 §Changes cross-check + README §Roadmap flip at release time) and unblocks
+T-V04-012 (release-manager - v0.5 release-quality handoff).
+
+Satisfies REQ-V04-001, REQ-V04-002, REQ-V04-003, REQ-V04-007, REQ-V04-008, REQ-V04-009,
+NFR-V04-005, SPEC-V04-001, SPEC-V04-002, SPEC-V04-003, SPEC-V04-006, SPEC-V04-007,
+SPEC-V04-008.
+
+### Decision: no separate release-readiness-guide.md
+
+`templates/release-readiness-guide-template.md` ships a per-perspective scaffold
+(product, UX, customer, engineering, security, operations, support, data, commercial,
+communications). v0.4 ships docs, scripts, and a CI workflow only. There is no
+runtime, no users, no migrations, no on-call rotation, no commercial impact, no data
+flow, and no external announcement that needs sign-off. Eight of ten perspectives
+collapse to N/A. The remaining two (engineering, communications) are already covered
+by `release-notes.md` §Quality gate.
+
+A separate guide would add noise without adding signal. v0.3 set the same precedent
+(no guide). The decision is recorded in `release-notes.md` §Readiness summary
+("Release readiness guide: not used"). The v0.5 release should re-evaluate per
+release; a runtime release would justify the guide.
+
+### Verification suite
+
+Worktree cut from `origin/main` at `e6edc07` on branch `feat/v04-t011-release-readiness`.
+Fresh `npm ci` install (worktrees do not share `node_modules`).
+
+| # | Command | Exit | Result |
+|---|---|---:|---|
+| 1 | `npm ci` | 0 | 30 packages installed; 0 vulnerabilities. |
+| 2 | `npm test` | 0 | 165/165 tests pass in 3.6s. |
+| 3 | `npm run verify` | 0 | `verify: ok` in 20.5s; all bundled checks green (`typecheck:scripts`, `test:scripts`, `check:agents`, `check:links`, `check:adr-index`, `check:commands`, `check:script-docs`, `check:workflow-docs`, `check:product-page`, `check:sites-tokens-mirror`, `check:frontmatter`, `check:obsidian`, `check:obsidian-assets`, `check:specs`, `check:roadmaps`, `check:traceability`, `check:token-budget`). |
+| 4 | `npm run quality:metrics` | 0 | Repo overall score 91.5%; 11 workflow states scanned; maturity Level 3 (Traceable); 0 active blockers; 5 specs with open clarifications, none in v0.4. |
+| 5 | `npm run quality:metrics -- --feature=version-0-4-plan` | 0 | v0.4 stage score 97.1% (stage `implementation`, status `active`); req-chain coverage 100%; EARS coverage 100%; test coverage `not expected yet` for current stage; 0 active blockers; 0 open clarifications (CLAR-V04-001 + CLAR-V04-002 both resolved). |
+| 6 | `npm run doctor` | 0 | Node v24.12.0; npm 11.9.0; git 2.47.0; branch tracking `origin/main`; working tree clean; dependencies present; verify workflow ready; pages workflow ready; ADR index ok; command inventories ok; verify gate ok. One advisory warning: 5 worktrees registered, 2 hygiene warnings — `feat/v04-t006-tests` and `feat/v04-t010-product-page` are merged into `origin/main` but the worktrees / branches were not pruned. Hygiene only; not a release blocker. |
+
+CI-readiness signals exercised by command 6: trigger keys (`pull_request:`, `push:`),
+push-covers-`main` evaluator (block-list and flow-list forms), verify-job-scoped
+SHA-pin evaluators for `actions/checkout` and `actions/setup-node`. All green.
+
+### Caveat surfaced
+
+`npm run quality:metrics --feature=<slug>` (without `--`) is silently swallowed by
+the npm CLI as an npm config flag (`npm warn Unknown cli config "--feature"`); the
+script never sees it and falls back to repo-wide scope. The proper invocation is
+`npm run quality:metrics -- --feature=<slug>` (with the `--` separator) or
+`tsx scripts/quality-metrics.ts --feature=<slug>` invoked directly. Recorded in
+`release-notes.md` §Verification steps so v0.5 release-readiness automation does not
+hit the same trap.
+
+### Deferred automation (per task DoD)
+
+- **Scheduled health reporting** - deferred to v0.5+ per CLAR-V04-002 (resolved
+  2026-05-01 in T-V04-002). PRD non-goals exclude telemetry / dashboards. v0.4
+  produces machine-readable signals (`npm run quality:metrics` JSON and exit codes,
+  `npm run doctor` exit code) that v0.5 can consume from a scheduled job. See
+  `docs/pr-ci-gate.md` §Out of scope.
+- **REQ/NFR -> TEST forward-coverage advisory check** - deferred (carried forward
+  from CLAR-V03-002) until the test-plan format is locked enough to avoid false
+  positives. v0.5 should re-evaluate. Captured in `release-notes.md` §Known
+  limitations and §Validation baseline for v0.5.
+
+### Edits in this PR
+
+- `release-notes.md` §Readiness summary — guide-not-used decision, **go** verdict,
+  three release-time conditions (T-V04-009 §Changes cross-check + README flip,
+  T-V04-010 §Communication checkbox confirmation, T-V04-012 v0.5 handoff), required
+  approvals (release-manager only).
+- `release-notes.md` §Verification steps — replaced TODO row 6 with the
+  feature-scoped invocation plus the `--` separator caveat; added doctor's CI
+  contract scope.
+- `release-notes.md` §Quality gate — flipped `[ ]` Readiness conditions to `[x]`.
+  `[ ]` Communication remains; release-manager confirms it during T-V04-009 close.
+- `workflow-state.md` Stage 8 marked `skipped` with rationale under §Skips
+  (`test-plan.md`, `test-report.md` skipped — meta-feature; canonical test
+  artifacts are `tests/scripts/doctor.test.ts` and `tests/scripts/quality-metrics.test.ts`
+  from T-V04-006).
+- `workflow-state.md` Hand-off note added (T-V04-011 closeout).
+- `implementation-log.md` §Task T-V04-011 (this section).
+
+### Verdict
+
+**Go**, conditional on the three release-time items in `release-notes.md`
+§Readiness summary. Verification suite is green; no release-blocking findings;
+deferred automation is documented; CLAR-V04-001 and CLAR-V04-002 are both resolved.
+
+### Handoff to T-V04-012
+
+Release-manager picks up T-V04-012 (v0.5 release-quality handoff) using
+`release-notes.md` §Validation baseline for v0.5 as the canonical input. That
+section already documents the machine-readable JSON / exit-code surfaces and the
+`--save` / `--compare` snapshot contract that v0.5 release-readiness should consume.
+T-V04-012's job is to write the consumption contract from the v0.5 side; this PR
+does not pre-empt it.

--- a/specs/version-0-4-plan/release-notes.md
+++ b/specs/version-0-4-plan/release-notes.md
@@ -59,9 +59,20 @@ v0.4 promotes the v0.3 hard-fail validators into a required PR CI quality gate. 
 
 ## Readiness summary
 
-- Release readiness guide: TODO — decide in T-V04-011 whether to use a separate `release-readiness-guide.md`.
-- Go/no-go verdict: TODO (lands in T-V04-011).
-- Required conditions or approvals: TODO.
+- **Release readiness guide:** not used. v0.4 ships docs, scripts, and a CI workflow only — no runtime, no users, no migrations, no on-call rotation, no commercial impact, no external announcement that needs sign-off. The per-perspective scaffold in [`templates/release-readiness-guide-template.md`](../../templates/release-readiness-guide-template.md) (UX, security, operations, support, data, commercial, communications) is mostly N/A for a meta-template release. The inline §Readiness summary plus §Quality gate below provides the equivalent decision record. v0.3 set the same precedent.
+- **Go / no-go verdict:** **go**. T-V04-011 verification on a fresh `npm ci` checkout of `feat/v04-t011-release-readiness` (cut from `origin/main` at `e6edc07`) was green end-to-end on 2026-05-01.
+  - `npm ci` — exit 0 (30 packages, 0 vulnerabilities).
+  - `npm test` — exit 0 (165/165 pass).
+  - `npm run verify` — exit 0 (`verify: ok` in 20.5s; all bundled checks pass).
+  - `npm run quality:metrics` (repo) — exit 0; overall score 91.5%; maturity Level 3 (Traceable); 0 active blockers.
+  - `npm run quality:metrics -- --feature=version-0-4-plan` — exit 0; v0.4 stage score 97.1%; 0 open clarifications; CLAR-V04-001 and CLAR-V04-002 both resolved.
+  - `npm run doctor` — exit 0; one advisory warning (two merged worktrees not yet pruned: `feat/v04-t006-tests`, `feat/v04-t010-product-page`). Hygiene only; not a release blocker.
+- **Required conditions before release ships:**
+  - T-V04-009 final cross-check: release-manager re-confirms §Changes against the final list of merged PRs at release time, and flips README.md §Roadmap row v0.4 from "Planned" to "Done" plus the `docs/specorator.md` v0.4 references (per the v0.3 pattern). Tracked in the T-V04-009 closeout note in `workflow-state.md`.
+  - T-V04-010 external-announcement disposition: the §Communication external-announcement quality-gate item is paired with T-V04-010, and that task already shipped the `sites/index.html` v0.4 positioning update; the `[ ]` Communication checkbox flips to `[x]` once the release-manager confirms no further external-announcement work is required.
+  - T-V04-012 v0.5 handoff: `release-notes.md` §Validation baseline for v0.5 is the canonical handoff input; T-V04-012 documents the consumption contract for v0.5 release-readiness automation.
+  - Worktree hygiene: prune the two merged-but-still-registered worktrees flagged by `npm run doctor` before opening the release tag (cosmetic; can also ride on a follow-up PR).
+- **Approvals required:** human release-manager sign-off on the T-V04-009 / T-V04-010 / T-V04-012 closures above. No legal, security, or compliance approvals required (no runtime change, no data flow, no third-party surface).
 
 ## Known limitations
 
@@ -77,9 +88,9 @@ After pulling v0.4:
 1. `npm ci` — installs dependencies with the lockfile.
 2. `npm test` (or `npm run test:scripts`) — runs the script test suite.
 3. `npm run verify` — full local verify gate. Expect `verify: ok`.
-4. `npm run quality:metrics` — workflow metrics report (rendered + JSON).
-5. `npm run doctor` — local environment + CI readiness checks.
-6. TODO — additional steps once T-V04-011 lands.
+4. `npm run quality:metrics` — repo-wide workflow metrics report (rendered + JSON).
+5. `npm run quality:metrics -- --feature=<slug>` — feature-scoped metrics. Note the `--` separator: `npm run quality:metrics --feature=<slug>` (without `--`) is silently swallowed by the npm CLI and the script falls back to repo-wide scope. Use `tsx scripts/quality-metrics.ts --feature=<slug>` if invoking the script directly.
+6. `npm run doctor` — local environment + CI readiness checks. Includes the verify.yml workflow contract (trigger keys, push-covers-main, verify-job-scoped SHA-pin), branch readiness, and worktree hygiene.
 
 ## Rollback plan
 
@@ -114,7 +125,7 @@ This subsection feeds T-V04-012 (v0.5 release-quality handoff). v0.5 release-rea
 
 - [x] Summary written for the audience (users / stakeholders, not engineers).
 - [x] User-visible impact stated.
-- [ ] Readiness conditions and approvals summarized, or guide marked not used. *(T-V04-011)*
+- [x] Readiness conditions and approvals summarized, or guide marked not used.
 - [x] Known limitations disclosed.
 - [x] Verification steps documented (T-V04-011 may add more).
 - [x] Rollback plan documented.

--- a/specs/version-0-4-plan/workflow-state.md
+++ b/specs/version-0-4-plan/workflow-state.md
@@ -4,7 +4,7 @@ area: V04
 current_stage: implementation
 status: active
 last_updated: 2026-05-01
-last_agent: claude-product-page-designer
+last_agent: claude-qa
 artifacts:
   idea.md: complete
   research.md: complete
@@ -13,8 +13,8 @@ artifacts:
   spec.md: complete
   tasks.md: complete
   implementation-log.md: in-progress
-  test-plan.md: pending
-  test-report.md: pending
+  test-plan.md: skipped
+  test-report.md: skipped
   review.md: pending
   traceability.md: pending
   release-notes.md: in-progress
@@ -34,14 +34,17 @@ artifacts:
 | 5. Specification | `spec.md` | complete |
 | 6. Tasks | `tasks.md` | complete |
 | 7. Implementation | `implementation-log.md` + code | in-progress |
-| 8. Testing | `test-plan.md`, `test-report.md` | pending |
+| 8. Testing | `test-plan.md`, `test-report.md` | skipped |
 | 9. Review | `review.md`, `traceability.md` | pending |
 | 10. Release | `release-notes.md` | in-progress |
 | 11. Learning | `retrospective.md` | pending |
 
 ## Skips
 
-- None.
+The v0.4 plan is a meta-feature: each task (T-V04-001 through T-V04-012) ships as its own PR, and testing evidence is scoped to the artifact each PR touches. The plan itself does not have a separate test-plan source tree or rollup test report, so the canonical Stage 8 artifacts are skipped here. Stage 7 implementation evidence still lives in `implementation-log.md` (one §Task entry per T-V04-* task) — not skipped — because the plan's per-task work itself is recorded centrally for cross-task traceability; this is the documented difference from v0.3.
+
+- `test-plan.md` skipped — testing strategy is documented per-task. T-V04-006 added focused tests under `tests/scripts/` (`tests/scripts/doctor.test.ts` for CI-readiness checks, `tests/scripts/quality-metrics.test.ts` for metrics behaviour by state). The v0.4 spec's test scenarios (`spec.md` §Test scenarios, TEST-V04-001 → TEST-V04-009) map onto those files; the canonical "test plan" for v0.4 is the spec's TEST-V04-* table plus the per-test-file naming, not a separate `test-plan.md`.
+- `test-report.md` skipped — test results live in (a) the per-task PR CI runs on GitHub Actions (`.github/workflows/verify.yml`); (b) the local `npm run verify` / `npm run test:scripts` outputs captured in T-V04-011's `implementation-log.md` §Task T-V04-011 entry; (c) the release-readiness command output captured in `release-notes.md` §Readiness summary. No rollup `test-report.md` adds signal beyond what those three already document.
 
 ## Blocks
 
@@ -64,6 +67,7 @@ artifacts:
 - 2026-05-01 (claude, T-V04-006): Completed T-V04-006 focused tests for CI readiness + metrics behaviour by state. Added 5 metrics tests covering the 5 task-named states (active / blocked / done / skipped / open-clarification): stage-aware scoring of an active workflow (already covered, refined with status assertion), `collectQualityMetrics` on a done workflow (`testCoverageExpected` true, `earsExpected` true, `expectedArtifact*` 100), skipped-canonical-artifact accounting (`completeArtifactsFor` counts skipped equivalently to complete), open-clarification surfacing in workflow counts and metrics signals, and pure-helper coverage for `expectedArtifactsForStage` + `traceabilityExpectation` under the blocked status (paused-at-current-stage; same shape as active) and the done status (full canonical set regardless of `currentStage`). Added 2 doctor-readiness tests filling coverage gaps: `dependencyReadinessCheck` happy path (both `node_modules` and lockfile present) and `branchReadinessCheck` topic-branch-ahead warn path (distinct from the integration-branch-ahead failure). Test count 158 → 165. Resolves SPEC-V04-002 (CI readiness contract — test side) and SPEC-V04-003 (metrics — test side); satisfies REQ-V04-001, REQ-V04-003, REQ-V04-004, REQ-V04-008, REQ-V04-009, NFR-V04-001, NFR-V04-002, NFR-V04-005. Unblocks T-V04-011 (qa — release readiness).
 - 2026-05-01 (claude, T-V04-009 pickup): Started substantive T-V04-009 work on `release-notes.md`. Picked up the starter draft authored in PR #163 / #164 (per the pickup checklist in PR #163). Filled non-blocked TODO sections — §Summary (drafted clean prose, no longer "starter draft"), §Improved (stage-aware scoring, trend snapshots, workflow-native quality reporting, doctor reads contract), §Fixed (none — first cycle for these surfaces), §User-visible impact (no action required, no breaking changes), §Known limitations (cross-feature ID rule, IDs-in-fenced-code risk, deferred CLAR-V03-002, doctor substring-marker scope follow-up), §Validation baseline for v0.5 (machine-readable JSON / exit-code surface contract for v0.5 consumption). Updated the §Changes T-V04-004 entry to describe what actually landed via PR #149 (`requiredEvaluators`, YAML-parser-backed push-covers-main, verify-job-scoped SHA-pin) instead of the round-1 description. Quality-gate checklist marked `[x]` for the items now drafted; `[ ]` retained for §Readiness summary (T-V04-011) and §Communication external announcement (T-V04-010). `release-notes.md` flipped from `pending` to `in-progress`; status banner reframed from "starter draft" to "in-progress draft". Remaining T-V04-009 work for the release-manager: cross-check §Changes against the final list of merged PRs at release time, and update README.md §Roadmap row v0.4 from "Planned" to "Done" + `docs/specorator.md` v0.4 references when the release ships (per v0.3 pattern). Closes the bulk of T-V04-009 substantive editing; final close gates on T-V04-010 / T-V04-011.
 - 2026-05-01 (claude, T-V04-010 closeout): Completed T-V04-010 product-page v0.4 positioning. `sites/index.html` §features grid: §Quality gates card now states `npm run verify` runs locally and as required PR CI (CI ≡ local); new §Workflow metrics & maturity card calls out `npm run quality:metrics` with stage-aware scoring, trend snapshots, and the five-level maturity assessment. 9 → 10 cards, no new sections, version-agnostic positioning preserved. Recorded the external-announcement decision in `release-notes.md` §Communication and flipped the matching quality-gate checkbox from `[ ]` to `[x]`. T-V04-010 entry added to `implementation-log.md` with deliberately-not-changed rationale. With T-V04-010 closed, T-V04-009 final close still gates only on T-V04-011 (qa — release readiness verification). Unblocks T-V04-011 (qa — release readiness verification): all upstream slices T-V04-005 / T-V04-007 / T-V04-008 / T-V04-010 are now complete.
+- 2026-05-01 (claude, T-V04-011 closeout): Completed T-V04-011 release-readiness verification. Decision: no separate `release-readiness-guide.md` — v0.4 ships docs / scripts / a CI workflow only, so the per-perspective scaffold in `templates/release-readiness-guide-template.md` is mostly N/A; inline `release-notes.md` §Readiness summary plus §Quality gate is the equivalent decision record (matches v0.3 precedent). Verification suite was green end-to-end on a fresh `npm ci` checkout of `feat/v04-t011-release-readiness` cut from `origin/main` at `e6edc07`: `npm ci` exit 0; `npm test` exit 0 (165/165 pass); `npm run verify` exit 0 (`verify: ok` in 20.5s); `npm run quality:metrics` exit 0 (repo score 91.5%, maturity Level 3 Traceable, 0 active blockers); `npm run quality:metrics -- --feature=version-0-4-plan` exit 0 (v0.4 stage score 97.1%, 0 open clarifications); `npm run doctor` exit 0 (one advisory warning: two merged worktrees `feat/v04-t006-tests`, `feat/v04-t010-product-page` not yet pruned — hygiene only, not a release blocker). Caveat surfaced and added to `release-notes.md` §Verification steps: bare `npm run quality:metrics --feature=...` is silently swallowed by the npm CLI; the script falls back to repo-wide scope. Use `npm run quality:metrics -- --feature=...` (with `--`) or `tsx scripts/quality-metrics.ts --feature=...` directly. Verdict: **go**, with three remaining release-time conditions owned by the release-manager (T-V04-009 final §Changes cross-check + README §Roadmap flip, T-V04-010 §Communication checkbox confirmation, T-V04-012 v0.5 handoff). Stage 8 (Testing) marked `skipped` with rationale under §Skips — meta-feature; canonical test artifacts are `tests/scripts/doctor.test.ts` and `tests/scripts/quality-metrics.test.ts` from T-V04-006 plus the verification commands captured in `implementation-log.md` §Task T-V04-011. `release-notes.md` §Readiness summary filled with verdict + commands + exit codes; quality-gate checkbox `[ ]` Readiness conditions → `[x]`. `implementation-log.md` appended with §Task T-V04-011 (commands, exit codes, decisions, traceability). Stage 10 (Release) stays `in-progress` until T-V04-012 (release-manager — v0.5 release-quality handoff). Unblocks T-V04-012.
 
 ## Open clarifications
 


### PR DESCRIPTION
## Summary

- Run the v0.4 release-readiness verification suite end-to-end on a fresh `npm ci` checkout cut from `origin/main` at `e6edc07`. All six commands exit 0; verdict is **go**, conditional on three release-time items owned by the release-manager.
- Decide that v0.4 does **not** need a separate `release-readiness-guide.md`. v0.4 ships docs, scripts, and a CI workflow only; eight of the ten template perspectives are N/A. Inline `release-notes.md` §Readiness summary plus §Quality gate is the equivalent decision record (matches v0.3 precedent).
- Surface and document a CLI caveat: bare `npm run quality:metrics --feature=...` (no `--`) is silently swallowed by the npm CLI; use the `--` separator or invoke `tsx scripts/quality-metrics.ts --feature=...` directly. Recorded in `release-notes.md` §Verification steps so v0.5 release-readiness automation does not hit the same trap.
- Mark Stage 8 (Testing) `skipped` in `workflow-state.md` with rationale under §Skips — meta-feature; canonical test artifacts are `tests/scripts/doctor.test.ts` and `tests/scripts/quality-metrics.test.ts` from T-V04-006 plus the verification commands captured in `implementation-log.md` §Task T-V04-011.

## Verification suite (this PR)

| # | Command | Exit | Headline |
|---|---|---:|---|
| 1 | `npm ci` | 0 | 30 packages, 0 vulnerabilities |
| 2 | `npm test` | 0 | 165/165 pass in 3.6s |
| 3 | `npm run verify` | 0 | `verify: ok` in 20.5s; all bundled checks green |
| 4 | `npm run quality:metrics` | 0 | repo 91.5%, maturity Level 3 (Traceable), 0 blockers |
| 5 | `npm run quality:metrics -- --feature=version-0-4-plan` | 0 | v0.4 stage score 97.1%, 0 open clarifications |
| 6 | `npm run doctor` | 0 | green; one advisory: 2 merged worktrees not pruned (hygiene) |

## Files changed

- `specs/version-0-4-plan/release-notes.md` — §Readiness summary filled (guide-not-used decision, **go** verdict, three release-time conditions, required approvers); §Verification steps replace TODO row 6 with the feature-scoped invocation plus the `--` separator caveat; §Quality gate `[ ]` Readiness → `[x]`.
- `specs/version-0-4-plan/workflow-state.md` — frontmatter `test-plan.md` / `test-report.md` `pending` → `skipped`; §Stage progress Stage 8 row `pending` → `skipped`; §Skips updated with rationale; T-V04-011 closeout hand-off note appended.
- `specs/version-0-4-plan/implementation-log.md` — §Task T-V04-011 appended (decision, verification suite with exit codes, caveat, deferred automation, edits, verdict, T-V04-012 handoff).

## Conditions before release ships (owned by release-manager)

1. **T-V04-009 final cross-check** — re-confirm §Changes against the final list of merged PRs at release time; flip README.md §Roadmap row v0.4 from "Planned" → "Done"; update `docs/specorator.md` v0.4 references (per v0.3 pattern).
2. **T-V04-010 §Communication checkbox** — flip the `[ ]` Communication checkbox to `[x]` once the release-manager confirms no further external-announcement work is required.
3. **T-V04-012 v0.5 handoff** — write the v0.5 consumption contract from `release-notes.md` §Validation baseline for v0.5.
4. **Worktree hygiene** — prune the two merged-but-still-registered worktrees flagged by `npm run doctor` (`feat/v04-t006-tests`, `feat/v04-t010-product-page`). Cosmetic; can ride on a follow-up PR.

## Test plan

- [x] `npm ci` exit 0 on fresh worktree
- [x] `npm test` exit 0 (165/165 pass)
- [x] `npm run verify` exit 0 (`verify: ok`)
- [x] `npm run quality:metrics` exit 0 (repo)
- [x] `npm run quality:metrics -- --feature=version-0-4-plan` exit 0
- [x] `npm run doctor` exit 0
- [x] release-notes.md §Readiness summary filled with go verdict + conditions
- [x] release-notes.md quality gate `[ ]` Readiness → `[x]`
- [x] workflow-state.md Stage 8 marked `skipped` with §Skips rationale
- [x] implementation-log.md §Task T-V04-011 appended
- [x] Conventional Commits subject with reference IDs

Refs: T-V04-011, REQ-V04-001, REQ-V04-002, REQ-V04-003, REQ-V04-007, REQ-V04-008, REQ-V04-009, NFR-V04-005, SPEC-V04-001, SPEC-V04-002, SPEC-V04-003, SPEC-V04-006, SPEC-V04-007, SPEC-V04-008.

🤖 Generated with [Claude Code](https://claude.com/claude-code)