### PR TITLE
feat(v06): PR-A steering profile (T-V06-001 + T-V06-002)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Repo = **template for spec-driven, agentic software development**. Defines workf
 1. **`memory/constitution.md`** — governing principles. Override only with explicit human approval.
 2. **`.claude/memory/MEMORY.md`** — operational memory: workflow rules + project state, indexed.
 3. **`docs/specorator.md`** — full workflow definition.
-4. **`docs/steering/`** — scoped context (product, tech, ux, quality, ops). Load only what's relevant.
+4. **`docs/specorator-product/`** — Specorator's own product steering for template-improvement work. Use `docs/steering/` as downstream project steering templates.
 5. **Current feature's `specs/<feature>/workflow-state.md`** — active stage + what's already produced.
 
 ## Operating rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ Entry point for Claude Code in this repository.
 @AGENTS.md
 @memory/constitution.md
 @.claude/memory/MEMORY.md
+@docs/specorator-product/README.md
 
 ## What this repo is
 

--- a/docs/specorator-product/README.md
+++ b/docs/specorator-product/README.md
@@ -1,0 +1,37 @@
+---
+title: "Specorator Product Steering"
+folder: "docs/specorator-product"
+description: "Specorator's own product, UX, technical, quality, and operations steering for template-improvement work."
+entry_point: true
+---
+# Specorator Product Steering
+
+This folder describes Specorator itself: the workflow template, docs, scripts, agent surfaces, release package, and public product page maintained in this repository.
+
+Use this folder when improving the template. Use [`docs/steering/`](../steering/README.md) when adopting Specorator for a downstream product or editing the blank steering templates that ship to adopters.
+
+## Decision
+
+T-V06-001 chooses the additive split from the v0.6 design:
+
+- `docs/steering/` remains the downstream starter-template home.
+- `docs/specorator-product/` holds Specorator's own product steering.
+- `AGENTS.md` and `CLAUDE.md` point template-improvement agents here.
+- No ADR is required because existing steering ownership is preserved.
+
+## Files
+
+| File | Use when |
+|---|---|
+| [`product.md`](product.md) | Framing roadmap, positioning, scope, personas, and success metrics. |
+| [`ux.md`](ux.md) | Changing docs IA, product-page UX, onboarding, examples, or content patterns. |
+| [`tech.md`](tech.md) | Changing scripts, repository layout, package distribution, adapters, or automation. |
+| [`quality.md`](quality.md) | Planning tests, verify-gate changes, review standards, or quality metrics. |
+| [`operations.md`](operations.md) | Changing release, publishing, CI, branch, rollback, or incident routines. |
+
+## Loading Rules
+
+- Load only the files relevant to the task.
+- Keep facts source-linked to repository artifacts where possible.
+- Update this folder in the same PR as product-facing changes that make its guidance stale.
+- Do not copy these files into downstream projects as starter templates; the starter templates are in `docs/steering/`.

--- a/docs/specorator-product/operations.md
+++ b/docs/specorator-product/operations.md
@@ -1,0 +1,52 @@
+# Specorator Operations Steering
+
+## Environments
+
+| Environment | Purpose | Source |
+|---|---|---|
+| Local worktree | Implementation and verification | `.worktrees/<slug>/` topic branches |
+| Pull request | Review, CI, and merge readiness | GitHub PRs against `main` |
+| GitHub Pages | Public product page | `sites/` deployment workflow |
+| GitHub Release | Tagged release notes and source archive | release branches and tags |
+| GitHub Packages | npm package distribution | package workflow and `package.json` |
+
+## Branch And PR Operations
+
+- Keep `main` as the integration branch unless a future ADR changes the branch model.
+- Use one topic branch per concern.
+- Work in `.worktrees/<slug>/` for non-trivial repository changes.
+- Run relevant verification before push and `npm run verify` before ready-for-review.
+- Do not force-push, merge, delete remote branches, or publish releases without explicit authorization or documented autonomous-merge criteria.
+
+## Release Cadence
+
+- Release trains are versioned milestones.
+- Release readiness is evidence-based: checks, release notes, package contract, public page state, and known limitations.
+- Tags are cut from the approved release source after merge readiness is confirmed.
+- Public positioning changes should land only after the evidence they cite exists or clearly states pending status.
+
+## Deployment And Publishing
+
+- GitHub Actions owns public page deployment and package/release workflows.
+- Manual release steps must be recorded in release notes or readiness docs.
+- Release-package contents must preserve fresh-surface starter semantics for downstream adopters.
+- Generated release notes use `.github/release.yml`; update categories with Conventional Commit policy changes.
+
+## Rollback
+
+- Documentation or template regressions roll forward through a corrective PR.
+- Product-page regressions can be reverted through a normal PR or redeployed from a known-good commit.
+- Package or release mistakes require a documented remediation note; never silently rewrite published history.
+
+## Observability
+
+- CI logs are the primary operational evidence for checks and deployments.
+- `npm run quality:metrics` provides repository and feature health signals.
+- Release notes capture readiness verdicts, caveats, and verification commands.
+- GitHub issues and PRs track roadmap and task state.
+
+## Incident Response
+
+- Security-sensitive incidents follow the repository's security guidance and require human authorization before public disclosure or credential rotation.
+- Broken release or package workflows should be isolated to a branch and verified locally before rerun.
+- Any process flaw that caused the incident should produce a follow-up issue, ADR, or memory note depending on permanence.

