### PR TITLE
docs(readme): add v0.8.1 product-box row to roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,7 @@ Full version in [`memory/constitution.md`](memory/constitution.md).
 | v0.6 | Planned | [Productization, cross-tool adapters, live proof, hooks, and agentic security](specs/version-0-6-plan/tasks.md) |
 | v0.7 | Planned | [Automation quality hardening for agents and humans](https://github.com/Luis85/agentic-workflow/issues/98) |
 | v0.8 | Planned | [Content-driven product page generation](specs/version-0-8-plan/tasks.md) |
+| v0.8.1 | Planned | [Product box feature](docs/superpowers/plans/2026-05-01-product-box.md) ([issue #145](https://github.com/Luis85/agentic-workflow/issues/145)) |
 | v0.9 | Planned | [Stakeholder sparring partner for roadmap communication](specs/version-0-9-plan/tasks.md) ([issue #125](https://github.com/Luis85/agentic-workflow/issues/125)) |
 
 ---


### PR DESCRIPTION
## Summary

- Adds one-row entry for v0.8.1 in the §Roadmap table of `README.md`, between v0.8 and v0.9.
- Links to the existing plan `docs/superpowers/plans/2026-05-01-product-box.md` and tracker issue #145.

## Test plan

- [x] `npm run verify` green locally (link checker resolves the new plan link + GitHub issue link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)