--- a/docs/specorator-product/product.md
+++ b/docs/specorator-product/product.md
@@ -1,0 +1,58 @@
+# Specorator Product Steering
+
+## Mission
+
+Specorator helps humans build software with AI agents without surrendering intent, traceability, or quality gates. The workflow is the product: a repository-native method for moving from idea to release through explicit artifacts, specialist agents, and deterministic verification.
+
+## Target Users
+
+- **Solo builder** - wants a disciplined path from vague idea to shipped feature without managing a full team. Needs clear prompts, resumable state, and low ceremony.
+- **Product or engineering team** - wants AI-assisted delivery that preserves product intent, reviewability, and handoffs across roles.
+- **Service provider or agency** - wants repeatable discovery, scoping, delivery, QA, and release records for client work.
+- **Enterprise evaluator** - wants evidence of governance, auditability, security posture, and reversibility before adopting agentic workflows.
+- **Brownfield maintainer** - wants to inventory an existing system and introduce one traceable feature without a rewrite.
+
+## Value Proposition
+
+Specorator is a file-based operating system for agentic software delivery: specs first, role-scoped agents, quality gates, and traceability in plain Markdown.
+
+## Strategic Priorities
+
+1. Make first-run adoption legible without reading the whole repository.
+2. Back public claims with repository evidence: verified demos, checks, release notes, and traceable artifacts.
+3. Keep the template portable across AI coding tools while preserving `AGENTS.md` and the workflow docs as source of truth.
+4. Keep advanced controls optional and reversible until an ADR promotes them.
+5. Improve the template without breaking downstream starter value.
+
+## Non-Goals
+
+- Do not turn Specorator into a hosted SaaS product.
+- Do not replace human acceptance, prioritization, or intent-setting.
+- Do not claim ISO certification, OWASP compliance, or complete security coverage.
+- Do not make every optional track mandatory for small projects.
+- Do not fragment the method into independent tool-specific manuals.
+
+## Success Metrics
+
+- A first-time adopter can identify the right starting path in under five minutes.
+- Lifecycle artifacts maintain traceability from requirements to tests and review.
+- `npm run verify` remains the single local confidence gate for contributors.
+- Public release claims link to evidence, examples, checks, or source docs.
+- Template improvements land through branch-per-concern PRs with documented verification.
+
+## Voice And Tone
+
+- Be plain, operational, and specific.
+- Prefer "run `npm run verify`" over "ensure quality".
+- State limits and caveats directly.
+- Avoid hype, certification language, and claims that are not backed by committed evidence.
+
+## Stakeholders
+
+| Role | Decision rights |
+|---|---|
+| Human maintainer | Product intent, priority, acceptance, irreversible changes. |
+| Lifecycle agents | Stage-specific artifact production inside their defined scope. |
+| Reviewer / QA agents | Quality verdicts, findings, verification evidence, residual risk. |
+| Release manager | Release readiness, public claims, package and tag hygiene. |
+| Downstream adopters | Their own product steering after they fork or instantiate the template. |

--- a/docs/specorator-product/quality.md
+++ b/docs/specorator-product/quality.md
@@ -1,0 +1,51 @@
+# Specorator Quality Steering
+
+## Quality Model
+
+Specorator quality is evidence-backed workflow integrity: artifacts match their inputs, traceability is preserved, checks are deterministic, and human acceptance points remain explicit.
+
+The canonical quality framework lives in [`docs/quality-framework.md`](../quality-framework.md). This file narrows it to template-improvement work.
+
+## Definition Of Tested
+
+A Specorator template change is tested when:
+
+1. The changed behavior is covered by an automated check, a targeted fixture, or a documented manual evidence note.
+2. The verification references the relevant task, requirement, spec item, or issue.
+3. `npm run verify` passes before push, or the skipped check is named with rationale.
+4. User-facing docs or product-page changes are checked for links, frontmatter, and claim accuracy.
+
+## Verification Layers
+
+| Layer | Use |
+|---|---|
+| `npm run check:fast` | Quick local feedback for common content, workflow, and script issues. |
+| `npm run verify:changed` | Targeted gate based on changed files. |
+| `npm run verify` | Final PR gate before push or ready-for-review. |
+| GitHub Actions | Remote confirmation for verify, PR title, security scans, spelling, and release workflows. |
+| Critic / reviewer pass | Judgment on scope, traceability, risk, and claims. |
+
+## Review Checklist
+
+- [ ] The change satisfies a named requirement, task, issue, or ADR.
+- [ ] Specs are updated before implementation when requirements change.
+- [ ] Downstream starter templates remain reusable.
+- [ ] Public claims are backed by committed evidence.
+- [ ] Optional controls remain opt-in unless an ADR says otherwise.
+- [ ] No unrelated refactors or process changes are bundled.
+- [ ] Verification evidence is recorded in the PR and, when required, the feature implementation log.
+
+## Risk Handling
+
+- **Traceability risk:** add or update task/spec references in the same branch.
+- **Adapter drift risk:** point back to `AGENTS.md` and tool-specific owners.
+- **Security overclaim risk:** state that guidance reduces internal risk and is not certification.
+- **Hook false-positive risk:** keep examples advisory and document disable paths.
+- **Release-package risk:** verify the fresh-surface contract before publishing.
+
+## Common Agent Mistakes
+
+- Treating docs-only changes as exempt from verification.
+- Updating a template without preserving starter usefulness.
+- Leaving `workflow-state.md` stale after a stage artifact changes.
+- Marking a draft PR ready before local verification is green.

--- a/docs/specorator-product/tech.md
+++ b/docs/specorator-product/tech.md
@@ -1,0 +1,75 @@
+# Specorator Technical Steering
+
+## Stack
+
+- **Primary artifact format:** Markdown with YAML frontmatter where required.
+- **Runtime for checks:** Node.js 20+.
+- **Language for automation:** TypeScript run through `tsx`.
+- **Package manager:** npm with `npm-shrinkwrap.json`.
+- **Public page:** static HTML/CSS/JS under `sites/`, deployed by GitHub Pages.
+- **CI/CD:** GitHub Actions for verify, security scans, typos, product-page checks, release/publish workflows, and PR title rules.
+- **Distribution:** GitHub source archive and GitHub Packages npm package, with package shape governed by release-package docs and checks.
+
+## Repository Layout
+
+```text
+AGENTS.md       - cross-tool operating source of truth
+CLAUDE.md       - Claude Code entry point
+.codex/         - Codex-specific instructions and workflows
+.claude/        - Claude agents, commands, skills, memory, settings
+docs/           - methodology, steering, quality, release, and reference docs
+specs/          - per-feature workflow artifacts and state
+templates/      - blank artifacts for downstream use
+scripts/        - deterministic checks, fixers, reports, and helpers
+tests/          - script and library tests
+sites/          - public product page
+```
+
+## Coding Conventions
+
+- Keep scripts deterministic and read-only unless explicitly named `fix:*`.
+- Use shared helpers under `scripts/lib/` before adding one-off parsing logic.
+- Prefer structured parsers for YAML, Markdown frontmatter, and repository inventories.
+- Add or update tests when script behavior changes.
+- Regenerate generated docs when TypeScript script APIs change.
+- Commit messages are imperative and reference task IDs or issue numbers.
+
+## Documentation Conventions
+
+- Keep methodology docs in Markdown.
+- Use stable IDs for requirements, tasks, tests, ADRs, and findings.
+- One folder gets one `README.md`; non-root README files need folder frontmatter.
+- Preserve downstream templates as templates. Put Specorator-specific reality in `docs/specorator-product/`.
+- Link to canonical sources rather than duplicating large sections.
+
+## Build, Test, Run
+
+```bash
+npm ci
+npm run check:fast
+npm run verify:changed
+npm run verify
+```
+
+Use `npm run verify` as the final local gate before pushing implementation PRs. Use narrower checks while iterating.
+
+## Dependency Policy
+
+- New runtime or dev dependencies require a PR justification.
+- Architecturally significant dependencies require an ADR.
+- Security-sensitive dependencies require explicit review.
+- Keep package metadata and release-package checks in sync.
+
+## Security Baseline
+
+- Do not commit secrets, tokens, private keys, or customer data.
+- Treat hooks and agentic-security checks as opt-in until an ADR promotes them.
+- Keep destructive operations behind explicit human authorization.
+- Keep adapters thin so workflow authority does not drift away from canonical sources.
+
+## Common Agent Mistakes
+
+- Editing the main checkout instead of the topic worktree.
+- Running only a targeted check and forgetting the final `npm run verify`.
+- Adding generated docs without updating the generating script or vice versa.
+- Making a tool adapter authoritative instead of a pointer to the canonical workflow.

--- a/docs/specorator-product/ux.md
+++ b/docs/specorator-product/ux.md
@@ -1,0 +1,50 @@
+# Specorator UX Steering
+
+## Design Principles
+
+- **Make the next action obvious** - Do point users to the smallest useful surface; do not make them read the whole repository first.
+- **Show the artifact path** - Do connect concepts to concrete files and commands; do not leave process advice detached from where work lives.
+- **Respect role boundaries** - Do clarify which agent or human owns each decision; do not blur stages into one generic AI prompt.
+- **Prefer evidence over persuasion** - Do link claims to demos, checks, release notes, or specs; do not rely on marketing copy alone.
+- **Keep starter surfaces reusable** - Do preserve blank downstream templates; do not fill them with Specorator-only context.
+
+## Information Architecture
+
+- `README.md` is the public entry point and quick-start map.
+- `sites/index.html` is the public product page.
+- `AGENTS.md` is the cross-tool source of truth for agent operating rules.
+- `.claude/`, `.codex/`, and future adapter folders are tool-specific projections.
+- `docs/specorator.md` defines the full workflow.
+- `docs/specorator-product/` defines this repository's own product steering.
+- `docs/steering/` remains adopter-facing starter context.
+
+## Interaction And Content Patterns
+
+- Use short sections with concrete links to files.
+- Keep role-specific paths separate from exhaustive reference material.
+- Mark optional tracks as optional.
+- Name commands exactly as users run them.
+- Preserve status and caveats near claims that depend on future PRs or evidence.
+- For product-page changes, keep the first viewport focused on Specorator and reveal the next section without making a marketing-only splash screen.
+
+## Accessibility
+
+- Public HTML must keep semantic headings, keyboard-reachable controls, visible focus states, and sufficient color contrast.
+- Documentation links must use descriptive labels, not "click here".
+- Avoid relying on color alone for status.
+- Keep Mermaid and diagram use backed by surrounding text for screen-reader and plain Markdown readers.
+
+## Content Standards
+
+- Use sentence case for headings unless a file already uses title case.
+- Prefer active voice.
+- Keep examples short and realistic.
+- Explain reversible opt-in behavior before advanced controls.
+- Avoid security or compliance overclaims.
+
+## Common Agent Mistakes
+
+- Treating `docs/steering/` as Specorator's own filled-in context.
+- Adding a new workflow stage without an ADR.
+- Updating public positioning before evidence exists.
+- Duplicating canonical rules into tool adapters instead of pointing back to `AGENTS.md`.

--- a/docs/steering/README.md
+++ b/docs/steering/README.md
@@ -8,6 +8,10 @@ entry_point: true
 
 Persistent, scoped context loaded by agents on demand. Inspired by Kiro's `.kiro/steering/` pattern.
 
+These files are **downstream project templates**. They describe the context an adopter should fill in after using Specorator as a starter. They do not describe Specorator itself.
+
+Specorator's own product steering lives in [`docs/specorator-product/`](../specorator-product/README.md). Use that folder when improving this repository, the workflow method, the product page, package distribution, adapters, hooks, or other template-owned surfaces.
+
 | File | Loaded by | When |
 |---|---|---|
 | `product.md` | PM, UX, UI, Reviewer, Release Manager | Product-shaped work |
@@ -23,6 +27,16 @@ Persistent, scoped context loaded by agents on demand. Inspired by Kiro's `.kiro
 - **Always-loaded:** none, by default. Steering files are scoped on purpose.
 - **Conditionally loaded:** agents declare in their frontmatter which steering files they need.
 - **Manually loaded:** humans can `@docs/steering/<file>.md` in a prompt to inject context.
+
+## Which steering source to load
+
+| Work type | Steering source |
+|---|---|
+| Improving Specorator itself | `docs/specorator-product/` |
+| Starting a new downstream product from the template | `docs/steering/` |
+| Editing these blank starter templates | `docs/steering/` plus `docs/specorator-product/quality.md` |
+| Writing public positioning for Specorator | `docs/specorator-product/product.md` and `docs/specorator-product/ux.md` |
+| Changing verification, release, or package behavior | `docs/specorator-product/tech.md`, `quality.md`, and `operations.md` |
 
 ## Style
 

--- a/specs/version-0-6-plan/implementation-log.md
+++ b/specs/version-0-6-plan/implementation-log.md
@@ -1,0 +1,54 @@
+---
+id: IMPL-LOG-V06-001
+title: Version 0.6 productization and trust plan - Implementation log
+stage: implementation
+feature: version-0-6-plan
+status: in-progress
+owner: dev
+inputs:
+  - SPECDOC-V06-001
+  - TASKS-V06-001
+created: 2026-05-02
+updated: 2026-05-02
+---
+
+# Implementation log - Version 0.6 productization and trust plan
+
+A running record of what was implemented, why a deviation was taken, and what was learned. Append-only during implementation; no rewriting history.
+
+## Entries
+
+### 2026-05-02 - T-V06-001 - Decide steering profile location
+
+- **Files changed:** `docs/specorator-product/README.md` (new); `docs/steering/README.md`; `AGENTS.md`; `CLAUDE.md`; `specs/version-0-6-plan/workflow-state.md`
+- **Commit:** *(staged in PR #175; commit SHA recorded after `npm run verify`)*
+- **Spec reference:** SPEC-V06-001 (REQ-V06-001, NFR-V06-001)
+- **Owner:** architect
+- **Outcome:** done
+- **Deviation from spec:** none
+- **Notes:** Chose the additive split recommended by `design.md`: `docs/steering/` remains downstream starter-template guidance and `docs/specorator-product/` becomes Specorator's own steering home. No ADR is required because the existing adopter-template ownership was preserved rather than repurposed.
+
+### 2026-05-02 - T-V06-002 - Fill Specorator product steering
+
+- **Files changed:** `docs/specorator-product/product.md` (new); `docs/specorator-product/ux.md` (new); `docs/specorator-product/tech.md` (new); `docs/specorator-product/quality.md` (new); `docs/specorator-product/operations.md` (new); `docs/steering/README.md`; `AGENTS.md`; `CLAUDE.md`
+- **Commit:** *(staged in PR #175; commit SHA recorded after `npm run verify`)*
+- **Spec reference:** SPEC-V06-001 (REQ-V06-001, NFR-V06-001)
+- **Owner:** pm
+- **Outcome:** done
+- **Deviation from spec:** none
+- **Notes:** Added product, UX, technical, quality, and operations steering for Specorator itself. The downstream steering files remain blank starter templates; their README now points agents to the correct steering source for template-improvement work.
+
+## Deviations summary
+
+| Date | Task | Deviation | Reason | ADR |
+|---|---|---|---|---|
+| 2026-05-02 | T-V06-001 | None | Existing template ownership preserved. | - |
+| 2026-05-02 | T-V06-002 | None | Implementation follows SPEC-V06-001. | - |
+
+## Quality gate
+
+- [ ] All tasks accounted for (done, partial, blocked, or dropped).
+- [ ] Implementation matches the spec; any deviation is logged with rationale and ADR if material.
+- [ ] No unrelated changes in any task entry.
+- [ ] Lint, type checks, unit tests, and docs checks green for the changed surface.
+- [ ] Commits reference task IDs.

--- a/specs/version-0-6-plan/implementation-log.md
+++ b/specs/version-0-6-plan/implementation-log.md
@@ -21,7 +21,7 @@ A running record of what was implemented, why a deviation was taken, and what wa
 ### 2026-05-02 - T-V06-001 - Decide steering profile location
 
 - **Files changed:** `docs/specorator-product/README.md` (new); `docs/steering/README.md`; `AGENTS.md`; `CLAUDE.md`; `specs/version-0-6-plan/workflow-state.md`
-- **Commit:** *(staged in PR #175; commit SHA recorded after `npm run verify`)*
+- **Commit:** PR #175 - bda2ec6.
 - **Spec reference:** SPEC-V06-001 (REQ-V06-001, NFR-V06-001)
 - **Owner:** architect
 - **Outcome:** done
@@ -31,7 +31,7 @@ A running record of what was implemented, why a deviation was taken, and what wa
 ### 2026-05-02 - T-V06-002 - Fill Specorator product steering
 
 - **Files changed:** `docs/specorator-product/product.md` (new); `docs/specorator-product/ux.md` (new); `docs/specorator-product/tech.md` (new); `docs/specorator-product/quality.md` (new); `docs/specorator-product/operations.md` (new); `docs/steering/README.md`; `AGENTS.md`; `CLAUDE.md`
-- **Commit:** *(staged in PR #175; commit SHA recorded after `npm run verify`)*
+- **Commit:** PR #175 - bda2ec6.
 - **Spec reference:** SPEC-V06-001 (REQ-V06-001, NFR-V06-001)
 - **Owner:** pm
 - **Outcome:** done

--- a/specs/version-0-6-plan/pr-plan-a-steering-profile.md
+++ b/specs/version-0-6-plan/pr-plan-a-steering-profile.md
@@ -67,6 +67,7 @@ If the decision changes ownership semantics → file ADR-0022 via [`/adr:new`](.
 - [ ] T-V06-002 Specorator steering filled at chosen location
 - [ ] Adopter template guidance preserved (no silent overwrite)
 - [ ] `AGENTS.md` + `CLAUDE.md` point to the correct steering source for template improvements
+- [ ] Append entry to [`specs/version-0-6-plan/implementation-log.md`](./implementation-log.md) per Stage 7
 - [ ] `npm run verify` green
 - [ ] PR title matches `feat(v06): ...` Conventional Commit pattern (PR-title CI)
 - [ ] References issue #91 + task IDs in commits
@@ -74,7 +75,7 @@ If the decision changes ownership semantics → file ADR-0022 via [`/adr:new`](.
 ## Workflow refs
 
 - [`AGENTS.md`](../../AGENTS.md) — operating rules + agent classes
-- [`docs/specorator.md`](../../docs/specorator.md) — full lifecycle
+- [`docs/specorator.md`](../../docs/specorator.md) — full lifecycle (Stage 7 = Implementation, current stage)
 - [`docs/steering/README.md`](../../docs/steering/README.md)
 - [`docs/branching.md`](../../docs/branching.md) — branch-per-concern
 - [`docs/verify-gate.md`](../../docs/verify-gate.md) — verify before push
@@ -87,5 +88,7 @@ None.
 
 ## Coordination
 
-- No file-scope overlap with other Wave 1 PRs.
+- **`AGENTS.md` collision** — also touched by PR-C (#177 *Tool-specific notes*) and PR-E (#179 pointer entry). Per [`feedback_parallel_pr_conflicts.md`](../../.claude/memory/feedback_parallel_pr_conflicts.md): merge not rebase to preserve reviewer line anchors.
+- **`CLAUDE.md` collision** — also touched by PR-E (#179 pointer entry).
 - T-V06-012 (public positioning) reads the steering decision after this PR merges.
+- Land first if possible — PR-C/PR-E read the *Read these first* structure once it stabilises here.

--- a/specs/version-0-6-plan/pr-plan-a-steering-profile.md
+++ b/specs/version-0-6-plan/pr-plan-a-steering-profile.md
@@ -67,7 +67,7 @@ If the decision changes ownership semantics → file ADR-0022 via [`/adr:new`](.
 - [ ] T-V06-002 Specorator steering filled at chosen location
 - [ ] Adopter template guidance preserved (no silent overwrite)
 - [ ] `AGENTS.md` + `CLAUDE.md` point to the correct steering source for template improvements
-- [ ] Append entry to [`specs/version-0-6-plan/implementation-log.md`](./implementation-log.md) per Stage 7
+- [ ] Append entry to `specs/version-0-6-plan/implementation-log.md` per Stage 7 (file is pending — first task to land creates it)
 - [ ] `npm run verify` green
 - [ ] PR title matches `feat(v06): ...` Conventional Commit pattern (PR-title CI)
 - [ ] References issue #91 + task IDs in commits

--- a/specs/version-0-6-plan/pr-plan-a-steering-profile.md
+++ b/specs/version-0-6-plan/pr-plan-a-steering-profile.md
@@ -1,0 +1,91 @@
+# PR-A — Steering profile
+
+> Implementer brief for the v0.6 steering-profile slice. Branch: `feat/v06-steering-profile`. Tracking issue: [#91](https://github.com/Luis85/agentic-workflow/issues/91). Milestone: v0.6.
+
+## Tasks
+
+| ID | Title | Owner role | Estimate |
+|---|---|---|---|
+| T-V06-001 | Decide steering profile location | architect | M |
+| T-V06-002 | Fill Specorator product steering | pm | M |
+
+T-V06-002 depends on T-V06-001 — the decision must land first (in this same PR).
+
+## Goal
+
+Distinguish Specorator's own product steering from the blank downstream steering templates without erasing adopter-facing template guidance.
+
+## Spec references
+
+- [idea.md](./idea.md)
+- [research.md](./research.md)
+- [requirements.md](./requirements.md) — REQ-V06-001
+- [design.md](./design.md) — see *Steering model*
+- [spec.md](./spec.md) — SPEC-V06-001
+- [tasks.md](./tasks.md) — T-V06-001, T-V06-002
+
+## Requirements satisfied
+
+- REQ-V06-001 — Fill Specorator product steering (ubiquitous, must)
+- NFR-V06-001 — First-run adoption legible without reading the whole repo
+- SPEC-V06-001 — Specorator steering profile
+
+## Test scenario
+
+| ID | Scenario | Expected |
+|---|---|---|
+| TEST-V06-001 | Contributor searches for Specorator's own product steering | Correct steering source explicit; adopter templates not erased |
+
+## Decision points (T-V06-001)
+
+Pick one location model from `design.md` and record it. Options:
+1. Repurpose `docs/steering/*.md` for Specorator and add blank templates elsewhere.
+2. Keep `docs/steering/*.md` as adopter blanks; add `docs/specorator-product/` (or equivalent) for Specorator's own steering.
+3. Keep `docs/steering/*.md` as adopter blanks; mark each one with a clearly-scoped section per audience.
+
+If the decision changes ownership semantics → file ADR-0022 via [`/adr:new`](../../.claude/skills/new-adr/SKILL.md). ADR is **required** for option 1.
+
+## Implementation outline (T-V06-002)
+
+1. Land the location decision (commit + ADR if option 1).
+2. Fill Specorator's own product, UX, tech, quality, operations steering at the chosen location, sourcing facts from `README.md`, `AGENTS.md`, `docs/specorator.md`, `docs/quality-framework.md`.
+3. Update `AGENTS.md` and `CLAUDE.md` "Read these first" sections so agents pick the right steering source for template improvements vs adopter projects.
+4. Update `docs/steering/README.md` to explain the split.
+
+## Files of interest
+
+- `docs/steering/README.md`
+- `docs/steering/{product,ux,tech,quality,operations}.md`
+- New `docs/specorator-product/` (option 2) or new blank-template home (option 1)
+- `AGENTS.md` — *Read these first* section
+- `CLAUDE.md` — primary context import list
+- `docs/adr/0022-*.md` — only if ownership semantics change
+
+## Definition of Done
+
+- [ ] T-V06-001 decision recorded in commit + ADR-0022 if required
+- [ ] T-V06-002 Specorator steering filled at chosen location
+- [ ] Adopter template guidance preserved (no silent overwrite)
+- [ ] `AGENTS.md` + `CLAUDE.md` point to the correct steering source for template improvements
+- [ ] `npm run verify` green
+- [ ] PR title matches `feat(v06): ...` Conventional Commit pattern (PR-title CI)
+- [ ] References issue #91 + task IDs in commits
+
+## Workflow refs
+
+- [`AGENTS.md`](../../AGENTS.md) — operating rules + agent classes
+- [`docs/specorator.md`](../../docs/specorator.md) — full lifecycle
+- [`docs/steering/README.md`](../../docs/steering/README.md)
+- [`docs/branching.md`](../../docs/branching.md) — branch-per-concern
+- [`docs/verify-gate.md`](../../docs/verify-gate.md) — verify before push
+- [`templates/adr-template.md`](../../templates/adr-template.md)
+- [`memory/constitution.md`](../../memory/constitution.md) — Article VIII Plain Language
+
+## CLAR resolution required
+
+None.
+
+## Coordination
+
+- No file-scope overlap with other Wave 1 PRs.
+- T-V06-012 (public positioning) reads the steering decision after this PR merges.

--- a/specs/version-0-6-plan/workflow-state.md
+++ b/specs/version-0-6-plan/workflow-state.md
@@ -3,8 +3,8 @@ feature: version-0-6-plan
 area: V06
 current_stage: implementation
 status: active
-last_updated: 2026-05-01
-last_agent: planner
+last_updated: 2026-05-02
+last_agent: codex-dev
 artifacts:
   idea.md: complete
   research.md: complete
@@ -12,7 +12,7 @@ artifacts:
   design.md: complete
   spec.md: complete
   tasks.md: complete
-  implementation-log.md: pending
+  implementation-log.md: in-progress
   test-plan.md: pending
   test-report.md: pending
   review.md: pending
@@ -33,7 +33,7 @@ artifacts:
 | 4. Design | `design.md` | complete |
 | 5. Specification | `spec.md` | complete |
 | 6. Tasks | `tasks.md` | complete |
-| 7. Implementation | `implementation-log.md` + code/docs | pending |
+| 7. Implementation | `implementation-log.md` + code/docs | in-progress |
 | 8. Testing | `test-plan.md`, `test-report.md` | pending |
 | 9. Review | `review.md`, `traceability.md` | pending |
 | 10. Release | `release-notes.md` | pending |
@@ -50,6 +50,7 @@ artifacts:
 ## Hand-off notes
 
 - 2026-05-01 (codex): Planned v0.6 through Stage 6 from the product research pass. Recommended implementation order is steering profile, live golden-path demo, cross-tool adapters, hook pack, agentic security workflow, proof-first public positioning, adoption profiles, ISO 9001:2026 watch item, then release readiness verification.
+- 2026-05-02 (codex, T-V06-001/T-V06-002): PR-A selected the additive steering split: downstream starter templates stay in `docs/steering/`, while Specorator's own product steering lives in `docs/specorator-product/`. No ADR required because existing template ownership was preserved. Implementation evidence lives in `implementation-log.md`.
 
 ## Open clarifications
 


### PR DESCRIPTION
## Refs

- Tracking issue: #91
- Milestone: v0.6
- Tasks: **T-V06-001**, **T-V06-002**
- Plan: [`specs/version-0-6-plan/pr-plan-a-steering-profile.md`](https://github.com/Luis85/agentic-workflow/blob/feat/v06-steering-profile/specs/version-0-6-plan/pr-plan-a-steering-profile.md)

## Scope

Distinguish Specorator's own product steering from blank downstream steering templates. Two sequential tasks in one PR (decision then fill).

| Task | Owner role | Description |
|---|---|---|
| T-V06-001 | architect | Decide steering profile location; ADR if ownership semantics change |
| T-V06-002 | pm | Fill Specorator product/UX/tech/quality/operations steering at chosen location |

## Spec references

- [idea.md](https://github.com/Luis85/agentic-workflow/blob/main/specs/version-0-6-plan/idea.md)
- [research.md](https://github.com/Luis85/agentic-workflow/blob/main/specs/version-0-6-plan/research.md)
- [requirements.md](https://github.com/Luis85/agentic-workflow/blob/main/specs/version-0-6-plan/requirements.md) — REQ-V06-001
- [design.md](https://github.com/Luis85/agentic-workflow/blob/main/specs/version-0-6-plan/design.md) — *Steering model*
- [spec.md](https://github.com/Luis85/agentic-workflow/blob/main/specs/version-0-6-plan/spec.md) — SPEC-V06-001
- [tasks.md](https://github.com/Luis85/agentic-workflow/blob/main/specs/version-0-6-plan/tasks.md) — T-V06-001, T-V06-002

## Requirements satisfied

- **REQ-V06-001** — Repository distinguishes Specorator's own product steering from blank downstream steering templates
- **NFR-V06-001** — First-run adoption legible without reading the whole repository
- **SPEC-V06-001** — Specorator steering profile

## Test scenario

| ID | Scenario | Expected |
|---|---|---|
| TEST-V06-001 | Contributor searches for Specorator's own product steering | Correct steering source explicit; adopter templates not erased |

## Decision

Selected option 2 from the design: keep `docs/steering/*.md` as adopter blanks and add `docs/specorator-product/` for Specorator's own steering. No ADR was required because existing template ownership was preserved.

## Files of interest

- `docs/steering/README.md`
- New `docs/specorator-product/README.md`
- New `docs/specorator-product/{product,ux,tech,quality,operations}.md`
- `AGENTS.md` — *Read these first*
- `CLAUDE.md` — primary context
- `specs/version-0-6-plan/implementation-log.md`

## Definition of Done

- [x] T-V06-001 location decision recorded (commit + ADR-0022 if required)
- [x] T-V06-002 Specorator steering filled at chosen location
- [x] Adopter template guidance preserved
- [x] `AGENTS.md` + `CLAUDE.md` point to correct steering source
- [x] Append entry to `specs/version-0-6-plan/implementation-log.md` per Stage 7
- [x] `npm run verify` green
- [x] PR title matches `feat(v06): ...` Conventional Commit pattern

## CLAR resolution

None required for this slice.

## Coordination

- May overlap PR-C (#177) and PR-E (#179) on `AGENTS.md` / `CLAUDE.md`. Per memory rule `feedback_parallel_pr_conflicts.md`: merge not rebase.
- T-V06-012 (positioning) reads steering decision after this merges.

## Verification

- `npm run check:frontmatter` — pass
- `npm run check:links` — pass
- `npm run check:specs` — pass
- `npm run verify:changed` — pass
- `npm ci` — pass, used to restore missing local `typedoc`
- `npm run verify` — pass

## Workflow refs

- [AGENTS.md](https://github.com/Luis85/agentic-workflow/blob/main/AGENTS.md)
- [docs/specorator.md](https://github.com/Luis85/agentic-workflow/blob/main/docs/specorator.md)
- [docs/branching.md](https://github.com/Luis85/agentic-workflow/blob/main/docs/branching.md)
- [docs/verify-gate.md](https://github.com/Luis85/agentic-workflow/blob/main/docs/verify-gate.md)
- [memory/constitution.md](https://github.com/Luis85/agentic-workflow/blob/main/memory/constitution.md)