### PR TITLE
feat(issue-breakdown): Phase 1 design + plan (spec-only PR)

### DIFF
--- a/docs/superpowers/plans/2026-05-02-issue-breakdown.md
+++ b/docs/superpowers/plans/2026-05-02-issue-breakdown.md
@@ -206,10 +206,10 @@ The conductor parses `tasks.md` directly using its template-guaranteed anchors (
 - [ ] **Step 4: Verify ADR index picks it up**
 
 ```bash
-npm run check:adr -- --quiet || npx tsx scripts/check-adr-index.ts
+npm run check:adr-index
 ```
 
-Expected: passes (the index regenerator picks up `0022`).
+Expected: passes (the index regenerator picks up `0022`). If it auto-updates `docs/adr/README.md`, stage that too in step 5.
 
 - [ ] **Step 5: Commit**
 
@@ -311,13 +311,13 @@ Not for:
 - Branching: [`docs/branching.md`](branching.md).
 ```
 
-- [ ] **Step 3: Verify links**
+- [ ] **Step 3: Verify links repo-wide**
 
 ```bash
-npx tsx scripts/check-markdown-links.ts -- docs/issue-breakdown-track.md
+npm run check:links
 ```
 
-Expected: all relative links resolve.
+Expected: green. The link checker walks the whole repo; it does not accept a single-file argument.
 
 - [ ] **Step 4: Commit**
 
@@ -385,13 +385,13 @@ Refs #<issue-number>
 <!-- The conductor appends the verbatim contents of .github/PULL_REQUEST_TEMPLATE.md here at runtime. -->
 ```
 
-- [ ] **Step 2: Verify frontmatter**
+- [ ] **Step 2: Verify frontmatter repo-wide**
 
 ```bash
-npx tsx scripts/check-frontmatter.ts -- templates/issue-breakdown-pr-body-template.md
+npm run check:frontmatter
 ```
 
-Expected: passes.
+Expected: green. (Walks the whole repo — does not accept a single-file argument.)
 
 - [ ] **Step 3: Commit**
 
@@ -428,13 +428,13 @@ Spec: `specs/<slug>/`. Re-run with `/issue:breakdown <n>` to refresh.
 <!-- END issue-breakdown:<slug> -->
 ```
 
-- [ ] **Step 2: Verify frontmatter**
+- [ ] **Step 2: Verify frontmatter repo-wide**
 
 ```bash
-npx tsx scripts/check-frontmatter.ts -- templates/issue-breakdown-issue-section.md
+npm run check:frontmatter
 ```
 
-Expected: passes.
+Expected: green.
 
 - [ ] **Step 3: Commit**
 
@@ -612,20 +612,13 @@ You **escalate to the conductor**, not to the user. The conductor surfaces choic
 - [ ] **Step 3: Verify agent registration**
 
 ```bash
-npx tsx scripts/check-agents.ts
+npm run check:agents
+npm run check:frontmatter
 ```
 
-Expected: passes (the new agent is registered automatically by name).
+Expected: both green. `check:agents` validates frontmatter shape (`name`, `description`, non-empty `tools` list, `## Scope` heading). `check:frontmatter` walks the whole repo.
 
-- [ ] **Step 4: Verify frontmatter**
-
-```bash
-npx tsx scripts/check-frontmatter.ts -- .claude/agents/issue-breakdown.md
-```
-
-Expected: passes.
-
-- [ ] **Step 5: Commit**
+- [ ] **Step 4: Commit**
 
 ```bash
 git add .claude/agents/issue-breakdown.md
@@ -687,10 +680,10 @@ See [`docs/issue-breakdown-track.md`](../../../docs/issue-breakdown-track.md) fo
 - [ ] **Step 4: Verify command registration**
 
 ```bash
-npx tsx scripts/check-command-docs.ts
+npm run check:commands
 ```
 
-Expected: passes.
+Expected: **fails** on this run, because `.claude/commands/README.md`, `README.md`, and `docs/workflow-overview.md` each contain auto-generated inventory blocks that need refreshing — Chunk 6 handles those. For now confirm the failure mode is *only* "generated block out of date", not a frontmatter or path issue. If the script complains about anything other than the BEGIN/END GENERATED blocks, fix that here before moving on.
 
 - [ ] **Step 5: Commit**
 
@@ -871,11 +864,12 @@ Do not bleed `/issue:breakdown` concerns back into `/spec:tasks` or vice versa.
 - [ ] **Step 3: Verify skill registration**
 
 ```bash
-npx tsx scripts/check-frontmatter.ts -- .claude/skills/issue-breakdown/SKILL.md
-npx tsx scripts/check-markdown-links.ts -- .claude/skills/issue-breakdown/SKILL.md
+npm run check:agents
+npm run check:frontmatter
+npm run check:links
 ```
 
-Expected: both pass.
+Expected: all green. `check:agents` also validates skill files (it discovers any `SKILL.md` under `.claude/skills/`). `check:links` walks the whole repo.
 
 - [ ] **Step 4: Commit**
 
@@ -884,69 +878,98 @@ git add .claude/skills/issue-breakdown/SKILL.md
 git commit -m "feat(issue-breakdown): add conductor skill"
 ```
 
+> **Note on `inputs/` intake gate.** The shared conductor pattern (`_shared/conductor-pattern.md`) and `CLAUDE.md` both say "every conductor's scope phase lists `inputs/`". This conductor intentionally *skips* the mandatory intake step because the input is the GitHub issue + an already-completed `tasks.md`, not a new work package. The methodology doc at `docs/issue-breakdown-track.md` documents this deviation. Call it out in the PR description so reviewers reading the conductor pattern don't flag a missing intake step.
+
 ---
 
 ## Chunk 6: Cross-references — wire the new track into existing indexes
 
 The check-scripts already pick up the new files automatically; this chunk only updates human-facing inventory pages so the track is discoverable.
 
-### Task 6.1: Update `.claude/commands/README.md`
+### Task 6.1: Register `issue/` namespace + regenerate command-inventory blocks
 
-**Files:** Modify `.claude/commands/README.md`.
+**Files:** Modify `scripts/lib/commands.ts`, `.claude/commands/README.md`, `README.md`, `docs/workflow-overview.md`.
 
-- [ ] **Step 1: Find the right insertion point**
+The slash-command inventory in three files is **auto-generated** between `<!-- BEGIN GENERATED: ... -->` / `<!-- END GENERATED: ... -->` markers. `npm run check:commands` regenerates the expected content and refuses if the file is out of sync. Touching the README tables by hand will fail verify.
 
-```bash
-grep -n "^|.*issue.*\|^| `/" .claude/commands/README.md | head
-grep -n "## " .claude/commands/README.md
+- [ ] **Step 1: Add the new namespace label**
+
+Open `scripts/lib/commands.ts`. Add an entry to the `labels` map (alphabetical insertion):
+
+```ts
+const labels = new Map([
+  ["adr", "Decisions"],
+  ["discovery", "Discovery Track"],
+  ["issue", "Issue Breakdown Track"],   // NEW
+  ["portfolio", "Portfolio Track"],
+  ...
+]);
 ```
 
-Expected: a "Slash commands" or namespaced table that lists `/spec:*`, `/discovery:*`, `/sales:*`, etc. Add `issue/` alongside.
-
-- [ ] **Step 2: Add row(s)**
-
-In the namespaces table, add a new row for the `issue/` namespace and a new row in the per-command table for `/issue:breakdown`. Match the surrounding table shape exactly.
-
-- [ ] **Step 3: Verify**
+- [ ] **Step 2: Regenerate the inventory blocks**
 
 ```bash
-npx tsx scripts/check-command-docs.ts
+npm run check:commands
 ```
 
-Expected: passes.
+Expected: **fails the first time**, but the failure output prints the exact regenerated block expected for each of the three files. Read the failure carefully.
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 3: Apply the regenerated blocks**
+
+Most repos ship a `fix-command-docs.ts` companion script that auto-writes the regenerated content. Run it if present:
 
 ```bash
-git add .claude/commands/README.md
-git commit -m "docs(commands): register issue/ namespace + /issue:breakdown"
+ls scripts/fix-command-docs.ts && npx tsx scripts/fix-command-docs.ts
+```
+
+If the fix script doesn't exist, paste the expected blocks from the failure output into:
+
+- `.claude/commands/README.md` (between `<!-- BEGIN GENERATED: command-inventory -->` and `<!-- END GENERATED: command-inventory -->`).
+- `README.md` (between `<!-- BEGIN GENERATED: slash-commands -->` and `<!-- END GENERATED: slash-commands -->`, around line 345).
+- `docs/workflow-overview.md` (between `<!-- BEGIN GENERATED: slash-commands -->` and `<!-- END GENERATED: slash-commands -->`, around line 110).
+
+- [ ] **Step 4: Verify**
+
+```bash
+npm run check:commands
+```
+
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lib/commands.ts .claude/commands/README.md README.md docs/workflow-overview.md
+git commit -m "docs(commands): register issue/ namespace and regenerate inventories"
 ```
 
 ### Task 6.2: Update `.claude/skills/README.md`
 
 **Files:** Modify `.claude/skills/README.md`.
 
-- [ ] **Step 1: Find the conductor-skills section**
+- [ ] **Step 1: Inspect the existing Workflow-conductors table**
 
 ```bash
-grep -n "orchestrate\|discovery-sprint\|sales-cycle" .claude/skills/README.md
+sed -n '40,60p' .claude/skills/README.md
 ```
 
-Expected: a list of conductor skills. Add `issue-breakdown` in alphabetical order or in the same logical grouping as `orchestrate`.
+Expected: a 3-column markdown table headed `| Skill | Triggers when… | What it does |` listing each conductor (`orchestrate/`, `discovery-sprint/`, `sales-cycle/`, etc.). Add a new row matching the existing column shape — **not** a bullet.
 
-- [ ] **Step 2: Add row**
+- [ ] **Step 2: Add the table row**
+
+Insert in alphabetical order:
 
 ```markdown
-- [`issue-breakdown`](issue-breakdown/SKILL.md) — post-/spec:tasks conductor that decomposes an issue into independent draft PRs.
+| [`issue-breakdown/`](issue-breakdown/SKILL.md) | post-/spec:tasks; "break this issue down", "decompose issue", `/issue:breakdown <n>` | Decompose a GitHub issue into independent draft PRs by parsing tasks.md `## Parallelisable batches`. |
 ```
 
-- [ ] **Step 3: Verify links**
+- [ ] **Step 3: Verify links repo-wide**
 
 ```bash
-npx tsx scripts/check-markdown-links.ts -- .claude/skills/README.md
+npm run check:links
 ```
 
-Expected: passes.
+Expected: green.
 
 - [ ] **Step 4: Commit**
 
@@ -977,15 +1000,17 @@ Add a new row after the "Quality assurance" row (or in the closest logical posit
 
 - [ ] **Step 3: Update conductor-skill summary line**
 
-Find the existing line listing all workflow-conductor skills (something like *"Ten workflow-conductor skills (`orchestrate`, `project-scaffolding`, …) are the conversational entry points."*) and bump the count + add `issue-breakdown` to the parenthesised list.
+Find the existing sentence: *"Ten workflow-conductor skills (`orchestrate`, `project-scaffolding`, `discovery-sprint`, `stock-taking`, `sales-cycle`, `project-run`, `roadmap-management`, `portfolio-track`, `quality-assurance`, `specorator-improvement`) are the conversational entry points."*
 
-- [ ] **Step 4: Verify**
+Change `Ten` to `Eleven` and append `, issue-breakdown` to the parenthesised list (after `specorator-improvement`).
+
+- [ ] **Step 4: Verify links repo-wide**
 
 ```bash
-npx tsx scripts/check-markdown-links.ts -- AGENTS.md
+npm run check:links
 ```
 
-Expected: passes.
+Expected: green.
 
 - [ ] **Step 5: Commit**
 
@@ -1014,13 +1039,13 @@ Expected: one match, with a table of opt-in tracks (Discovery, Stock-taking, Sal
 
 Place it after the "Portfolio" row to preserve the existing pre-/post-Specorator ordering.
 
-- [ ] **Step 3: Verify**
+- [ ] **Step 3: Verify links repo-wide**
 
 ```bash
-npx tsx scripts/check-markdown-links.ts -- CLAUDE.md
+npm run check:links
 ```
 
-Expected: passes.
+Expected: green.
 
 - [ ] **Step 4: Commit**
 
@@ -1063,13 +1088,13 @@ Edit the inline list to include `specs/<slug>/issue-breakdown-log.md` between `i
 
 > `docs/CONTEXT.md`, `docs/glossary/*.md` …, `specs/<slug>/implementation-log.md`, `specs/<slug>/issue-breakdown-log.md`, and the `## Hand-off notes` free-form section of `workflow-state.md` are append-only in spirit. …
 
-- [ ] **Step 5: Verify**
+- [ ] **Step 5: Verify links repo-wide**
 
 ```bash
-npx tsx scripts/check-markdown-links.ts -- docs/sink.md
+npm run check:links
 ```
 
-Expected: passes.
+Expected: green.
 
 - [ ] **Step 6: Commit**
 
@@ -1099,11 +1124,11 @@ Expected: green. Common failure modes and fixes:
 | Failure | Fix |
 |---|---|
 | `check:frontmatter` flags a new file | Add the missing frontmatter fields (compare against a sibling file). |
-| `check:command-docs` says `/issue:breakdown` is undocumented | Step 2 of Task 6.1 missed the per-command table. |
-| `check:agents` says `issue-breakdown` is unregistered | Step 2 of Task 6.3 missed the agent classes table. |
-| `check:markdown-links` reports a broken link | The slash-command file's relative path back to the skill is wrong (count `../` carefully — it's `../../skills/...`). |
-| `check:adr` says ADR-0022 isn't indexed | Re-run `npx tsx scripts/check-adr-index.ts` and stage `docs/adr/README.md` in the next commit. |
-| `check:obsidian` flags missing folder frontmatter | Each new doc folder requires a folder-level `README.md` with frontmatter; if a new folder was created, add one. |
+| `check:commands` says inventory blocks are stale | Re-run Task 6.1 — the three generated blocks must be regenerated together. |
+| `check:agents` says `issue-breakdown` is unregistered | Inspect the agent file's frontmatter (`name`, `description`, `tools` non-empty, `## Scope` heading present). |
+| `check:links` reports a broken link | The slash-command file's relative path back to the skill is wrong (count `../` carefully — from `.claude/commands/issue/breakdown.md` to the skill is `../../skills/issue-breakdown/SKILL.md`). |
+| `check:adr-index` says ADR-0022 isn't indexed | Re-run `npm run check:adr-index`; if it auto-updates `docs/adr/README.md`, stage that file in the fix-up commit. |
+| `check:frontmatter` flags missing folder-level frontmatter | If a new doc folder was created (e.g. `docs/superpowers/plans/` if absent), add a `README.md` with `title`, `folder`, `description`, `entry_point` frontmatter. (This plan creates no new folders, so this should not fire.) |
 
 If any check fails, fix the root cause; never `--no-verify`.
 
@@ -1125,10 +1150,10 @@ git commit -m "fix(issue-breakdown): satisfy verify gate"
 
 ```bash
 ls .claude/commands/issue/breakdown.md
-grep -l "issue-breakdown" .claude/commands/README.md .claude/skills/README.md AGENTS.md CLAUDE.md
+grep -l "issue-breakdown" .claude/commands/README.md .claude/skills/README.md AGENTS.md CLAUDE.md README.md docs/workflow-overview.md docs/sink.md
 ```
 
-Expected: the file exists; all four index files mention `issue-breakdown` at least once.
+Expected: the file exists; all seven index files mention `issue-breakdown` at least once.
 
 - [ ] **Step 2: Confirm the conductor skill resolves the slash command**
 
@@ -1180,6 +1205,11 @@ Phase 1 of the issue-breakdown track:
 - Cross-references in `AGENTS.md`, `CLAUDE.md`, `.claude/skills/README.md`, `.claude/commands/README.md`, `docs/sink.md`.
 
 Phase 2 (operational bot under `agents/operational/issue-breakdown-bot/`) is deferred to a follow-up PR.
+
+## Notes for reviewers
+
+- `/issue:breakdown` intentionally skips the canonical `inputs/` intake gate that the shared conductor pattern (`_shared/conductor-pattern.md`) requires of new conductors. Rationale: the input is the GitHub issue + an already-completed `tasks.md`, not a fresh work package. Documented in `docs/issue-breakdown-track.md`.
+- ADR-0022 explains the trade-offs that led to a post-/spec:tasks track instead of extending `/spec:tasks` itself.
 
 ## Spec / design
 

--- a/docs/superpowers/plans/2026-05-02-issue-breakdown.md
+++ b/docs/superpowers/plans/2026-05-02-issue-breakdown.md
@@ -248,7 +248,7 @@ entry_point: false
 
 Opt-in track that runs *after* `/spec:tasks`. Decomposes a GitHub issue describing a product increment into N independent draft PRs (one per parallelisable batch from `tasks.md`), keeps the parent issue as the canonical progress dashboard, and is idempotent across re-runs.
 
-Filed by [ADR-0022](adr/0022-add-issue-breakdown-track.md).
+Filed by ADR-0022 (`docs/adr/0022-add-issue-breakdown-track.md`).
 
 ## When to use
 
@@ -303,12 +303,12 @@ Not for:
 
 ## References
 
-- Design spec: [`docs/superpowers/specs/2026-05-02-issue-breakdown-design.md`](superpowers/specs/2026-05-02-issue-breakdown-design.md).
-- ADR: [`docs/adr/0022-add-issue-breakdown-track.md`](adr/0022-add-issue-breakdown-track.md).
-- Slicing primitive: [`.claude/skills/tracer-bullet/SKILL.md`](../.claude/skills/tracer-bullet/SKILL.md).
-- Sink: [`docs/sink.md`](sink.md).
-- Verify gate: [`docs/verify-gate.md`](verify-gate.md).
-- Branching: [`docs/branching.md`](branching.md).
+- Design spec: `docs/superpowers/specs/2026-05-02-issue-breakdown-design.md`.
+- ADR: `docs/adr/0022-add-issue-breakdown-track.md`.
+- Slicing primitive: `.claude/skills/tracer-bullet/SKILL.md`.
+- Sink: `docs/sink.md`.
+- Verify gate: `docs/verify-gate.md`.
+- Branching: `docs/branching.md`.
 ```
 
 - [ ] **Step 3: Verify links repo-wide**
@@ -667,14 +667,14 @@ model: sonnet
 
 Decompose GitHub issue #$ARGUMENTS into independent draft PRs.
 
-Run the [`issue-breakdown`](../../skills/issue-breakdown/SKILL.md) skill against issue #$ARGUMENTS. The skill is the brain; this command is the entry point.
+Run the `issue-breakdown` skill (`.claude/skills/issue-breakdown/SKILL.md`) against issue #$ARGUMENTS. The skill is the brain; this command is the entry point.
 
 The skill enforces:
 
 - The feature linked from the issue must have `tasks.md` status `complete` in its `workflow-state.md`. If not, it will tell you to run `/spec:tasks` first.
 - Re-runs are idempotent: prior runs are detected by the `<!-- issue-breakdown-slice: issue-<n>-<NN> -->` HTML comment in PR bodies and the `<!-- BEGIN issue-breakdown:<slug> --> ... <!-- END issue-breakdown:<slug> -->` block in the parent issue body.
 
-See [`docs/issue-breakdown-track.md`](../../../docs/issue-breakdown-track.md) for the full methodology and [ADR-0022](../../../docs/adr/0022-add-issue-breakdown-track.md) for the rationale.
+See `docs/issue-breakdown-track.md` for the full methodology and `docs/adr/0022-add-issue-breakdown-track.md` for the rationale.
 ```
 
 - [ ] **Step 4: Verify command registration**
@@ -724,16 +724,16 @@ argument-hint: <issue-number>
 
 # Issue-breakdown conductor
 
-You conduct the issue-breakdown track defined in [`docs/issue-breakdown-track.md`](../../../docs/issue-breakdown-track.md). Your job: **gate** between phases, **dispatch** the [`issue-breakdown`](../../agents/issue-breakdown.md) specialist agent, **never** do the agent's work yourself. Filed by [ADR-0022](../../../docs/adr/0022-add-issue-breakdown-track.md).
+You conduct the issue-breakdown track defined in `docs/issue-breakdown-track.md`. Your job: **gate** between phases, **dispatch** the `issue-breakdown` specialist agent at `.claude/agents/issue-breakdown.md`, **never** do the agent's work yourself. Filed by ADR-0022 (`docs/adr/0022-add-issue-breakdown-track.md`).
 
-Shared rules (gating, escalation, intake-gate, constraints common to all conductors): [`_shared/conductor-pattern.md`](../_shared/conductor-pattern.md).
+Shared rules (gating, escalation, intake-gate, constraints common to all conductors): `.claude/skills/_shared/conductor-pattern.md`.
 
 ## Read first
 
-- [`docs/superpowers/specs/2026-05-02-issue-breakdown-design.md`](../../../docs/superpowers/specs/2026-05-02-issue-breakdown-design.md) — source-of-truth spec.
-- [`docs/issue-breakdown-track.md`](../../../docs/issue-breakdown-track.md) — methodology.
-- [`templates/tasks-template.md`](../../../templates/tasks-template.md) — the layout the agent parses.
-- [`memory/constitution.md`](../../../memory/constitution.md) — Articles I, II, VI, IX especially.
+- `docs/superpowers/specs/2026-05-02-issue-breakdown-design.md` — source-of-truth spec.
+- `docs/issue-breakdown-track.md` — methodology.
+- `templates/tasks-template.md` — the layout the agent parses.
+- `memory/constitution.md` — Articles I, II, VI, IX especially.
 
 ## Inputs
 
@@ -834,7 +834,7 @@ Print a 3-line summary to the user:
 
 ## Constraints (issue-breakdown-specific)
 
-Generic conductor constraints + escalation pattern: [`_shared/conductor-pattern.md`](../_shared/conductor-pattern.md). Specifics for this skill:
+Generic conductor constraints + escalation pattern: `.claude/skills/_shared/conductor-pattern.md`. Specifics for this skill:
 
 - **Never** invoke `tracer-bullet` at runtime. `tasks.md` is the input; it has already been produced upstream.
 - **Never** modify `tasks.md`. If parse fails, the user fixes it (or re-runs `/spec:tasks`).
@@ -853,12 +853,12 @@ Do not bleed `/issue:breakdown` concerns back into `/spec:tasks` or vice versa.
 
 ## References
 
-- Design spec: [`docs/superpowers/specs/2026-05-02-issue-breakdown-design.md`](../../../docs/superpowers/specs/2026-05-02-issue-breakdown-design.md).
-- Methodology: [`docs/issue-breakdown-track.md`](../../../docs/issue-breakdown-track.md).
-- ADR: [`docs/adr/0022-add-issue-breakdown-track.md`](../../../docs/adr/0022-add-issue-breakdown-track.md).
-- Tasks template: [`templates/tasks-template.md`](../../../templates/tasks-template.md).
-- Slicing primitive (consumed upstream by `/spec:tasks`): [`.claude/skills/tracer-bullet/SKILL.md`](../tracer-bullet/SKILL.md).
-- Sink: [`docs/sink.md`](../../../docs/sink.md).
+- Design spec: `docs/superpowers/specs/2026-05-02-issue-breakdown-design.md`.
+- Methodology: `docs/issue-breakdown-track.md`.
+- ADR: `docs/adr/0022-add-issue-breakdown-track.md`.
+- Tasks template: `templates/tasks-template.md`.
+- Slicing primitive (consumed upstream by `/spec:tasks`): `.claude/skills/tracer-bullet/SKILL.md`.
+- Sink: `docs/sink.md`.
 ```
 
 - [ ] **Step 3: Verify skill registration**
@@ -957,11 +957,11 @@ Expected: a 3-column markdown table headed `| Skill | Triggers when… | What it
 
 - [ ] **Step 2: Add the table row**
 
-Insert in alphabetical order:
+Insert in alphabetical order. Match the markdown-link form used by sibling rows in the same table — link the first column to `issue-breakdown/SKILL.md`. Column values:
 
-```markdown
-| [`issue-breakdown/`](issue-breakdown/SKILL.md) | post-/spec:tasks; "break this issue down", "decompose issue", `/issue:breakdown <n>` | Decompose a GitHub issue into independent draft PRs by parsing tasks.md `## Parallelisable batches`. |
-```
+- Column 1 (Skill): a markdown link with text `` `issue-breakdown/` `` pointing at `issue-breakdown/SKILL.md`.
+- Column 2 (Triggers when…): `post-/spec:tasks; "break this issue down", "decompose issue", /issue:breakdown <n>`.
+- Column 3 (What it does): `Decompose a GitHub issue into independent draft PRs by parsing tasks.md ## Parallelisable batches.`
 
 - [ ] **Step 3: Verify links repo-wide**
 
@@ -992,11 +992,12 @@ Expected: one match, with a table listing each agent class.
 
 - [ ] **Step 2: Add row**
 
-Add a new row after the "Quality assurance" row (or in the closest logical position), mirroring the existing row shape:
+Add a new row after the "Quality assurance" row (or in the closest logical position), mirroring the existing row shape. The fourth column should follow the same dual-link convention used by sibling rows: a markdown link to the methodology doc, followed by a parenthesised markdown link to the ADR. Column values, in inline-code form for clarity:
 
-```markdown
-| **Issue-breakdown** *(opt-in, post-/spec:tasks)* | `.claude/agents/issue-breakdown.md` | Decompose a GitHub issue into independent draft PRs from `tasks.md`. State lives `specs/<slug>/issue-breakdown-log.md`. Reads `specs/`; never edits requirements, design, spec, or tasks artifacts. | [`docs/issue-breakdown-track.md`](docs/issue-breakdown-track.md) ([ADR-0022](docs/adr/0022-add-issue-breakdown-track.md)) |
-```
+- Column 1: `**Issue-breakdown** *(opt-in, post-/spec:tasks)*`
+- Column 2: `` `.claude/agents/issue-breakdown.md` ``
+- Column 3: `Decompose a GitHub issue into independent draft PRs from tasks.md. State lives specs/<slug>/issue-breakdown-log.md. Reads specs/; never edits requirements, design, spec, or tasks artifacts.`
+- Column 4: a link to `docs/issue-breakdown-track.md` followed by a parenthesised link to `docs/adr/0022-add-issue-breakdown-track.md` labelled `ADR-0022`.
 
 - [ ] **Step 3: Update conductor-skill summary line**
 
@@ -1033,11 +1034,15 @@ Expected: one match, with a table of opt-in tracks (Discovery, Stock-taking, Sal
 
 - [ ] **Step 2: Add row**
 
-```markdown
-| **Issue-breakdown** | post-`/spec:tasks`, decompose issue into draft PRs | [`issue-breakdown`](.claude/skills/issue-breakdown/SKILL.md) | `/issue:breakdown <n>` | [`docs/issue-breakdown-track.md`](docs/issue-breakdown-track.md) ([ADR-0022](docs/adr/0022-add-issue-breakdown-track.md)) |
-```
+Add a 5-column row after the "Portfolio" row, matching the existing column shape. Use markdown links in columns 3 and 5 — same convention as sibling rows. Column values, in inline-code form for clarity:
 
-Place it after the "Portfolio" row to preserve the existing pre-/post-Specorator ordering.
+- Column 1 (Track): `**Issue-breakdown**`.
+- Column 2 (When to use): `post-/spec:tasks, decompose issue into draft PRs`.
+- Column 3 (Conductor skill): a link with text `` `issue-breakdown` `` pointing at `.claude/skills/issue-breakdown/SKILL.md`.
+- Column 4 (Manual entry): `` `/issue:breakdown <n>` ``.
+- Column 5 (Reference): a link with text `` `docs/issue-breakdown-track.md` `` pointing at `docs/issue-breakdown-track.md`, followed by `(ADR-0022)` where ADR-0022 links to `docs/adr/0022-add-issue-breakdown-track.md`.
+
+This preserves the existing pre-/post-Specorator ordering.
 
 - [ ] **Step 3: Verify links repo-wide**
 
@@ -1254,8 +1259,8 @@ Phase 3 — refinements (backlog):
 ## References
 
 - Spec: [`docs/superpowers/specs/2026-05-02-issue-breakdown-design.md`](../specs/2026-05-02-issue-breakdown-design.md).
-- ADR: [`docs/adr/0022-add-issue-breakdown-track.md`](../../adr/0022-add-issue-breakdown-track.md).
-- Methodology: [`docs/issue-breakdown-track.md`](../../issue-breakdown-track.md).
+- ADR (to be created by Task 1.3): `docs/adr/0022-add-issue-breakdown-track.md`.
+- Methodology (to be created by Task 1.4): `docs/issue-breakdown-track.md`.
 - Conductor pattern: [`.claude/skills/_shared/conductor-pattern.md`](../../../.claude/skills/_shared/conductor-pattern.md).
 - Tasks template: [`templates/tasks-template.md`](../../../templates/tasks-template.md).
 - PR template: [`.github/PULL_REQUEST_TEMPLATE.md`](../../../.github/PULL_REQUEST_TEMPLATE.md).

--- a/docs/superpowers/plans/2026-05-02-issue-breakdown.md
+++ b/docs/superpowers/plans/2026-05-02-issue-breakdown.md
@@ -1,0 +1,1233 @@
+# Issue-breakdown Track Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship Phase 1 of the issue-breakdown track — a new conductor skill `/issue:breakdown <n>` that decomposes a GitHub issue (post `/spec:tasks`) into independent draft PRs by parsing `tasks.md`, plus all supporting artifacts (subagent, slash command, ADR, methodology doc, PR/issue templates).
+
+**Architecture:** Markdown-only deliverable. New conductor skill at `.claude/skills/issue-breakdown/SKILL.md` is dispatched by a thin `/issue:breakdown` slash command. The skill parses `specs/<slug>/tasks.md`'s `## Parallelisable batches` section into slices, opens one body-only draft PR per slice with an empty scaffold commit, edits the parent issue body to add a sentinel-bracketed `## Work packages` checklist, and appends a hand-off note + audit-log entry. Phase 2 (operational bot) is deferred to a follow-up plan.
+
+**Tech Stack:** Markdown for all artifacts. `gh` + `git` invoked via Bash from the conductor agent. No new TypeScript code in v1. Verify gate via `npm run verify` validates frontmatter, agent registration, slash-command registration, ADR index, and link integrity.
+
+**Spec:** `docs/superpowers/specs/2026-05-02-issue-breakdown-design.md` (load before each task; the spec is the source of truth for shapes, edge cases, and naming conventions).
+
+---
+
+## File Structure
+
+New files:
+
+| Path | Owner | Lifecycle |
+|---|---|---|
+| `.claude/skills/issue-breakdown/SKILL.md` | conductor | versioned |
+| `.claude/commands/issue/breakdown.md` | command author | versioned |
+| `.claude/agents/issue-breakdown.md` | agent author | versioned |
+| `docs/issue-breakdown-track.md` | this track's methodology doc | versioned |
+| `docs/adr/0022-add-issue-breakdown-track.md` | ADR | immutable once accepted |
+| `templates/issue-breakdown-pr-body-template.md` | template author | versioned |
+| `templates/issue-breakdown-issue-section.md` | template author | versioned |
+
+Updates:
+
+| Path | Change |
+|---|---|
+| `.claude/commands/README.md` | Register `issue/` namespace + the new command. |
+| `.claude/skills/README.md` | Register the new skill in the skills inventory. |
+| `AGENTS.md` | Add `issue-breakdown` row to "Agent classes" table; add row to skills/conductors table if present. |
+| `CLAUDE.md` | Add `issue-breakdown` row to "Other tracks (opt-in)" table. |
+| `docs/sink.md` | Add Ownership-table row for `specs/<slug>/issue-breakdown-log.md`; extend `### Append-only` paragraph. |
+| `.gitignore` | Add `.issue-breakdown-staging/`. |
+
+No source code edits.
+
+---
+
+## Chunk 1: Foundation — branch, ADR, methodology doc, .gitignore
+
+This chunk creates the immutable backbone artifacts (ADR, methodology doc, gitignore entry). They have no code dependencies and unblock every later chunk.
+
+### Task 1.1: Confirm working tree and branch
+
+**Files:** none.
+
+- [ ] **Step 1: Check current branch**
+
+```bash
+git status
+git rev-parse --abbrev-ref HEAD
+```
+
+Expected: clean working tree on branch `spec/issue-breakdown-design` (the brainstorm branch where the spec already lives) — or, if executing in a worktree, on a fresh topic branch off `main`.
+
+- [ ] **Step 2: Confirm spec is reachable**
+
+```bash
+ls docs/superpowers/specs/2026-05-02-issue-breakdown-design.md
+```
+
+Expected: file exists. If not, abort — the spec is required to drive every subsequent task.
+
+### Task 1.2: Add `.issue-breakdown-staging/` to `.gitignore`
+
+**Files:** Modify `.gitignore`.
+
+- [ ] **Step 1: Append the staging-dir ignore line**
+
+Open `.gitignore` and append, after the existing `.worktrees/` block:
+
+```text
+# issue-breakdown skill — transient PR/issue body files staged for `gh ... --body-file`.
+# Never committed; deleted at end of run. See docs/issue-breakdown-track.md.
+.issue-breakdown-staging/
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+grep -n "issue-breakdown-staging" .gitignore
+```
+
+Expected: one match.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .gitignore
+git commit -m "chore(issue-breakdown): ignore .issue-breakdown-staging/ working dir"
+```
+
+### Task 1.3: File ADR-0022 — adopt issue-breakdown track
+
+**Files:** Create `docs/adr/0022-add-issue-breakdown-track.md`.
+
+- [ ] **Step 1: Confirm next ADR number**
+
+```bash
+ls docs/adr/0*.md | tail -1
+```
+
+Expected: latest is `0021-…`. If a higher number exists, use the next one and update every reference in this plan accordingly.
+
+- [ ] **Step 2: Scaffold from template**
+
+```bash
+cp templates/adr-template.md docs/adr/0022-add-issue-breakdown-track.md
+```
+
+- [ ] **Step 3: Fill ADR body**
+
+Replace the template scaffolding so the resulting file matches:
+
+```markdown
+---
+id: ADR-0022
+title: Adopt issue-breakdown track for parallelising post-tasks issue work
+status: proposed
+date: 2026-05-02
+deciders:
+  - Luis Mendez
+consulted:
+  - Claude Opus 4.7 (1M context)
+informed:
+  - Repo maintainers
+supersedes: []
+superseded-by: []
+tags: [workflow, github, parallelisation]
+---
+
+# ADR-0022 — Adopt issue-breakdown track for parallelising post-tasks issue work
+
+## Status
+
+Proposed
+
+## Context
+
+When a feature reaches `/spec:tasks`, the path from "tasks.md is complete" to "multiple people working on independent draft PRs against this issue" is manual today. Engineers eyeball `tasks.md`, run `gh pr create --draft` per slice, type each PR body, and edit the issue body to track progress. The repo already owns the right slicing primitive (the `tracer-bullet` skill, which produces `## Parallelisable batches` in `tasks.md`), but nothing consumes that structure to produce GitHub state.
+
+The new track must:
+
+1. Run *after* `/spec:tasks` (Article II — separation of concerns; planning ≠ GitHub state).
+2. Re-use existing slicing output (no parallel slicing engine).
+3. Keep the parent issue as the canonical progress dashboard.
+4. Match the shape of every other opt-in track (conductor + slash command + agent + methodology doc + ADR), with an operational-bot follow-up.
+
+## Decision
+
+Add `issue-breakdown` as a *post-stage-6* opt-in track:
+
+- New conductor skill at `.claude/skills/issue-breakdown/SKILL.md` driven by `/issue:breakdown <issue-number>`.
+- New specialist subagent at `.claude/agents/issue-breakdown.md` with a narrow tool list (`Read, Edit, Write, Bash, Grep, Glob`).
+- New methodology doc `docs/issue-breakdown-track.md`.
+- New PR-body and issue-section templates under `templates/`.
+- New append-only audit log at `specs/<slug>/issue-breakdown-log.md`.
+- Phase 2 (label-triggered operational bot) ships in a follow-up.
+
+The conductor parses `tasks.md` directly using its template-guaranteed anchors (`## Parallelisable batches`, per-task `**Description:**`, `**Definition of done:**`, `**Depends on:**`, the spec's `## Quality gate`). Each parallelisable batch becomes one draft PR; `🪓 may-slice` annotations override the batch grouping. The conductor does not invoke `tracer-bullet` at runtime — that skill is consumed once during `/spec:tasks` to produce the artifact.
+
+## Alternatives considered
+
+1. **Extend `/spec:tasks` to auto-open PRs.** Rejected — couples task-planning to GitHub state and breaks separation of concerns.
+2. **Operational bot only, no conductor.** Rejected — inconsistent with every other multi-step workflow's shape; lacks a clean entry point for novel runs and re-runs.
+3. **Mechanical 1:1 task→PR.** Rejected — produces too many tiny PRs and ignores `blockedBy` chains.
+4. **Stacked branches off a `feat/issue-<n>` integration branch.** Rejected — adds a merge step the repo doesn't currently use.
+5. **Body + scaffolding commit (test stubs, type stubs).** Rejected — conductor would need per-language file conventions; out of scope for v1.
+
+## Consequences
+
+### Positive
+
+- Standard surface for parallelisable issue work.
+- Spec lineage preserved in PR bodies (every slice PR cites `requirements.md`, `design.md`, `spec.md`, `tasks.md` IDs).
+- Idempotent (sentinel-bracketed re-edit zone; HTML-comment slice tag on PRs).
+- Mirrors existing opt-in track shape — low cognitive cost for adopters.
+
+### Negative
+
+- One more skill + agent + methodology doc to maintain.
+- Coupled to the heading layout of `templates/tasks-template.md` (drift risk; mitigated by the conductor's "refuse on missing anchor" rule).
+- Empty scaffold commit per slice is mildly noisy in `git log`.
+- Sentinel-block re-edits are last-write-wins (documented in the spec).
+
+### Neutral
+
+- New append-only audit-log artifact under `specs/<slug>/issue-breakdown-log.md`. No schema change to `workflow-state.md`.
+- A future structured side-car (`specs/<slug>/tasks.json` emitted by `tracer-bullet`) would replace the regex parser. Out of scope for v1.
+
+## References
+
+- `docs/superpowers/specs/2026-05-02-issue-breakdown-design.md`
+- `docs/specorator.md`
+- `docs/sink.md`
+- `templates/tasks-template.md`
+- `.claude/skills/tracer-bullet/SKILL.md`
+- ADR-0005 (Discovery Track), ADR-0006 (Sales Cycle), ADR-0011 (Project Scaffolding) — opt-in track precedent.
+```
+
+- [ ] **Step 4: Verify ADR index picks it up**
+
+```bash
+npm run check:adr -- --quiet || npx tsx scripts/check-adr-index.ts
+```
+
+Expected: passes (the index regenerator picks up `0022`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/adr/0022-add-issue-breakdown-track.md docs/adr/README.md
+git commit -m "docs(adr): file ADR-0022 — adopt issue-breakdown track"
+```
+
+(Stage `docs/adr/README.md` only if `check:adr` regenerated it; otherwise omit.)
+
+### Task 1.4: Write methodology doc `docs/issue-breakdown-track.md`
+
+**Files:** Create `docs/issue-breakdown-track.md`.
+
+- [ ] **Step 1: Read shape of an existing track doc**
+
+```bash
+head -60 docs/discovery-track.md
+```
+
+Expected: section order — frontmatter, intro, "When to use", "Inputs", "Outputs", flow diagram, "Constraints", "References". Mirror this shape.
+
+- [ ] **Step 2: Write the file**
+
+Create `docs/issue-breakdown-track.md` with:
+
+```markdown
+---
+title: Issue-breakdown track
+folder: docs
+description: Post-/spec:tasks opt-in track that decomposes a GitHub issue into independent draft PRs.
+entry_point: false
+---
+
+# Issue-breakdown track
+
+Opt-in track that runs *after* `/spec:tasks`. Decomposes a GitHub issue describing a product increment into N independent draft PRs (one per parallelisable batch from `tasks.md`), keeps the parent issue as the canonical progress dashboard, and is idempotent across re-runs.
+
+Filed by [ADR-0022](adr/0022-add-issue-breakdown-track.md).
+
+## When to use
+
+- A feature has reached `/spec:tasks` (`tasks.md` is `complete`).
+- A GitHub issue exists for the feature, and you want multiple people to pick up parallel work.
+- You want each PR scoped to a vertical slice with full spec lineage in the body.
+
+Not for:
+
+- Features without a completed `tasks.md` — run `/spec:tasks` first.
+- One-person work where a single PR is enough.
+- Brownfield issues with no spec lineage at all — open `/spec:start` first or document the issue as `wontfix`/`needs-spec`.
+
+## Inputs
+
+- A GitHub issue number.
+- A `specs/<slug>/` folder with `workflow-state.md`, `requirements.md`, `design.md`, `spec.md`, `tasks.md` all `complete`.
+- Optional: an `inputs/` work package surfaced via the canonical intake gate (per `docs/inputs-ingestion.md`). The conductor consults `inputs/` only if the user explicitly references something there — there is no mandatory intake step in this track.
+
+## Outputs
+
+- N draft PRs (one per parallelisable batch in `tasks.md`), each with a generated body that cites spec lineage, task IDs, dependency chain, and DoD.
+- A `## Work packages` section appended to the parent issue body inside a sentinel-bracketed re-edit zone.
+- A new append-only `specs/<slug>/issue-breakdown-log.md` with one timestamped entry per run.
+- One dated line appended to the `## Hand-off notes` free-form section of `specs/<slug>/workflow-state.md`.
+
+## Flow
+
+```
+/issue:breakdown <n>
+   │
+   ├─ Pre-flight ────────── gh auth ok? issue open? read issue.
+   ├─ Resolve spec ──────── issue body specs/ link → label spec:<slug>
+   │                        → AskUserQuestion (list candidates).
+   ├─ Verify gate ───────── workflow-state.md tasks.md == complete?
+   ├─ Idempotency ───────── gh pr list --search slice-tag → resume / re-plan / abort.
+   ├─ Parse tasks.md ────── ## Parallelisable batches → slice list.
+   ├─ Confirm ──────────── AskUserQuestion (open / edit / abort).
+   ├─ Per-slice loop ────── branch → empty commit → push → draft PR.
+   ├─ Update issue body ─── sentinel-bracketed ## Work packages section.
+   ├─ Audit log ────────── append specs/<slug>/issue-breakdown-log.md.
+   └─ Hand-off note ────── append one line to workflow-state.md.
+```
+
+## Constraints
+
+- **No `--no-verify`.** Empty scaffold commits must pass the verify gate cleanly. If they don't, fix the gate, not the commit.
+- **No direct writes to `main`.** Slice branches use the `feat/<slug>-slice-<NN>-<short>` pattern.
+- **One PR per parallelisable batch.** `🪓 may-slice` annotations override.
+- **Sentinel-block discipline.** The `<!-- BEGIN issue-breakdown:<slug> --> … <!-- END issue-breakdown:<slug> -->` block in the parent issue body is conductor-owned; humans annotate outside it.
+- **Phase 2 file boundary.** The operational bot (`agents/operational/issue-breakdown-bot/`) is a separate PR; it must not import or transclude any file under `.claude/skills/issue-breakdown/`.
+
+## References
+
+- Design spec: [`docs/superpowers/specs/2026-05-02-issue-breakdown-design.md`](superpowers/specs/2026-05-02-issue-breakdown-design.md).
+- ADR: [`docs/adr/0022-add-issue-breakdown-track.md`](adr/0022-add-issue-breakdown-track.md).
+- Slicing primitive: [`.claude/skills/tracer-bullet/SKILL.md`](../.claude/skills/tracer-bullet/SKILL.md).
+- Sink: [`docs/sink.md`](sink.md).
+- Verify gate: [`docs/verify-gate.md`](verify-gate.md).
+- Branching: [`docs/branching.md`](branching.md).
+```
+
+- [ ] **Step 3: Verify links**
+
+```bash
+npx tsx scripts/check-markdown-links.ts -- docs/issue-breakdown-track.md
+```
+
+Expected: all relative links resolve.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/issue-breakdown-track.md
+git commit -m "docs(issue-breakdown): add methodology doc"
+```
+
+---
+
+## Chunk 2: Templates — PR body and issue section
+
+These are pure template files consumed by the conductor at runtime via `gh ... --body-file`. They have no runtime behavior of their own.
+
+### Task 2.1: PR body template
+
+**Files:** Create `templates/issue-breakdown-pr-body-template.md`.
+
+- [ ] **Step 1: Write the file**
+
+Create `templates/issue-breakdown-pr-body-template.md`:
+
+```markdown
+---
+title: Issue-breakdown PR body template
+folder: templates
+description: Skeleton body for draft PRs opened by /issue:breakdown. Concatenated with .github/PULL_REQUEST_TEMPLATE.md at runtime.
+entry_point: false
+---
+
+<!-- Generated by issue-breakdown skill. Edit freely after first real commit. -->
+<!-- issue-breakdown-slice: issue-<issue-number>-<NN> -->
+
+## Slice <NN>/<N>: <goal>
+
+Refs #<issue-number>
+
+## Spec lineage
+
+- Feature: `specs/<slug>/`
+- Requirements: `specs/<slug>/requirements.md` § <REQ-IDs>
+- Design: `specs/<slug>/design.md` § <section anchors>
+- Spec: `specs/<slug>/spec.md` § <interface IDs>
+- Tasks: `specs/<slug>/tasks.md` § <T-IDs>
+
+## Tasks in this slice
+
+- [ ] T-AREA-NNN — <title>
+- [ ] T-AREA-NNN — <title>
+
+## Depends on
+
+- #<PRn> (slice <MM>) — or `none`
+
+## Definition of done
+
+- [ ] All tasks above marked done in `tasks.md`
+- [ ] Tests for relevant TEST-IDs pass
+- [ ] `npm run verify` green
+- [ ] Docs updated in this PR
+- [ ] PR template checklist below complete
+
+---
+
+<!-- The conductor appends the verbatim contents of .github/PULL_REQUEST_TEMPLATE.md here at runtime. -->
+```
+
+- [ ] **Step 2: Verify frontmatter**
+
+```bash
+npx tsx scripts/check-frontmatter.ts -- templates/issue-breakdown-pr-body-template.md
+```
+
+Expected: passes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add templates/issue-breakdown-pr-body-template.md
+git commit -m "feat(issue-breakdown): add PR body template"
+```
+
+### Task 2.2: Issue section template
+
+**Files:** Create `templates/issue-breakdown-issue-section.md`.
+
+- [ ] **Step 1: Write the file**
+
+Create `templates/issue-breakdown-issue-section.md`:
+
+```markdown
+---
+title: Issue-breakdown issue-section template
+folder: templates
+description: Sentinel-bracketed `## Work packages` block injected into the parent issue body by /issue:breakdown.
+entry_point: false
+---
+
+## Work packages
+
+<!-- BEGIN issue-breakdown:<slug> -->
+Generated <YYYY-MM-DD> by `/issue:breakdown`.
+
+- [ ] #<PR1> — slice 01: <goal>
+- [ ] #<PR2> — slice 02: <goal>
+
+Spec: `specs/<slug>/`. Re-run with `/issue:breakdown <n>` to refresh.
+<!-- END issue-breakdown:<slug> -->
+```
+
+- [ ] **Step 2: Verify frontmatter**
+
+```bash
+npx tsx scripts/check-frontmatter.ts -- templates/issue-breakdown-issue-section.md
+```
+
+Expected: passes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add templates/issue-breakdown-issue-section.md
+git commit -m "feat(issue-breakdown): add issue-section template"
+```
+
+---
+
+## Chunk 3: Subagent — `.claude/agents/issue-breakdown.md`
+
+The agent is the workhorse the conductor dispatches against. Tool list is intentionally narrow (Article VI).
+
+### Task 3.1: Write agent definition
+
+**Files:** Create `.claude/agents/issue-breakdown.md`.
+
+- [ ] **Step 1: Read existing agent shapes for reference**
+
+```bash
+head -30 .claude/agents/reviewer.md
+head -30 .claude/agents/release-manager.md
+```
+
+Expected: each starts with frontmatter (`name`, `description`, `tools`, `model`, `color`), then a body with sections like Scope / Read first / Procedure / Constraints.
+
+- [ ] **Step 2: Write the file**
+
+Create `.claude/agents/issue-breakdown.md`:
+
+```markdown
+---
+name: issue-breakdown
+description: Use for the issue-breakdown track. Decomposes a GitHub issue + completed tasks.md into vertical-slice draft PRs. Reads specs/<slug>/, edits the parent issue body, opens draft PRs via gh. Does not modify code, requirements, or design artifacts.
+tools: [Read, Edit, Write, Bash, Grep, Glob]
+model: sonnet
+color: cyan
+---
+
+You are the **issue-breakdown** agent.
+
+## Scope
+
+You produce N draft PRs from a single GitHub issue whose feature has reached `/spec:tasks`. You read everything under `specs/<slug>/`, you edit only your own audit log + the parent issue body via `gh`, and you append a one-line hand-off note to `specs/<slug>/workflow-state.md`. You do **not** modify `requirements.md`, `design.md`, `spec.md`, `tasks.md`, code, or any other agent's artifacts.
+
+## Read first
+
+1. `docs/superpowers/specs/2026-05-02-issue-breakdown-design.md` — the source-of-truth spec.
+2. `docs/issue-breakdown-track.md` — methodology doc.
+3. `templates/tasks-template.md` — the layout you parse.
+4. `templates/issue-breakdown-pr-body-template.md` — the body you render per PR.
+5. `templates/issue-breakdown-issue-section.md` — the block you inject into the parent issue.
+6. The active feature's `specs/<slug>/workflow-state.md` (confirm `tasks.md` status is `complete`) and `specs/<slug>/tasks.md`.
+
+## Procedure
+
+### Step 1 — Pre-flight
+
+- `gh auth status` must succeed.
+- `gh issue view <n> --json number,title,body,labels,state,url` — refuse if `state != "OPEN"`.
+- `git status --porcelain` — refuse if working tree is dirty.
+
+### Step 2 — Resolve spec lineage
+
+Try in order:
+
+1. Scan issue body for the first `specs/<slug>/` link. If found, use that slug.
+2. Else scan issue labels for `spec:<slug>`. If found, use that slug.
+3. Else surface to the conductor: list every `specs/*/workflow-state.md` whose `tasks.md` artifact status is `complete`, and ask the user to pick.
+
+### Step 3 — Verify gate
+
+Read `specs/<slug>/workflow-state.md`. Hard-stop if `tasks.md` is not `complete`. Surface "run `/spec:tasks` first" and exit.
+
+### Step 4 — Idempotency check
+
+```bash
+gh pr list --search "in:body issue-breakdown-slice issue-<n>" --state all --json number,headRefName,title,body
+```
+
+Search returns PRs whose body contains the slice-tag HTML comment. If any results, surface to the conductor for resume / re-plan / abort. The conductor calls back with the user's choice; default to *resume* (skip slices whose tag is already on a PR).
+
+If `gh search` proves unreliable for the literal tag, fall back: `gh pr list --search "Refs #<n>" --state all --json number,body,headRefName`, then grep each body for the exact slice-tag.
+
+### Step 5 — Parse tasks.md
+
+Parse `specs/<slug>/tasks.md` per the spec's "Slicing input" section:
+
+- Required headings: `## Parallelisable batches`, `## Task list`.
+- Per-batch line: `- **Batch N:** T-<AREA>-NNN, T-<AREA>-NNN, …`. One slice per batch (zero-padded ordinal).
+- Per-task heading: `### T-<AREA>-NNN <emoji> — <short title>`.
+- Per-task fields: `**Description:**`, `**Definition of done:**`, `**Depends on:**`.
+- `🪓 may-slice` tasks override the batch grouping — split into their own slice using the `**Slice plan:**` line.
+- Final gate: `## Quality gate` (copied verbatim into each PR's DoD block).
+
+Refuse if any required anchor is missing. Surface the offending heading.
+
+### Step 6 — Render PR body and issue section
+
+Stage rendered body files under `<repo-root>/.issue-breakdown-staging/` (gitignored). One file per slice plus one for the issue body.
+
+The PR body file is the template at `templates/issue-breakdown-pr-body-template.md` with placeholders substituted, then concatenated with the verbatim contents of `.github/PULL_REQUEST_TEMPLATE.md`.
+
+The issue body is rendered by reading the current issue body, finding the `<!-- BEGIN issue-breakdown:<slug> -->` … `<!-- END issue-breakdown:<slug> -->` block (if present), replacing its contents in-place; if absent, appending the template at the end. **Refuse** if a prior run is detected (slice-tag PRs exist) but the sentinel block is missing — surface the inconsistency.
+
+### Step 7 — Per-slice loop (sequential)
+
+For each slice in document order:
+
+1. Compute branch name `feat/<slug>-slice-<NN>-<short>` (truncate `<short>` so total ≤ 60 chars).
+2. `git switch -c <branch> main`. If branch exists remotely, append `-NN` numeric suffix and retry.
+3. `git commit --allow-empty -m "chore(<area>): scaffold <T-<AREA>-NNN> slice"`.
+4. `git push -u origin <branch>`.
+5. `gh pr create --draft --base main --head <branch> --title "feat(<area>): <goal> (slice <NN>/<N>)" --body-file .issue-breakdown-staging/slice-<NN>.md`.
+6. Capture the PR number; record into the run log.
+7. `git switch main` before the next iteration so each slice branches off `main`.
+
+If any step fails, abort the run. Partial state is recoverable on re-run via the idempotency check.
+
+### Step 8 — Update parent issue body
+
+```bash
+gh issue edit <n> --body-file .issue-breakdown-staging/issue-body.md
+```
+
+### Step 9 — Audit log
+
+Append to `specs/<slug>/issue-breakdown-log.md` (create if absent — no frontmatter required):
+
+```markdown
+## <YYYY-MM-DD HH:MM> — issue #<n>, run #<run-id>
+
+Opened slices:
+- slice 01 — feat/<slug>-slice-01-... → PR #<x>
+- slice 02 — feat/<slug>-slice-02-... → PR #<y>
+
+Skipped (prior run): none / [list]
+Aborted: none / [list with reason]
+```
+
+### Step 10 — Hand-off note
+
+Append one dated line to the `## Hand-off notes` free-form section of `specs/<slug>/workflow-state.md`:
+
+```text
+2026-05-02 (issue-breakdown): opened N draft PRs for issue #<n> (#<x>-#<y>).
+```
+
+### Step 11 — Cleanup
+
+`rm -rf .issue-breakdown-staging/` at end of run.
+
+## Constraints
+
+- Never `--no-verify`. Empty commits must pass the verify gate cleanly.
+- Never push to `main` or `develop`. The `.claude/settings.json` deny rules will block this anyway.
+- Never invoke `tracer-bullet` at runtime. `tasks.md` is parsed in-process.
+- Never modify `requirements.md`, `design.md`, `spec.md`, or `tasks.md`.
+- Never modify the YAML frontmatter of `workflow-state.md`. Only the `## Hand-off notes` markdown section.
+- Sequential — no parallel `gh pr create` (rate limits + clean git state per slice).
+
+## Escalation
+
+You **escalate to the conductor**, not to the user. The conductor surfaces choices via `AskUserQuestion`. You return a structured outcome:
+
+- `ready` — slice list and confirmation needed.
+- `prior-run-detected` — list of existing slice-tagged PRs; needs resume / re-plan / abort.
+- `parse-error` — offending heading; cannot proceed.
+- `concurrent-run` — Phase 2 workflow run in flight; cannot proceed.
+- `done` — N PRs opened; issue body updated.
+- `aborted` — partial state; recoverable on re-run.
+```
+
+- [ ] **Step 3: Verify agent registration**
+
+```bash
+npx tsx scripts/check-agents.ts
+```
+
+Expected: passes (the new agent is registered automatically by name).
+
+- [ ] **Step 4: Verify frontmatter**
+
+```bash
+npx tsx scripts/check-frontmatter.ts -- .claude/agents/issue-breakdown.md
+```
+
+Expected: passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .claude/agents/issue-breakdown.md
+git commit -m "feat(issue-breakdown): add specialist subagent"
+```
+
+---
+
+## Chunk 4: Slash command — `/issue:breakdown`
+
+Thin wrapper that hands control to the conductor skill.
+
+### Task 4.1: Create the `issue/` namespace folder and command
+
+**Files:** Create `.claude/commands/issue/breakdown.md`.
+
+- [ ] **Step 1: Confirm namespace doesn't already exist**
+
+```bash
+ls .claude/commands/issue/ 2>&1 | head -1
+```
+
+Expected: "No such file or directory". If it exists already, inspect contents before adding.
+
+- [ ] **Step 2: Read an existing thin-wrapper command for shape**
+
+```bash
+cat .claude/commands/spec/start.md
+```
+
+Expected: very short file with frontmatter (`description`, `argument-hint`, `allowed-tools`, `model`) and one paragraph instructing the model what to do.
+
+- [ ] **Step 3: Write the command**
+
+Create `.claude/commands/issue/breakdown.md`:
+
+```markdown
+---
+description: Decompose a GitHub issue into independent draft PRs from tasks.md. Runs the issue-breakdown conductor.
+argument-hint: <issue-number>
+allowed-tools: [Read, Edit, Write, Bash, Grep, Glob]
+model: sonnet
+---
+
+# /issue:breakdown
+
+Decompose GitHub issue #$ARGUMENTS into independent draft PRs.
+
+Run the [`issue-breakdown`](../../skills/issue-breakdown/SKILL.md) skill against issue #$ARGUMENTS. The skill is the brain; this command is the entry point.
+
+The skill enforces:
+
+- The feature linked from the issue must have `tasks.md` status `complete` in its `workflow-state.md`. If not, it will tell you to run `/spec:tasks` first.
+- Re-runs are idempotent: prior runs are detected by the `<!-- issue-breakdown-slice: issue-<n>-<NN> -->` HTML comment in PR bodies and the `<!-- BEGIN issue-breakdown:<slug> --> ... <!-- END issue-breakdown:<slug> -->` block in the parent issue body.
+
+See [`docs/issue-breakdown-track.md`](../../../docs/issue-breakdown-track.md) for the full methodology and [ADR-0022](../../../docs/adr/0022-add-issue-breakdown-track.md) for the rationale.
+```
+
+- [ ] **Step 4: Verify command registration**
+
+```bash
+npx tsx scripts/check-command-docs.ts
+```
+
+Expected: passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .claude/commands/issue/breakdown.md
+git commit -m "feat(issue-breakdown): add /issue:breakdown slash command"
+```
+
+---
+
+## Chunk 5: Conductor skill — `.claude/skills/issue-breakdown/SKILL.md`
+
+This is the brain. The slash command is the entry point; the agent is the workhorse the skill dispatches.
+
+### Task 5.1: Scaffold skill folder
+
+**Files:** Create `.claude/skills/issue-breakdown/SKILL.md`.
+
+- [ ] **Step 1: Read the canonical conductor shape**
+
+```bash
+sed -n '1,50p' .claude/skills/orchestrate/SKILL.md
+sed -n '1,50p' .claude/skills/discovery-sprint/SKILL.md
+```
+
+Expected: both have frontmatter (`name`, `description`, `argument-hint`), a "Read first" section, a numbered procedure, a "Constraints" section, and a "References" section. Both link `_shared/conductor-pattern.md` for shared gating rules.
+
+- [ ] **Step 2: Write the skill**
+
+Create `.claude/skills/issue-breakdown/SKILL.md`:
+
+```markdown
+---
+name: issue-breakdown
+description: Conductor for the issue-breakdown track. Post-/spec:tasks. Decomposes a GitHub issue into independent draft PRs by parsing tasks.md, opens one draft PR per parallelisable batch, edits the parent issue body to track progress. Triggers "/issue:breakdown <n>", "break this issue down into draft PRs", "decompose issue".
+argument-hint: <issue-number>
+---
+
+# Issue-breakdown conductor
+
+You conduct the issue-breakdown track defined in [`docs/issue-breakdown-track.md`](../../../docs/issue-breakdown-track.md). Your job: **gate** between phases, **dispatch** the [`issue-breakdown`](../../agents/issue-breakdown.md) specialist agent, **never** do the agent's work yourself. Filed by [ADR-0022](../../../docs/adr/0022-add-issue-breakdown-track.md).
+
+Shared rules (gating, escalation, intake-gate, constraints common to all conductors): [`_shared/conductor-pattern.md`](../_shared/conductor-pattern.md).
+
+## Read first
+
+- [`docs/superpowers/specs/2026-05-02-issue-breakdown-design.md`](../../../docs/superpowers/specs/2026-05-02-issue-breakdown-design.md) — source-of-truth spec.
+- [`docs/issue-breakdown-track.md`](../../../docs/issue-breakdown-track.md) — methodology.
+- [`templates/tasks-template.md`](../../../templates/tasks-template.md) — the layout the agent parses.
+- [`memory/constitution.md`](../../../memory/constitution.md) — Articles I, II, VI, IX especially.
+
+## Inputs
+
+- `<issue-number>` — required GitHub issue number passed as `$ARGUMENTS`.
+
+## What you do, step by step
+
+### Step 1 — Pre-flight
+
+Confirm `gh auth status` succeeds. If not, surface to the user and exit.
+
+Read the issue:
+
+```bash
+gh issue view <issue-number> --json number,title,body,labels,state,url
+```
+
+If `state != "OPEN"`, hard-stop. Tell the user the issue must be open.
+
+### Step 2 — Resolve spec lineage
+
+Dispatch the `issue-breakdown` agent with the issue payload. The agent attempts:
+
+1. First `specs/<slug>/` link in issue body.
+2. `spec:<slug>` label.
+3. Surface candidates.
+
+If the agent returns multiple candidates, batch a single `AskUserQuestion`:
+
+- One option per candidate `specs/<slug>/` (recommended-first by `last_updated`).
+- "Other" → free-text override (skip).
+
+If the agent returns a single candidate, accept silently.
+
+### Step 3 — Verify gate
+
+Agent reads `specs/<slug>/workflow-state.md`. If `tasks.md` status is not `complete`, hard-stop. Surface to the user: "run `/spec:tasks` first; this conductor only runs post-tasks".
+
+### Step 4 — Idempotency check
+
+Agent searches for prior-run PRs via the slice-tag HTML comment.
+
+If matches exist, batch one `AskUserQuestion`:
+
+- `Resume — open only the missing slices` (Recommended).
+- `Re-plan — recompute slices and open new ones (existing PRs untouched)`.
+- `Abort`.
+
+If matches exist *and* the parent issue body has no `<!-- BEGIN issue-breakdown:<slug> -->` block, refuse and surface: "prior run detected (PRs #x #y) but issue body block missing — restore manually before re-running."
+
+### Step 5 — Parse tasks.md
+
+Agent parses `specs/<slug>/tasks.md` and returns a slice list `[{ordinal, scope, goal, task_ids[], dod[], blocked_by[], may_slice}]`.
+
+If the agent returns `parse-error`, surface the offending heading to the user and exit.
+
+### Step 6 — Confirm slices
+
+Batch one `AskUserQuestion`:
+
+> N slices computed from `## Parallelisable batches` in `tasks.md`:
+>
+> - 01 — <goal> (T-AUTH-001, T-AUTH-005)
+> - 02 — <goal> (T-AUTH-002)
+> - …
+>
+> Open N draft PRs against issue #<n>?
+
+Options:
+
+- `Open N drafts` (Recommended).
+- `Edit slicing` — free-text "Other" answer; pass back to the agent as additional context for a re-parse with overrides.
+- `Abort`.
+
+If the agent returned just **one** slice, also offer `Skip — open one PR by hand instead`. Some single-slice flows are more friction than they save.
+
+### Step 7 — Per-slice loop
+
+Hand off control fully to the agent. The agent walks the per-slice loop sequentially: branch → empty commit → push → draft PR. You wait.
+
+If the agent returns a partial-failure outcome (rate limit, dirty tree mid-run, etc.), surface the failure and the recoverable PR list to the user. Idempotency on re-run will resume.
+
+### Step 8 — Update parent issue body
+
+Agent renders and applies the sentinel-bracketed `## Work packages` section to the issue body.
+
+### Step 9 — Audit log + hand-off note
+
+Agent writes `specs/<slug>/issue-breakdown-log.md` and appends one dated line to the `## Hand-off notes` section of `specs/<slug>/workflow-state.md`.
+
+### Step 10 — Report
+
+Print a 3-line summary to the user:
+
+- Path to feature folder.
+- Count of PRs opened (with numbers).
+- Path to audit log.
+
+## Constraints (issue-breakdown-specific)
+
+Generic conductor constraints + escalation pattern: [`_shared/conductor-pattern.md`](../_shared/conductor-pattern.md). Specifics for this skill:
+
+- **Never** invoke `tracer-bullet` at runtime. `tasks.md` is the input; it has already been produced upstream.
+- **Never** modify `tasks.md`. If parse fails, the user fixes it (or re-runs `/spec:tasks`).
+- **Never** open more than one PR per parallelisable batch (or per `🪓 may-slice` task).
+- **Sequential** PR creation only — no `gh pr create` parallelism.
+- Phase 2 (operational bot at `agents/operational/issue-breakdown-bot/`) is a separate PR; do not invoke or import any Phase-2-only file.
+
+## Boundary with /spec:tasks
+
+`/spec:tasks` produces `tasks.md` with `## Parallelisable batches`. This skill consumes that artifact. Their boundary is:
+
+- `/spec:tasks` decides *what* to build (slices, dependencies, DoD).
+- `/issue:breakdown` decides *how to track that work on GitHub* (one PR per slice, parent issue as dashboard).
+
+Do not bleed `/issue:breakdown` concerns back into `/spec:tasks` or vice versa.
+
+## References
+
+- Design spec: [`docs/superpowers/specs/2026-05-02-issue-breakdown-design.md`](../../../docs/superpowers/specs/2026-05-02-issue-breakdown-design.md).
+- Methodology: [`docs/issue-breakdown-track.md`](../../../docs/issue-breakdown-track.md).
+- ADR: [`docs/adr/0022-add-issue-breakdown-track.md`](../../../docs/adr/0022-add-issue-breakdown-track.md).
+- Tasks template: [`templates/tasks-template.md`](../../../templates/tasks-template.md).
+- Slicing primitive (consumed upstream by `/spec:tasks`): [`.claude/skills/tracer-bullet/SKILL.md`](../tracer-bullet/SKILL.md).
+- Sink: [`docs/sink.md`](../../../docs/sink.md).
+```
+
+- [ ] **Step 3: Verify skill registration**
+
+```bash
+npx tsx scripts/check-frontmatter.ts -- .claude/skills/issue-breakdown/SKILL.md
+npx tsx scripts/check-markdown-links.ts -- .claude/skills/issue-breakdown/SKILL.md
+```
+
+Expected: both pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/issue-breakdown/SKILL.md
+git commit -m "feat(issue-breakdown): add conductor skill"
+```
+
+---
+
+## Chunk 6: Cross-references — wire the new track into existing indexes
+
+The check-scripts already pick up the new files automatically; this chunk only updates human-facing inventory pages so the track is discoverable.
+
+### Task 6.1: Update `.claude/commands/README.md`
+
+**Files:** Modify `.claude/commands/README.md`.
+
+- [ ] **Step 1: Find the right insertion point**
+
+```bash
+grep -n "^|.*issue.*\|^| `/" .claude/commands/README.md | head
+grep -n "## " .claude/commands/README.md
+```
+
+Expected: a "Slash commands" or namespaced table that lists `/spec:*`, `/discovery:*`, `/sales:*`, etc. Add `issue/` alongside.
+
+- [ ] **Step 2: Add row(s)**
+
+In the namespaces table, add a new row for the `issue/` namespace and a new row in the per-command table for `/issue:breakdown`. Match the surrounding table shape exactly.
+
+- [ ] **Step 3: Verify**
+
+```bash
+npx tsx scripts/check-command-docs.ts
+```
+
+Expected: passes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/commands/README.md
+git commit -m "docs(commands): register issue/ namespace + /issue:breakdown"
+```
+
+### Task 6.2: Update `.claude/skills/README.md`
+
+**Files:** Modify `.claude/skills/README.md`.
+
+- [ ] **Step 1: Find the conductor-skills section**
+
+```bash
+grep -n "orchestrate\|discovery-sprint\|sales-cycle" .claude/skills/README.md
+```
+
+Expected: a list of conductor skills. Add `issue-breakdown` in alphabetical order or in the same logical grouping as `orchestrate`.
+
+- [ ] **Step 2: Add row**
+
+```markdown
+- [`issue-breakdown`](issue-breakdown/SKILL.md) — post-/spec:tasks conductor that decomposes an issue into independent draft PRs.
+```
+
+- [ ] **Step 3: Verify links**
+
+```bash
+npx tsx scripts/check-markdown-links.ts -- .claude/skills/README.md
+```
+
+Expected: passes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/README.md
+git commit -m "docs(skills): list issue-breakdown conductor"
+```
+
+### Task 6.3: Update `AGENTS.md`
+
+**Files:** Modify `AGENTS.md`.
+
+- [ ] **Step 1: Find the agent classes table**
+
+```bash
+grep -n "## Agent classes" AGENTS.md
+```
+
+Expected: one match, with a table listing each agent class.
+
+- [ ] **Step 2: Add row**
+
+Add a new row after the "Quality assurance" row (or in the closest logical position), mirroring the existing row shape:
+
+```markdown
+| **Issue-breakdown** *(opt-in, post-/spec:tasks)* | `.claude/agents/issue-breakdown.md` | Decompose a GitHub issue into independent draft PRs from `tasks.md`. State lives `specs/<slug>/issue-breakdown-log.md`. Reads `specs/`; never edits requirements, design, spec, or tasks artifacts. | [`docs/issue-breakdown-track.md`](docs/issue-breakdown-track.md) ([ADR-0022](docs/adr/0022-add-issue-breakdown-track.md)) |
+```
+
+- [ ] **Step 3: Update conductor-skill summary line**
+
+Find the existing line listing all workflow-conductor skills (something like *"Ten workflow-conductor skills (`orchestrate`, `project-scaffolding`, …) are the conversational entry points."*) and bump the count + add `issue-breakdown` to the parenthesised list.
+
+- [ ] **Step 4: Verify**
+
+```bash
+npx tsx scripts/check-markdown-links.ts -- AGENTS.md
+```
+
+Expected: passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add AGENTS.md
+git commit -m "docs(agents): register issue-breakdown agent class"
+```
+
+### Task 6.4: Update `CLAUDE.md`
+
+**Files:** Modify `CLAUDE.md`.
+
+- [ ] **Step 1: Find the "Other tracks (opt-in)" table**
+
+```bash
+grep -n "Other tracks" CLAUDE.md
+```
+
+Expected: one match, with a table of opt-in tracks (Discovery, Stock-taking, Sales, Project Manager, Portfolio).
+
+- [ ] **Step 2: Add row**
+
+```markdown
+| **Issue-breakdown** | post-`/spec:tasks`, decompose issue into draft PRs | [`issue-breakdown`](.claude/skills/issue-breakdown/SKILL.md) | `/issue:breakdown <n>` | [`docs/issue-breakdown-track.md`](docs/issue-breakdown-track.md) ([ADR-0022](docs/adr/0022-add-issue-breakdown-track.md)) |
+```
+
+Place it after the "Portfolio" row to preserve the existing pre-/post-Specorator ordering.
+
+- [ ] **Step 3: Verify**
+
+```bash
+npx tsx scripts/check-markdown-links.ts -- CLAUDE.md
+```
+
+Expected: passes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(claude): register issue-breakdown opt-in track"
+```
+
+### Task 6.5: Update `docs/sink.md`
+
+**Files:** Modify `docs/sink.md`.
+
+- [ ] **Step 1: Find the Ownership table**
+
+```bash
+grep -n "^| Path" docs/sink.md
+```
+
+Expected: one match — the Ownership table header `| Path | Owner | Mutability |`. Note its exact column shape.
+
+- [ ] **Step 2: Add Ownership row**
+
+Insert after the existing `specs/<slug>/implementation-log.md` row:
+
+```markdown
+| `specs/<slug>/issue-breakdown-log.md` | `issue-breakdown` agent | Append-only — dated entries, never rewritten |
+```
+
+- [ ] **Step 3: Find the `### Append-only` paragraph**
+
+```bash
+grep -n "^### Append-only" docs/sink.md
+```
+
+Expected: one match. The next paragraph lists append-only artifacts inline.
+
+- [ ] **Step 4: Extend the Append-only paragraph**
+
+Edit the inline list to include `specs/<slug>/issue-breakdown-log.md` between `implementation-log.md` and the `## Hand-off notes` mention. The paragraph reads, after edit:
+
+> `docs/CONTEXT.md`, `docs/glossary/*.md` …, `specs/<slug>/implementation-log.md`, `specs/<slug>/issue-breakdown-log.md`, and the `## Hand-off notes` free-form section of `workflow-state.md` are append-only in spirit. …
+
+- [ ] **Step 5: Verify**
+
+```bash
+npx tsx scripts/check-markdown-links.ts -- docs/sink.md
+```
+
+Expected: passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/sink.md
+git commit -m "docs(sink): register specs/<slug>/issue-breakdown-log.md as append-only"
+```
+
+---
+
+## Chunk 7: Verify gate + dogfood smoke check
+
+Final integration. The verify gate is the deterministic safety net; the smoke check confirms the new artifacts hang together.
+
+### Task 7.1: Run the full verify gate
+
+**Files:** none.
+
+- [ ] **Step 1: Run verify**
+
+```bash
+npm run verify
+```
+
+Expected: green. Common failure modes and fixes:
+
+| Failure | Fix |
+|---|---|
+| `check:frontmatter` flags a new file | Add the missing frontmatter fields (compare against a sibling file). |
+| `check:command-docs` says `/issue:breakdown` is undocumented | Step 2 of Task 6.1 missed the per-command table. |
+| `check:agents` says `issue-breakdown` is unregistered | Step 2 of Task 6.3 missed the agent classes table. |
+| `check:markdown-links` reports a broken link | The slash-command file's relative path back to the skill is wrong (count `../` carefully — it's `../../skills/...`). |
+| `check:adr` says ADR-0022 isn't indexed | Re-run `npx tsx scripts/check-adr-index.ts` and stage `docs/adr/README.md` in the next commit. |
+| `check:obsidian` flags missing folder frontmatter | Each new doc folder requires a folder-level `README.md` with frontmatter; if a new folder was created, add one. |
+
+If any check fails, fix the root cause; never `--no-verify`.
+
+- [ ] **Step 2: Commit any verify-driven fix-ups**
+
+```bash
+git status
+git add -p   # review every hunk
+git commit -m "fix(issue-breakdown): satisfy verify gate"
+```
+
+(Skip this step if `npm run verify` was clean on the first run.)
+
+### Task 7.2: Smoke-check the slash command resolves
+
+**Files:** none.
+
+- [ ] **Step 1: Confirm the command file is discovered**
+
+```bash
+ls .claude/commands/issue/breakdown.md
+grep -l "issue-breakdown" .claude/commands/README.md .claude/skills/README.md AGENTS.md CLAUDE.md
+```
+
+Expected: the file exists; all four index files mention `issue-breakdown` at least once.
+
+- [ ] **Step 2: Confirm the conductor skill resolves the slash command**
+
+```bash
+grep -n "issue-breakdown" .claude/skills/issue-breakdown/SKILL.md | head -5
+```
+
+Expected: at least the frontmatter `name: issue-breakdown` and the cross-link to the agent.
+
+### Task 7.3: Document bootstrap caveat for the dogfood run
+
+**Files:** none — this is a runtime check, not an edit.
+
+The spec's Bootstrap section says: when this feature itself is decomposed via `/issue:breakdown`, the bootstrapped PRs that built the conductor must have the slice-tag HTML comment pasted into their bodies *manually*, otherwise idempotency falls back to `Refs #<n>` matching only.
+
+- [ ] **Step 1: When opening the dogfood tracking issue, confirm:**
+
+  - The first ~3 manually-opened bootstrap PRs (whichever PRs build the conductor itself) contain `<!-- issue-breakdown-slice: issue-<n>-<NN> -->` somewhere in their body.
+  - The parent issue body is left bare for the very first `/issue:breakdown` run; the conductor will inject the sentinel block fresh.
+
+This task has no commit. It's a runtime checklist to follow when this plan reaches GitHub.
+
+### Task 7.4: Open the PR
+
+**Files:** none.
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin spec/issue-breakdown-design
+```
+
+(Or whichever branch the implementer is on. The push must not target `main` or `develop`; `.claude/settings.json` will block that.)
+
+- [ ] **Step 2: Open a single PR for Phase 1**
+
+```bash
+gh pr create --base main --head spec/issue-breakdown-design --title "feat(issue-breakdown): Phase 1 — conductor + agent + ADR-0022" --body-file - <<'EOF'
+## Summary
+
+Phase 1 of the issue-breakdown track:
+
+- New conductor skill `/issue:breakdown <n>` (`.claude/skills/issue-breakdown/SKILL.md`).
+- Specialist agent (`.claude/agents/issue-breakdown.md`) with narrow tool list.
+- PR-body and issue-section templates under `templates/`.
+- Methodology doc `docs/issue-breakdown-track.md`.
+- ADR-0022 — adopt issue-breakdown track.
+- `.gitignore` entry for `.issue-breakdown-staging/`.
+- Cross-references in `AGENTS.md`, `CLAUDE.md`, `.claude/skills/README.md`, `.claude/commands/README.md`, `docs/sink.md`.
+
+Phase 2 (operational bot under `agents/operational/issue-breakdown-bot/`) is deferred to a follow-up PR.
+
+## Spec / design
+
+- Spec: `docs/superpowers/specs/2026-05-02-issue-breakdown-design.md`.
+- Plan: `docs/superpowers/plans/2026-05-02-issue-breakdown.md`.
+- ADR: `docs/adr/0022-add-issue-breakdown-track.md`.
+
+## Test plan
+
+- [x] `npm run verify` green locally.
+- [x] `check:agents`, `check:command-docs`, `check:frontmatter`, `check:adr`, `check:markdown-links` all pass.
+- [ ] Reviewer-driven dogfood: open a tracking issue, run the conductor against it, observe N draft PRs + an updated `## Work packages` section.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+```
+
+The PR is **not** decomposed by `/issue:breakdown` itself (chicken-and-egg per the spec's Bootstrap section). It ships as one PR.
+
+- [ ] **Step 3: Hand off**
+
+Post a comment in the PR linking back to the spec + plan, requesting review. After merge to `main`, the conductor is available; subsequent issues use `/issue:breakdown <n>` end-to-end.
+
+---
+
+## Out of scope (Phase 2 / Phase 3)
+
+Phase 2 — operational bot. Separate PR after Phase 1 stabilises:
+
+- `agents/operational/issue-breakdown-bot/PROMPT.md`
+- `agents/operational/issue-breakdown-bot/README.md`
+- `.github/workflows/issue-breakdown-bot.yml` (label-triggered on `breakdown-me`)
+
+Phase 3 — refinements (backlog):
+
+- GitHub Project board sync (slice PRs auto-added to a project).
+- CODEOWNERS-aware default reviewers per slice.
+- `tasks.json` side-car emitted by `tracer-bullet` to retire the regex parser.
+
+---
+
+## References
+
+- Spec: [`docs/superpowers/specs/2026-05-02-issue-breakdown-design.md`](../specs/2026-05-02-issue-breakdown-design.md).
+- ADR: [`docs/adr/0022-add-issue-breakdown-track.md`](../../adr/0022-add-issue-breakdown-track.md).
+- Methodology: [`docs/issue-breakdown-track.md`](../../issue-breakdown-track.md).
+- Conductor pattern: [`.claude/skills/_shared/conductor-pattern.md`](../../../.claude/skills/_shared/conductor-pattern.md).
+- Tasks template: [`templates/tasks-template.md`](../../../templates/tasks-template.md).
+- PR template: [`.github/PULL_REQUEST_TEMPLATE.md`](../../../.github/PULL_REQUEST_TEMPLATE.md).
+- Verify gate: [`docs/verify-gate.md`](../../verify-gate.md).
+- Branching rules: [`docs/branching.md`](../../branching.md).

--- a/docs/superpowers/plans/2026-05-02-issue-breakdown.md
+++ b/docs/superpowers/plans/2026-05-02-issue-breakdown.md
@@ -209,7 +209,7 @@ The conductor parses `tasks.md` directly using its template-guaranteed anchors (
 npm run check:adr-index
 ```
 
-Expected: passes (the index regenerator picks up `0022`). If it auto-updates `docs/adr/README.md`, stage that too in step 5.
+Expected: passes (the index regenerator picks up `0022`). If `check:adr-index` auto-updates `docs/adr/README.md`, stage that too in step 5.
 
 - [ ] **Step 5: Commit**
 
@@ -218,7 +218,7 @@ git add docs/adr/0022-add-issue-breakdown-track.md docs/adr/README.md
 git commit -m "docs(adr): file ADR-0022 — adopt issue-breakdown track"
 ```
 
-(Stage `docs/adr/README.md` only if `check:adr` regenerated it; otherwise omit.)
+(Stage `docs/adr/README.md` only if `check:adr-index` regenerated it; otherwise omit.)
 
 ### Task 1.4: Write methodology doc `docs/issue-breakdown-track.md`
 
@@ -916,13 +916,13 @@ Expected: **fails the first time**, but the failure output prints the exact rege
 
 - [ ] **Step 3: Apply the regenerated blocks**
 
-Most repos ship a `fix-command-docs.ts` companion script that auto-writes the regenerated content. Run it if present:
+The repo ships a `fix:commands` alias that auto-writes the regenerated content. Run it:
 
 ```bash
-ls scripts/fix-command-docs.ts && npx tsx scripts/fix-command-docs.ts
+npm run fix:commands
 ```
 
-If the fix script doesn't exist, paste the expected blocks from the failure output into:
+If `fix:commands` is not defined in `package.json`, paste the expected blocks from the `check:commands` failure output into:
 
 - `.claude/commands/README.md` (between `<!-- BEGIN GENERATED: command-inventory -->` and `<!-- END GENERATED: command-inventory -->`).
 - `README.md` (between `<!-- BEGIN GENERATED: slash-commands -->` and `<!-- END GENERATED: slash-commands -->`, around line 345).
@@ -1220,7 +1220,7 @@ Phase 2 (operational bot under `agents/operational/issue-breakdown-bot/`) is def
 ## Test plan
 
 - [x] `npm run verify` green locally.
-- [x] `check:agents`, `check:command-docs`, `check:frontmatter`, `check:adr`, `check:markdown-links` all pass.
+- [x] `check:agents`, `check:commands`, `check:frontmatter`, `check:adr-index`, `check:links` all pass.
 - [ ] Reviewer-driven dogfood: open a tracking issue, run the conductor against it, observe N draft PRs + an updated `## Work packages` section.
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/superpowers/specs/2026-05-02-issue-breakdown-design.md
+++ b/docs/superpowers/specs/2026-05-02-issue-breakdown-design.md
@@ -27,7 +27,7 @@ We need an integrated workflow that: (a) decomposes a `tasks.md` into vertical s
 ## Goals
 
 1. **Conversational entry point.** A new `/issue:breakdown <issue-number>` slash command and matching conductor skill drive the flow end-to-end, gating with `AskUserQuestion`.
-2. **Vertical-slice decomposition** of `tasks.md` rows into independent draft PRs via the existing `tracer-bullet` skill — no parallel slicing engine.
+2. **Vertical-slice decomposition** of `tasks.md` rows into independent draft PRs by parsing `specs/<slug>/tasks.md` (which is itself produced by `tracer-bullet` during `/spec:tasks`). The conductor does **not** dispatch `tracer-bullet` — `tasks.md` is the canonical input and already contains the slice structure, dependency graph, IDs, acceptance criteria, and Definition of Done. See "Slicing input" below.
 3. **Body-only PRs.** Each PR is opened with a generated body (spec lineage, task IDs, DoD, references, standard PR template) and a single empty scaffold commit (no source diff). Implementers write the first real commit.
 4. **Issue stays canonical.** Conductor edits the parent issue body once to add a `## Work packages` section linking each draft PR. GitHub's task-list-link feature auto-strikes entries when PRs close.
 5. **Branch per slice, off `main`.** Honours the repo's `branch per concern` rule. No worktrees pre-created — implementers run the worktree skill themselves when picking up a slice.
@@ -73,8 +73,9 @@ These are recorded in the ADR (see "Decisions" below).
    │                        existing PRs found → AskUserQuestion
    │                        (resume / re-plan / abort)
    │
-   ├─ Slice ─────────────── dispatch tracer-bullet skill on tasks.md
-   │                        → [{slug, goal, task_ids[], dod[], depends_on[]}]
+   ├─ Slice ─────────────── parse specs/<slug>/tasks.md
+   │                        (already produced by tracer-bullet in /spec:tasks)
+   │                        → [{ordinal, scope, goal, task_ids[], dod[], blocked_by[]}]
    │
    ├─ Confirm ──────────── AskUserQuestion: open drafts / edit / abort
    │
@@ -120,8 +121,9 @@ Updates to existing files:
 - `.claude/commands/README.md` — add `issue/` namespace.
 - `.claude/skills/README.md` — list new skill.
 - `AGENTS.md` — add row to skill table; add row to agent classes table.
-- `docs/sink.md` — declare sink for `specs/<slug>/issue-breakdown-log.md`.
+- `docs/sink.md` — add row for `specs/<slug>/issue-breakdown-log.md` (lifecycle: append-only; owner: `issue-breakdown` agent).
 - `CLAUDE.md` — link new track from "Other tracks (opt-in)" table.
+- `.gitignore` — add `.issue-breakdown-staging/` so transient PR/issue body files never land in version control.
 
 ### Conductor skill (`.claude/skills/issue-breakdown/SKILL.md`)
 
@@ -134,13 +136,35 @@ Body sections:
 3. Resolve spec lineage (3 fallback strategies).
 4. Verify gate (`tasks.md` complete).
 5. Idempotency check.
-6. Slice (dispatch `tracer-bullet`; parse output).
+6. Parse `tasks.md` (no skill dispatch; see "Slicing input" below).
 7. Confirm (single `AskUserQuestion`).
 8. Per-slice loop (branch → empty commit → push → draft PR).
 9. Update parent issue body (sentinel-bracketed re-edit zone).
 10. Audit log + hand-off note.
 11. Constraints (idempotent; never `--no-verify`; sequential; no `main` writes).
 12. References.
+
+### Slicing input — parsing `tasks.md`
+
+`tasks.md` is produced by the `tracer-bullet` skill during `/spec:tasks` and follows `templates/tasks-template.md`. It is **markdown**, not structured data. The conductor parses it directly using stable anchors that the template guarantees:
+
+| Field | Source in `tasks.md` |
+|---|---|
+| Ordinal `NN` | Conductor-assigned (1-based) over slice headings in document order. |
+| Task ID `T-<AREA>-NNN` | Per-slice heading line, regex `T-[A-Z0-9]+-\d{3}`. |
+| Slice goal | Slice heading text after the ID. |
+| Acceptance criteria | "Acceptance criteria" section under each slice (bullet list). |
+| Test approach | "Test approach" section under each slice. |
+| Risk level (L/M/H) | "Risk level" line. |
+| Blocked by | "Blocked by" line; comma-separated `T-<AREA>-NNN` list. |
+| DoD (whole spec) | Final "Definition of done" section. |
+
+This contract is fragile (heading-based regex). Two mitigations:
+
+1. The conductor refuses to proceed if any slice is missing one of the above anchors and surfaces the offending heading. This forces `tasks.md` authors (and `tracer-bullet`) to keep the template stable.
+2. A separate, deferred deliverable (out of scope here) may extend `tracer-bullet` to also emit a structured side-car (e.g. `specs/<slug>/tasks.json`). That extension is *not* a precondition for v1; if/when it lands, the conductor can switch to consuming it. This is recorded in the ADR's "consequences" as a deferred refinement.
+
+If a slice's `<goal>` is empty or `<area>` cannot be derived from `<AREA>`, the conductor refuses and surfaces the parse error.
 
 ### Subagent (`.claude/agents/issue-breakdown.md`)
 
@@ -155,9 +179,12 @@ tools: [Read, Edit, Write, Bash, Grep, Glob]
 Tool scoping rationale (per Article VI):
 
 - **Read / Grep / Glob** — read `specs/<slug>/`, `tasks.md`, templates.
-- **Edit / Write** — write `issue-breakdown-log.md`; staged PR/issue body files; one-line hand-off note in `workflow-state.md`.
+- **Edit / Write** —
+  - Write `specs/<slug>/issue-breakdown-log.md` (new artifact, owned by this agent — see "Sink update" below).
+  - Append one dated line to the `## Hand-off notes` free-form section of `specs/<slug>/workflow-state.md`. The frontmatter schema is **not** modified. This append is sanctioned by `docs/sink.md` line 423 ("the active feature's `workflow-state.md` gets a dated one-line entry appended … so the workflow has a paper trail") and is not exclusive to the orchestrator.
+  - Stage transient PR/issue body files under `<repo-root>/.issue-breakdown-staging/` (gitignored; never committed). Files are deleted at end of run. The PR body is fed to `gh` via `--body-file`.
 - **Bash** — `git`, `gh`. Pushes to `main` / `develop` already denied by `.claude/settings.json`. Branch pushes to `feat/*` allowed.
-- **No Agent tool** — no further dispatch; `tracer-bullet` runs as a Skill not a subagent.
+- **No Agent tool** — no further dispatch. `tasks.md` is parsed in-process; no sub-agent is spawned.
 
 ### Slash command (`.claude/commands/issue/breakdown.md`)
 
@@ -176,6 +203,7 @@ Run the issue-breakdown skill for issue #$ARGUMENTS.
 
 ```markdown
 <!-- Generated by issue-breakdown skill. Edit freely after first real commit. -->
+<!-- issue-breakdown-slice: issue-<issue-number>-<NN> -->
 
 ## Slice <NN>/<N>: <goal>
 
@@ -233,9 +261,11 @@ The `<!-- BEGIN ... -->` / `<!-- END ... -->` sentinel comments delimit the cond
 
 ### Phase 2 — operational bot
 
-`agents/operational/issue-breakdown-bot/PROMPT.md` is the source-of-truth prompt loaded by the scheduled GitHub Action. Same logic as the conductor agent, with these differences:
+`agents/operational/issue-breakdown-bot/PROMPT.md` is the source-of-truth prompt loaded by the scheduled GitHub Action. **It is a stand-alone file**, not a transclusion of the conductor agent. The two are kept in sync by both being derived from the same design spec (this document) and by a smoke-test that runs the same fixture through both surfaces. This matches the existing operational-bot precedent (`agents/operational/review-bot/PROMPT.md` is also stand-alone).
 
-- Headless: no `AskUserQuestion`. Auto-picks "Open drafts" at confirm step; auto-picks "Resume" at idempotency check.
+Behaviour differences from Phase 1:
+
+- Headless: no `AskUserQuestion`. Auto-picks "Open drafts" at confirm step; auto-picks "Resume" at idempotency check; refuses on any condition Phase 1 would surface as a clarification (missing sentinel, multiple spec candidates, dirty tree N/A in CI, etc.).
 - Reads issue context from the GitHub Action environment (`GITHUB_EVENT_PATH` issue payload).
 - On finish: removes `breakdown-me` label, comments `Created N draft PRs: #x #y …`.
 - On error: comments error trace, leaves the label so the issue is visibly stuck.
@@ -254,7 +284,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-      contents: write
+      contents: write          # branch push for feat/* only
     concurrency:
       group: issue-breakdown-${{ github.event.issue.number }}
       cancel-in-progress: false
@@ -263,7 +293,15 @@ jobs:
       # Run Claude Code action with PROMPT.md + issue context.
 ```
 
-Bot ships in a follow-up PR after the conductor stabilises. The two share `PROMPT.md` content via reference (bot's `PROMPT.md` includes the conductor agent body and overrides the gating sections).
+Branch prefix is `feat/` (same as Phase 1) so a single set of branch-protection rules covers both. The GitHub Action's `GITHUB_TOKEN` is the credential — repo `.claude/settings.json` deny rules govern only Claude-driven local pushes; CI pushes go through the Action token, which inherits branch-protection rules but not the local Claude permission set.
+
+**Phase 1 / Phase 2 coupling.** To keep the bot a follow-up rather than co-shipped, Phase 1 must:
+
+- Centralise gating logic in clearly-marked sections of the conductor skill body (so Phase 2 can mirror the same step boundaries without copying gating UI).
+- Avoid encoding Phase-2-only state (workflow run inspection, label removal) in Phase 1 surfaces.
+- Document the contract between conductor and `tasks.md` (the "Slicing input" section above) so Phase 2 can implement the same parser independently.
+
+No source code or prompt content is shared between them at v1.
 
 ## Data flow
 
@@ -298,7 +336,59 @@ issue-breakdown agent
                          ## Work packages section (sentinel-bracketed)
 ```
 
-## Edge cases
+## Naming, identifiers, and conventions
+
+Three identifier schemes coexist; this section pins them to avoid ambiguity:
+
+| Token | Domain | Example |
+|---|---|---|
+| `<NN>` | Conductor-assigned slice ordinal, 1-based, zero-padded to 2 digits. Document order in `tasks.md`. | `01`, `02` |
+| `T-<AREA>-NNN` | Inner task ID(s) inside the slice, sourced from `tasks.md`. | `T-AUTH-014` |
+| `<AREA>` | Uppercase area code from the spec's `workflow-state.md` (e.g. `AUTH`). Used in IDs. | `AUTH` |
+| `<area>` | Lowercase Conventional Commits scope, derived as `<AREA>.toLowerCase()` unless the feature's `workflow-state.md` declares an override. | `auth` |
+| `<short>` | Kebab-case short title, derived from slice goal: lowercase, ASCII-only, ≤32 chars. | `password-reset` |
+| `<slug>` | Feature slug (matches `specs/<slug>/`). | `password-reset` |
+
+Derived strings:
+
+- **Branch name**: `feat/<slug>-slice-<NN>-<short>` — kebab-case, hard-capped at 60 chars; if exceeded, `<short>` is truncated.
+- **PR title**: `feat(<area>): <goal> (slice <NN>/<N>)` — Conventional Commits scope (lowercase). Validated against `.github/workflows/pr-title.yml`.
+- **Empty scaffold commit message**: `chore(<area>): scaffold <T-<AREA>-NNN> slice` — `chore`, not `scaffold`, to match repo's existing CC type set.
+- **Slice tag** (PR body discriminator): `<!-- issue-breakdown-slice: issue-<n>-<NN> -->` — primary idempotency key (preferred over `Refs #<n>` which matches any PR mentioning the issue).
+
+## CI implications of body-only / empty-commit PRs
+
+The repo's verify gate is **manual** — no `.husky/` directory and no client-side `pre-commit` hook is installed. `npm run verify` is run by the human/agent before push. Empty commits therefore pass locally without ceremony.
+
+CI gates that *do* run on PR open:
+
+- **`pr-title.yml`** — Conventional Commits validation. PR title format above complies.
+- **`verify.yml`** — runs `npm run verify` in CI on PR. With zero source diff, every check should be a no-op pass; nothing runs against changed files. The conductor does **not** suppress this CI run; reviewers expect it to be green.
+- **`gitleaks.yml` / `typos.yml` / `actionlint.yml` / `zizmor.yml`** — secret scan, typo check, action-lint, GHA security. All no-op on empty diffs.
+- **GitHub Pages deploy (`pages.yml`)** — only triggers on `main` writes; not affected.
+
+If any CI gate fails on an empty PR, that's a CI misconfiguration to fix at the gate, not a reason to skip the gate (`--no-verify` remains forbidden by `.claude/settings.json` and `feedback_verify_gate.md`).
+
+The conductor also does **not** create changesets. Empty PRs deliberately have no user-facing change to release-note. Implementers add changesets in their first real commit if the slice is user-visible.
+
+## Sink update — `specs/<slug>/issue-breakdown-log.md`
+
+Lifecycle classification (per `docs/sink.md`): **append-only**. Same shape as `implementation-log.md`. Added by this PR to the sink table:
+
+| Path | Owner | Lifecycle | Notes |
+|---|---|---|---|
+| `specs/<slug>/issue-breakdown-log.md` | `issue-breakdown` agent | append-only | Audit log of `/issue:breakdown` runs against this feature. Free-form markdown; no schema. |
+
+The append-only contract mirrors `implementation-log.md`: dated entries, never rewritten, agents may refine wording but historical narrative survives.
+
+## Idempotency — concurrency model and failure modes
+
+The sentinel-bracketed re-edit zone is the conductor's idempotency primitive. Its limits, made explicit:
+
+- **No optimistic lock.** `gh issue edit --body` is last-write-wins. Two concurrent runs (e.g. interactive conductor + label-triggered bot in Phase 2) can race. Phase 2 mitigates this with a workflow `concurrency.group: issue-breakdown-${{ github.event.issue.number }}` so a queued bot run waits for an earlier one. Phase 1 (interactive) is single-user-per-tty by construction; the conductor checks for an in-flight Phase 2 run by inspecting the workflow run list before proceeding.
+- **In-block edits are silently overwritten.** Anything a human writes between `<!-- BEGIN issue-breakdown:<slug> -->` and `<!-- END issue-breakdown:<slug> -->` is replaced on re-run. The block is conductor-owned. Humans annotate *outside* the block.
+- **Missing block on a known-prior-run issue.** If `gh pr list --search "issue-breakdown-slice: issue-<n>" --state all` returns ≥ 1 PR but the issue body has no `BEGIN/END` block, the conductor **refuses** and surfaces: "prior run detected (PRs #x #y) but issue body block missing — restore manually or pass `--force-rebuild` to re-emit." It never silently appends a second block.
+- **Discriminator.** Idempotency on the PR side keys off the `<!-- issue-breakdown-slice: issue-<n>-<NN> -->` HTML comment in the PR body — searched via `gh pr list --search`. `Refs #<n>` is informational only, not the key.
 
 | Case | Handling |
 |---|---|
@@ -311,10 +401,14 @@ issue-breakdown agent
 | `verify` hook fails on empty commit | Triage; never `--no-verify`. Empty commit means no source diff; failures indicate a hook misconfiguration to fix. |
 | `gh pr create` fails (rate limit / perms) | Abort run; partial state recoverable via re-run idempotency. Audit log records what got created before the failure. |
 | User has 2+ candidate `specs/<slug>/` matches | `AskUserQuestion` to disambiguate. |
-| `tracer-bullet` returns 0 slices | Surface to user; abort. |
-| `tracer-bullet` returns 1 slice | Confirm — single PR may not need this skill. Offer to abort. |
+| `tasks.md` parse yields 0 slices | Surface to user; abort. |
+| `tasks.md` parse yields 1 slice | Confirm — single PR may be more friction than `gh pr create --draft` by hand. Offer to abort. |
+| `tasks.md` parse missing required anchor (heading, ID, AC, DoD) | Hard-stop. Surface offending heading. Direct user to fix `tasks.md` or re-run `tracer-bullet`. |
 | Issue body has no `specs/` link AND no `spec:` label | `AskUserQuestion` lists all `tasks.md`-complete features. |
 | User aborts confirmation | No git or gh side-effects. |
+| Sentinel block in issue body deleted between runs | Refuse and surface (see Idempotency section). Offer `--force-rebuild`. |
+| Concurrent run already in flight (Phase 2 active) | Refuse; report active workflow run; suggest waiting. |
+| Empty PR's `verify.yml` CI passes but reviewer expects diff | Documented in PR template; reviewer-side education, not a defect. |
 
 ## Verify-gate impact
 
@@ -343,8 +437,9 @@ ADR captures:
   3. Mechanical 1:1 task→PR (rejected: ignores blockedBy chains, produces tiny PRs).
 - **Consequences.**
   - **Positive.** Standard surface for parallelisable work; preserves spec lineage in PR bodies; idempotent.
-  - **Negative.** Extra skill+agent+bot to maintain; coupled to `tracer-bullet` shape (drift risk); empty-commit per slice is mildly noisy in `git log`.
-  - **Neutral.** New audit-log artifact under `specs/<slug>/`; no schema change.
+  - **Negative.** Extra skill+agent+bot to maintain; coupled to the heading layout of `templates/tasks-template.md` (drift risk if `tracer-bullet` rewrites the template — mitigated by the conductor's "refuse on missing anchor" rule); empty-commit per slice is mildly noisy in `git log`; sentinel-block re-edits are last-write-wins (documented above).
+  - **Neutral.** New append-only audit-log artifact under `specs/<slug>/issue-breakdown-log.md`; no schema change to `workflow-state.md`.
+  - **Deferred refinement.** A structured side-car (`specs/<slug>/tasks.json`) emitted by `tracer-bullet` would replace the regex parser. Out of scope for v1.
 
 ## Testing strategy
 
@@ -361,13 +456,22 @@ ADR captures:
 | Phase 2 | Operational bot + Action workflow | Follow-up |
 | Phase 3 | Optional refinements (e.g., GitHub Project board sync, CODEOWNERS-aware PR assignees) | Backlog |
 
+## Bootstrap — first-run caveat
+
+The conductor doesn't exist when the work to *build it* starts. The dogfood plan ("first slice PR is the conductor itself, subsequent slices are templates / ADR / docs / bot") therefore requires:
+
+1. Bootstrap by hand: open the tracking issue, run `/spec:start … /spec:tasks` through `/orchestrate`, then **manually open the first ~3 draft PRs** (conductor skill + slash command + agent) using `gh pr create --draft` from the user's terminal.
+2. Once those PRs merge and the conductor is on `main`, run `/issue:breakdown <n>` against the same tracking issue. Idempotency (sentinel-block check + slice-tag search) ensures the already-merged PRs are recognised and only the *remaining* slices are opened.
+
+This is a one-time bootstrap; subsequent issues use the conductor end-to-end.
+
 ## Open questions
 
-None at design time. All material questions resolved during brainstorming. Surfaces to revisit during planning:
+All material questions resolved. Items to confirm during planning:
 
-- Exact format of `tracer-bullet`'s output that the conductor parses (heading-based regex vs. structured emit).
-- Whether the empty scaffold commit should be `chore(<area>):` or `scaffold(<area>):` (existing repo uses `chore` for non-functional commits — go with `chore`).
+- Whether the empty scaffold commit message should be `chore(<area>):` or `chore(scope):` — go with `chore(<area>)` to mirror the PR title's scope.
 - Whether to emit the audit log in YAML frontmatter + body, or pure markdown (markdown for v1; promote to YAML if downstream tooling needs it).
+- Whether `<AREA>` casing override (lowercase scope distinct from uppercase ID prefix) needs a `workflow-state.md` field — current plan: derive `<area>` mechanically as `<AREA>.toLowerCase()`, no field added.
 
 ## References
 

--- a/docs/superpowers/specs/2026-05-02-issue-breakdown-design.md
+++ b/docs/superpowers/specs/2026-05-02-issue-breakdown-design.md
@@ -146,25 +146,42 @@ Body sections:
 
 ### Slicing input — parsing `tasks.md`
 
-`tasks.md` is produced by the `tracer-bullet` skill during `/spec:tasks` and follows `templates/tasks-template.md`. It is **markdown**, not structured data. The conductor parses it directly using stable anchors that the template guarantees:
+`tasks.md` is produced by `tracer-bullet` during `/spec:tasks` and follows `templates/tasks-template.md`. It is **markdown**, not structured data. The conductor parses it directly using stable anchors the template actually contains.
+
+**A slice is a parallelisable batch.** The template provides this primitive in its `## Parallelisable batches` section (e.g. "Batch 1: T-AUTH-001, T-AUTH-005"). Each batch is, by definition, a set of tasks with no inter-dependencies — exactly the property a draft PR needs. The conductor's mapping rule is:
+
+- **One PR per `Batch N`** — slice ordinal `<NN>` = `N`.
+- **Tasks-in-slice** = the `T-<AREA>-NNN` list on that batch's line.
+- **`🪓 may slice` annotations** override the batch grouping for individual tasks: a task flagged `🪓` with a `**Slice plan:**` line is split out into its own slice (or sub-slices) regardless of which batch it sits in.
+
+The conductor parses these template-guaranteed anchors:
 
 | Field | Source in `tasks.md` |
 |---|---|
-| Ordinal `NN` | Conductor-assigned (1-based) over slice headings in document order. |
-| Task ID `T-<AREA>-NNN` | Per-slice heading line, regex `T-[A-Z0-9]+-\d{3}`. |
-| Slice goal | Slice heading text after the ID. |
-| Acceptance criteria | "Acceptance criteria" section under each slice (bullet list). |
-| Test approach | "Test approach" section under each slice. |
-| Risk level (L/M/H) | "Risk level" line. |
-| Blocked by | "Blocked by" line; comma-separated `T-<AREA>-NNN` list. |
-| DoD (whole spec) | Final "Definition of done" section. |
+| Slice ordinal `<NN>` | `## Parallelisable batches` body, line prefix `- **Batch N:**`, zero-padded to 2 digits. |
+| Tasks in slice | Same line; comma-separated `T-<AREA>-NNN` tokens. |
+| Per-task heading | `### T-<AREA>-NNN <emoji> — <short title>` — regex `^### (T-[A-Z0-9]+-\d{3}) ([🧪🔨📐📚🚀🪓]+) — (.+)$`. Goal = `<short title>`. |
+| Per-task description | Bullet `- **Description:**` under the heading. |
+| Per-task DoD | Bullet `- **Definition of done:**` followed by checklist items. |
+| Per-task `Depends on` | Bullet `- **Depends on:**` (used to cross-check that the batch is actually independent — surface a warning if not). |
+| `🪓 may-slice` flag | `🪓` in the heading emoji set; followed by a `**Slice plan:**` bullet. |
+| Slice goal (PR title) | Concatenation of in-batch task short titles, separated by " + ", truncated to 60 chars. If the batch is a single `🪓` task, the slice goal is that task's short title. |
+| Slice DoD (PR body) | Aggregation of in-batch tasks' per-task DoD checklists, plus the spec's `## Quality gate` section as a final gate. |
 
-This contract is fragile (heading-based regex). Two mitigations:
+There is **no** "Acceptance criteria" or "Test approach" section in the template — these are the planner's discretion inside `**Description:**` or `**Definition of done:**`. The conductor does not require them as anchors.
 
-1. The conductor refuses to proceed if any slice is missing one of the above anchors and surfaces the offending heading. This forces `tasks.md` authors (and `tracer-bullet`) to keep the template stable.
-2. A separate, deferred deliverable (out of scope here) may extend `tracer-bullet` to also emit a structured side-car (e.g. `specs/<slug>/tasks.json`). That extension is *not* a precondition for v1; if/when it lands, the conductor can switch to consuming it. This is recorded in the ADR's "consequences" as a deferred refinement.
+There is **no** whole-spec "Definition of done" section either — the analogous gate is `## Quality gate` (line 87 of the template), which the conductor copies into the PR body's "Definition of done" block as the final gate.
 
-If a slice's `<goal>` is empty or `<area>` cannot be derived from `<AREA>`, the conductor refuses and surfaces the parse error.
+**Refuse-on-missing-anchor.** The conductor hard-stops if any of these are absent or malformed:
+
+- `## Parallelisable batches` heading.
+- At least one `- **Batch N:**` line under it.
+- Every `T-<AREA>-NNN` referenced in a batch line resolves to a `### T-<AREA>-NNN …` heading in `## Task list`.
+- The matching task heading has both `**Description:**` and `**Definition of done:**` bullets.
+
+The error message names the offending line and instructs the user to either fix `tasks.md` directly or re-run `/spec:tasks`.
+
+**Deferred refinement.** A future `tasks.json` side-car (out of scope here) would replace this regex parser. Recorded in the ADR's "consequences".
 
 ### Subagent (`.claude/agents/issue-breakdown.md`)
 
@@ -301,7 +318,7 @@ Branch prefix is `feat/` (same as Phase 1) so a single set of branch-protection 
 - Avoid encoding Phase-2-only state (workflow run inspection, label removal) in Phase 1 surfaces.
 - Document the contract between conductor and `tasks.md` (the "Slicing input" section above) so Phase 2 can implement the same parser independently.
 
-No source code or prompt content is shared between them at v1.
+**File-level boundary.** Phase 2 introduces only files under `agents/operational/issue-breakdown-bot/` and `.github/workflows/issue-breakdown-bot.yml`. It does **not** import, transclude, or reference any file under `.claude/skills/issue-breakdown/` or `.claude/agents/issue-breakdown.md`. There is no shared template file. The two surfaces are kept consistent by sharing this design spec, not by sharing source.
 
 ## Data flow
 
@@ -316,11 +333,10 @@ issue-breakdown agent
         │                          requirements.md,
         │                          design.md,
         │                          spec.md,
-        │                          tasks.md}
-        │
-        ├─ dispatches ──► tracer-bullet skill
-        │                       │
-        │                       └─► slice list
+        │                          tasks.md}                ← parsed in-process
+        │                                                     (slice list derived from
+        │                                                      ## Parallelisable batches +
+        │                                                      🪓 may-slice annotations)
         │
         ├─ writes ──► specs/<slug>/issue-breakdown-log.md  (audit)
         ├─ appends ─► specs/<slug>/workflow-state.md       (## Hand-off notes line)
@@ -373,11 +389,17 @@ The conductor also does **not** create changesets. Empty PRs deliberately have n
 
 ## Sink update — `specs/<slug>/issue-breakdown-log.md`
 
-Lifecycle classification (per `docs/sink.md`): **append-only**. Same shape as `implementation-log.md`. Added by this PR to the sink table:
+Two updates to `docs/sink.md` (the real sink schema is `| Path | Owner | Mutability |` in the Ownership table, plus a separate prose "### Append-only" section — not the four-column shape used in earlier draft):
 
-| Path | Owner | Lifecycle | Notes |
-|---|---|---|---|
-| `specs/<slug>/issue-breakdown-log.md` | `issue-breakdown` agent | append-only | Audit log of `/issue:breakdown` runs against this feature. Free-form markdown; no schema. |
+1. **Ownership table row** (in the existing 3-column shape):
+
+   ```
+   | `specs/<slug>/issue-breakdown-log.md` | `issue-breakdown` agent | Append-only — dated entries, never rewritten |
+   ```
+
+2. **Append-only paragraph extension** — add `specs/<slug>/issue-breakdown-log.md` to the existing list at lines 268–270 of `docs/sink.md`, alongside `implementation-log.md` and the `## Hand-off notes` section. New text:
+
+   > `docs/CONTEXT.md`, `docs/glossary/*.md` …, `specs/<slug>/implementation-log.md`, **`specs/<slug>/issue-breakdown-log.md`**, and the `## Hand-off notes` free-form section of `workflow-state.md` are append-only in spirit. …
 
 The append-only contract mirrors `implementation-log.md`: dated entries, never rewritten, agents may refine wording but historical narrative survives.
 
@@ -385,10 +407,11 @@ The append-only contract mirrors `implementation-log.md`: dated entries, never r
 
 The sentinel-bracketed re-edit zone is the conductor's idempotency primitive. Its limits, made explicit:
 
-- **No optimistic lock.** `gh issue edit --body` is last-write-wins. Two concurrent runs (e.g. interactive conductor + label-triggered bot in Phase 2) can race. Phase 2 mitigates this with a workflow `concurrency.group: issue-breakdown-${{ github.event.issue.number }}` so a queued bot run waits for an earlier one. Phase 1 (interactive) is single-user-per-tty by construction; the conductor checks for an in-flight Phase 2 run by inspecting the workflow run list before proceeding.
+- **No optimistic lock.** `gh issue edit --body` is last-write-wins. Two concurrent runs (e.g. interactive conductor + label-triggered bot in Phase 2) can race. Phase 2 mitigates this with a workflow `concurrency.group: issue-breakdown-${{ github.event.issue.number }}` so a queued bot run waits for an earlier one. Phase 1 (interactive) is single-user-per-tty by construction; the conductor checks for an in-flight Phase 2 run by inspecting the workflow run list before proceeding, and **refuses** with a surfaced run URL if one is active. The user must wait for the workflow to finish (or cancel it manually) before re-running. There is no `--force-run` override at v1.
 - **In-block edits are silently overwritten.** Anything a human writes between `<!-- BEGIN issue-breakdown:<slug> -->` and `<!-- END issue-breakdown:<slug> -->` is replaced on re-run. The block is conductor-owned. Humans annotate *outside* the block.
 - **Missing block on a known-prior-run issue.** If `gh pr list --search "issue-breakdown-slice: issue-<n>" --state all` returns ≥ 1 PR but the issue body has no `BEGIN/END` block, the conductor **refuses** and surfaces: "prior run detected (PRs #x #y) but issue body block missing — restore manually or pass `--force-rebuild` to re-emit." It never silently appends a second block.
 - **Discriminator.** Idempotency on the PR side keys off the `<!-- issue-breakdown-slice: issue-<n>-<NN> -->` HTML comment in the PR body — searched via `gh pr list --search`. `Refs #<n>` is informational only, not the key.
+- **Search reliability caveat.** `gh pr list --search` queries GitHub's code-search index, which tokenises on word boundaries. The `:`, `<`, `>`, and `-` characters in the slice tag may not match as a literal phrase across all GitHub versions. The implementation plan must include a smoke-test that opens a known-tagged draft PR and confirms `gh pr list --search "issue-breakdown-slice issue-<n>"` (without colons) returns it. If the search proves unreliable, fall back to a brute-force scan: list all PRs that match `Refs #<n>` and grep the body locally for the exact tag.
 
 | Case | Handling |
 |---|---|
@@ -461,17 +484,19 @@ ADR captures:
 The conductor doesn't exist when the work to *build it* starts. The dogfood plan ("first slice PR is the conductor itself, subsequent slices are templates / ADR / docs / bot") therefore requires:
 
 1. Bootstrap by hand: open the tracking issue, run `/spec:start … /spec:tasks` through `/orchestrate`, then **manually open the first ~3 draft PRs** (conductor skill + slash command + agent) using `gh pr create --draft` from the user's terminal.
-2. Once those PRs merge and the conductor is on `main`, run `/issue:breakdown <n>` against the same tracking issue. Idempotency (sentinel-block check + slice-tag search) ensures the already-merged PRs are recognised and only the *remaining* slices are opened.
+2. **Manually paste the slice tag** into the body of each bootstrapped PR (`<!-- issue-breakdown-slice: issue-<n>-<NN> -->`) so subsequent re-runs of `/issue:breakdown <n>` recognise them as already-existing slices. Without the tag, the discriminator falls back to `Refs #<n>` matching only and the conductor may produce duplicates.
+3. Once those PRs merge and the conductor is on `main`, run `/issue:breakdown <n>` against the same tracking issue. Idempotency (sentinel-block check + slice-tag search) ensures the already-merged PRs are recognised and only the *remaining* slices are opened.
 
 This is a one-time bootstrap; subsequent issues use the conductor end-to-end.
 
-## Open questions
+## Decisions confirmed during round-2 review
 
-All material questions resolved. Items to confirm during planning:
+(Folded down from the prior "Open questions" section after round 2.)
 
-- Whether the empty scaffold commit message should be `chore(<area>):` or `chore(scope):` — go with `chore(<area>)` to mirror the PR title's scope.
-- Whether to emit the audit log in YAML frontmatter + body, or pure markdown (markdown for v1; promote to YAML if downstream tooling needs it).
-- Whether `<AREA>` casing override (lowercase scope distinct from uppercase ID prefix) needs a `workflow-state.md` field — current plan: derive `<area>` mechanically as `<AREA>.toLowerCase()`, no field added.
+- Empty scaffold commit message uses `chore(<area>):` (lowercase scope), mirroring the PR title.
+- Audit log is plain markdown for v1; promotable to YAML frontmatter + body if downstream tooling needs it.
+- `<area>` (lowercase) is derived mechanically as `<AREA>.toLowerCase()`. No new `workflow-state.md` field is added; if a feature genuinely needs a different scope value, it can override at the conductor's `AskUserQuestion` confirm step.
+- `gitleaks` runs on the PR's commit range. An empty-commit PR has zero new content to scan — pass is fast. `pages.yml` triggers only on `main` writes; not relevant for slice draft PRs.
 
 ## References
 
@@ -480,7 +505,7 @@ All material questions resolved. Items to confirm during planning:
 - `docs/discovery-track.md` — opt-in track shape (mirrored here).
 - `.claude/skills/orchestrate/SKILL.md` — conductor pattern.
 - `.claude/skills/_shared/conductor-pattern.md` — gating + escalation.
-- `.claude/skills/tracer-bullet/SKILL.md` — slice decomposition (dispatched by this skill).
+- `.claude/skills/tracer-bullet/SKILL.md` — produces `tasks.md` upstream during `/spec:tasks`. This conductor consumes that artifact; it does not invoke the skill at runtime.
 - `agents/operational/review-bot/` — operational-bot shape (mirrored for Phase 2).
 - `templates/adr-template.md` — ADR template.
 - `.claude/memory/feedback_pr_hygiene.md` — branch-per-concern rule.

--- a/docs/superpowers/specs/2026-05-02-issue-breakdown-design.md
+++ b/docs/superpowers/specs/2026-05-02-issue-breakdown-design.md
@@ -160,7 +160,7 @@ The conductor parses these template-guaranteed anchors:
 |---|---|
 | Slice ordinal `<NN>` | `## Parallelisable batches` body, line prefix `- **Batch N:**`, zero-padded to 2 digits. |
 | Tasks in slice | Same line; comma-separated `T-<AREA>-NNN` tokens. |
-| Per-task heading | `### T-<AREA>-NNN <emoji> — <short title>` — regex `^### (T-[A-Z0-9]+-\d{3}) ([🧪🔨📐📚🚀🪓]+) — (.+)$`. Goal = `<short title>`. |
+| Per-task heading | `### T-<AREA>-NNN <emoji> — <short title>` — regex `^### (T-[A-Z0-9]+-\d{3}) ([🧪🔨📐📚🚀🪓]) — (.+)$`. Goal = `<short title>`. |
 | Per-task description | Bullet `- **Description:**` under the heading. |
 | Per-task DoD | Bullet `- **Definition of done:**` followed by checklist items. |
 | Per-task `Depends on` | Bullet `- **Depends on:**` (used to cross-check that the batch is actually independent — surface a warning if not). |
@@ -170,7 +170,7 @@ The conductor parses these template-guaranteed anchors:
 
 There is **no** "Acceptance criteria" or "Test approach" section in the template — these are the planner's discretion inside `**Description:**` or `**Definition of done:**`. The conductor does not require them as anchors.
 
-There is **no** whole-spec "Definition of done" section either — the analogous gate is `## Quality gate` (line 87 of the template), which the conductor copies into the PR body's "Definition of done" block as the final gate.
+There is **no** whole-spec "Definition of done" section either — the analogous gate is the `## Quality gate` heading at the bottom of the template, which the conductor copies into the PR body's "Definition of done" block as the final gate.
 
 **Refuse-on-missing-anchor.** The conductor hard-stops if any of these are absent or malformed:
 
@@ -198,7 +198,7 @@ Tool scoping rationale (per Article VI):
 - **Read / Grep / Glob** — read `specs/<slug>/`, `tasks.md`, templates.
 - **Edit / Write** —
   - Write `specs/<slug>/issue-breakdown-log.md` (new artifact, owned by this agent — see "Sink update" below).
-  - Append one dated line to the `## Hand-off notes` free-form section of `specs/<slug>/workflow-state.md`. The frontmatter schema is **not** modified. This append is sanctioned by `docs/sink.md` line 423 ("the active feature's `workflow-state.md` gets a dated one-line entry appended … so the workflow has a paper trail") and is not exclusive to the orchestrator.
+  - Append one dated line to the `## Hand-off notes` free-form section of `specs/<slug>/workflow-state.md`. The frontmatter schema is **not** modified. This append is sanctioned by the `### Append-only` paragraph in `docs/sink.md` ("the active feature's `workflow-state.md` gets a dated one-line entry appended … so the workflow has a paper trail") and is not exclusive to the orchestrator.
   - Stage transient PR/issue body files under `<repo-root>/.issue-breakdown-staging/` (gitignored; never committed). Files are deleted at end of run. The PR body is fed to `gh` via `--body-file`.
 - **Bash** — `git`, `gh`. Pushes to `main` / `develop` already denied by `.claude/settings.json`. Branch pushes to `feat/*` allowed.
 - **No Agent tool** — no further dispatch. `tasks.md` is parsed in-process; no sub-agent is spawned.
@@ -397,7 +397,7 @@ Two updates to `docs/sink.md` (the real sink schema is `| Path | Owner | Mutabil
    | `specs/<slug>/issue-breakdown-log.md` | `issue-breakdown` agent | Append-only — dated entries, never rewritten |
    ```
 
-2. **Append-only paragraph extension** — add `specs/<slug>/issue-breakdown-log.md` to the existing list at lines 268–270 of `docs/sink.md`, alongside `implementation-log.md` and the `## Hand-off notes` section. New text:
+2. **Append-only paragraph extension** — add `specs/<slug>/issue-breakdown-log.md` to the existing list under the `### Append-only` heading of `docs/sink.md`, alongside `implementation-log.md` and the `## Hand-off notes` section. New text:
 
    > `docs/CONTEXT.md`, `docs/glossary/*.md` …, `specs/<slug>/implementation-log.md`, **`specs/<slug>/issue-breakdown-log.md`**, and the `## Hand-off notes` free-form section of `workflow-state.md` are append-only in spirit. …
 
@@ -426,7 +426,7 @@ The sentinel-bracketed re-edit zone is the conductor's idempotency primitive. It
 | User has 2+ candidate `specs/<slug>/` matches | `AskUserQuestion` to disambiguate. |
 | `tasks.md` parse yields 0 slices | Surface to user; abort. |
 | `tasks.md` parse yields 1 slice | Confirm — single PR may be more friction than `gh pr create --draft` by hand. Offer to abort. |
-| `tasks.md` parse missing required anchor (heading, ID, AC, DoD) | Hard-stop. Surface offending heading. Direct user to fix `tasks.md` or re-run `tracer-bullet`. |
+| `tasks.md` parse missing required anchor (`## Parallelisable batches`, `### T-<AREA>-NNN` heading, `**Description:**`, `**Definition of done:**`) | Hard-stop. Surface offending heading. Direct user to fix `tasks.md` or re-run `tracer-bullet`. |
 | Issue body has no `specs/` link AND no `spec:` label | `AskUserQuestion` lists all `tasks.md`-complete features. |
 | User aborts confirmation | No git or gh side-effects. |
 | Sentinel block in issue body deleted between runs | Refuse and surface (see Idempotency section). Offer `--force-rebuild`. |

--- a/docs/superpowers/specs/2026-05-02-issue-breakdown-design.md
+++ b/docs/superpowers/specs/2026-05-02-issue-breakdown-design.md
@@ -1,0 +1,383 @@
+---
+title: Issue-breakdown track — design
+date: 2026-05-02
+status: draft
+authors:
+  - Luis Mendez (with Claude Opus 4.7)
+related:
+  - docs/specorator.md
+  - .claude/skills/tracer-bullet/SKILL.md
+  - .claude/skills/orchestrate/SKILL.md
+  - docs/sink.md
+  - AGENTS.md
+---
+
+# Issue-breakdown track — design
+
+## Problem
+
+Today, when a GitHub issue describes a product increment whose Specorator workflow has reached `/spec:tasks` (i.e. `tasks.md` is `complete`), the path from "tasks ready" to "multiple people working on independent draft PRs against this issue" is manual:
+
+- A human reads `tasks.md`, decides what slices look like, opens `gh pr create --draft` per slice, types each PR body, and then edits the issue body to track progress.
+- This is repetitive, error-prone, and skips the repo's existing slice-decomposition discipline (the `tracer-bullet` skill).
+- Multiple people cannot trivially pick up parallel work, because the chunking and PR scaffolding live only in the human's head.
+
+We need an integrated workflow that: (a) decomposes a `tasks.md` into vertical slices via the canonical skill, (b) opens one independent draft PR per slice, (c) keeps the parent issue as the canonical progress dashboard, and (d) exposes both an interactive (conductor) and an unattended (operational bot) surface — matching how every other workflow in this repo is shaped.
+
+## Goals
+
+1. **Conversational entry point.** A new `/issue:breakdown <issue-number>` slash command and matching conductor skill drive the flow end-to-end, gating with `AskUserQuestion`.
+2. **Vertical-slice decomposition** of `tasks.md` rows into independent draft PRs via the existing `tracer-bullet` skill — no parallel slicing engine.
+3. **Body-only PRs.** Each PR is opened with a generated body (spec lineage, task IDs, DoD, references, standard PR template) and a single empty scaffold commit (no source diff). Implementers write the first real commit.
+4. **Issue stays canonical.** Conductor edits the parent issue body once to add a `## Work packages` section linking each draft PR. GitHub's task-list-link feature auto-strikes entries when PRs close.
+5. **Branch per slice, off `main`.** Honours the repo's `branch per concern` rule. No worktrees pre-created — implementers run the worktree skill themselves when picking up a slice.
+6. **Idempotent.** Re-running the conductor against the same issue resumes (skips slices that already have PRs) or re-plans (creates only missing PRs); never duplicates.
+7. **Audit log under the feature.** A free-form `specs/<slug>/issue-breakdown-log.md` records each run's slice→PR mapping for traceability. Workflow-state schema is *not* changed.
+8. **Phase 2: operational bot.** Headless variant under `agents/operational/issue-breakdown-bot/` triggers on `breakdown-me` label and shares the conductor's source-of-truth prompt.
+
+## Non-goals
+
+- Replacing `/spec:tasks`. The conductor is strictly post-tasks.
+- Decomposing issues that have no spec lineage. Hard-stop with a recommendation to run `/spec:start` and the upstream stages.
+- Auto-implementing the slices. The PR is empty; implementers write code.
+- Auto-merging slice PRs. Out of scope; existing review-bot + verify-gate handle that.
+- Stacked branches off an integration parent. Slices target `main` directly. Cross-slice dependencies are expressed via `Depends on #<PRn>` in the PR body, not by branch graph.
+- Mutation of `tasks.md` or `workflow-state.md` schema. Only a free-form `## Hand-off notes` line is appended.
+
+## Out-of-scope alternatives considered
+
+These were rejected during brainstorming:
+
+- **Extend `/spec:tasks` to auto-open PRs.** Couples task-planning to GitHub state and breaks separation of concerns (Article II).
+- **Operational bot only, no conductor.** Lacks a clean entry point for novel runs and re-runs; inconsistent with every other multi-step workflow in the repo (each has both a conductor skill and a slash command).
+- **Mechanical 1:1 task→PR.** Produces too many tiny PRs and ignores `blockedBy` chains.
+- **Stacked branches off `feat/issue-<n>` integration branch.** Adds a merge step the repo doesn't currently use.
+- **Body + scaffolding commit (test stubs, type stubs).** Conductor would need to know the project's file conventions per-language; out of scope for v1.
+
+These are recorded in the ADR (see "Decisions" below).
+
+## High-level flow
+
+```
+/issue:breakdown <n>
+   │
+   ├─ Pre-flight ────────── gh auth ok? issue open? read issue.
+   │
+   ├─ Resolve spec ──────── issue body specs/ link → label spec:<slug>
+   │                        → AskUserQuestion (list candidates)
+   │
+   ├─ Verify gate ───────── workflow-state.md tasks.md == complete?
+   │                        if not, hard-stop with "run /spec:tasks first"
+   │
+   ├─ Idempotency ───────── gh pr list --search "Refs #<n>"
+   │                        existing PRs found → AskUserQuestion
+   │                        (resume / re-plan / abort)
+   │
+   ├─ Slice ─────────────── dispatch tracer-bullet skill on tasks.md
+   │                        → [{slug, goal, task_ids[], dod[], depends_on[]}]
+   │
+   ├─ Confirm ──────────── AskUserQuestion: open drafts / edit / abort
+   │
+   ├─ Per-slice loop ────── (sequential)
+   │      ├─ git switch -c feat/<slug>-slice-NN-<short> main
+   │      ├─ git commit --allow-empty -m "chore(<area>): scaffold T-<AREA-NNN> slice"
+   │      ├─ git push -u origin <branch>
+   │      └─ gh pr create --draft --base main --head <branch>
+   │              --title "feat(<area>): <goal> (slice NN/N)"
+   │              --body-file <rendered-pr-body>
+   │
+   ├─ Update parent issue ─ gh issue edit <n> --body-file <rendered-issue>
+   │                        (idempotent BEGIN/END sentinel block)
+   │
+   ├─ Audit log ─────────── append specs/<slug>/issue-breakdown-log.md
+   │
+   └─ Hand-off note ─────── append one line to specs/<slug>/workflow-state.md
+                            ## Hand-off notes section
+```
+
+## Components
+
+### File map
+
+New artifacts:
+
+```
+.claude/skills/issue-breakdown/SKILL.md         # conductor (Phase 1)
+.claude/commands/issue/breakdown.md             # /issue:breakdown <num>
+.claude/agents/issue-breakdown.md               # specialist subagent
+docs/issue-breakdown-track.md                   # methodology doc
+docs/adr/NNNN-add-issue-breakdown-track.md      # required ADR
+templates/issue-breakdown-pr-body-template.md   # PR body skeleton
+templates/issue-breakdown-issue-section.md      # issue `## Work packages` seed
+agents/operational/issue-breakdown-bot/         # Phase 2 (follow-up PR)
+  PROMPT.md
+  README.md
+.github/workflows/issue-breakdown-bot.yml       # Phase 2
+```
+
+Updates to existing files:
+
+- `.claude/commands/README.md` — add `issue/` namespace.
+- `.claude/skills/README.md` — list new skill.
+- `AGENTS.md` — add row to skill table; add row to agent classes table.
+- `docs/sink.md` — declare sink for `specs/<slug>/issue-breakdown-log.md`.
+- `CLAUDE.md` — link new track from "Other tracks (opt-in)" table.
+
+### Conductor skill (`.claude/skills/issue-breakdown/SKILL.md`)
+
+Frontmatter: `name`, `description`, `argument-hint: <issue-number>`. Imports `_shared/conductor-pattern.md` for gating + escalation rules (consistent with `orchestrate`, `discovery-sprint`, `sales-cycle`).
+
+Body sections:
+
+1. Read first (state, references).
+2. Pre-flight (auth, issue read).
+3. Resolve spec lineage (3 fallback strategies).
+4. Verify gate (`tasks.md` complete).
+5. Idempotency check.
+6. Slice (dispatch `tracer-bullet`; parse output).
+7. Confirm (single `AskUserQuestion`).
+8. Per-slice loop (branch → empty commit → push → draft PR).
+9. Update parent issue body (sentinel-bracketed re-edit zone).
+10. Audit log + hand-off note.
+11. Constraints (idempotent; never `--no-verify`; sequential; no `main` writes).
+12. References.
+
+### Subagent (`.claude/agents/issue-breakdown.md`)
+
+```yaml
+---
+name: issue-breakdown
+description: Decomposes an issue + completed tasks.md into vertical-slice draft PRs.
+tools: [Read, Edit, Write, Bash, Grep, Glob]
+---
+```
+
+Tool scoping rationale (per Article VI):
+
+- **Read / Grep / Glob** — read `specs/<slug>/`, `tasks.md`, templates.
+- **Edit / Write** — write `issue-breakdown-log.md`; staged PR/issue body files; one-line hand-off note in `workflow-state.md`.
+- **Bash** — `git`, `gh`. Pushes to `main` / `develop` already denied by `.claude/settings.json`. Branch pushes to `feat/*` allowed.
+- **No Agent tool** — no further dispatch; `tracer-bullet` runs as a Skill not a subagent.
+
+### Slash command (`.claude/commands/issue/breakdown.md`)
+
+Thin wrapper; pattern matches `/orchestrate` → orchestrate skill.
+
+```yaml
+---
+description: Decompose a GitHub issue into independent draft PRs from tasks.md.
+argument-hint: <issue-number>
+---
+
+Run the issue-breakdown skill for issue #$ARGUMENTS.
+```
+
+### PR body template (`templates/issue-breakdown-pr-body-template.md`)
+
+```markdown
+<!-- Generated by issue-breakdown skill. Edit freely after first real commit. -->
+
+## Slice <NN>/<N>: <goal>
+
+Refs #<issue-number>
+
+## Spec lineage
+
+- Feature: `specs/<slug>/`
+- Requirements: `specs/<slug>/requirements.md` § <REQ-IDs>
+- Design: `specs/<slug>/design.md` § <section anchors>
+- Spec: `specs/<slug>/spec.md` § <interface IDs>
+- Tasks: `specs/<slug>/tasks.md` § <T-IDs>
+
+## Tasks in this slice
+
+- [ ] T-AREA-NNN — <title>
+- [ ] T-AREA-NNN — <title>
+
+## Depends on
+
+- #<PRn> (slice <MM>) — or `none`
+
+## Definition of done
+
+- [ ] All tasks above marked done in `tasks.md`
+- [ ] Tests for relevant TEST-IDs pass
+- [ ] `npm run verify` green
+- [ ] Docs updated in this PR
+- [ ] PR template checklist below complete
+
+---
+
+<!-- Standard PR template appended verbatim from .github/PULL_REQUEST_TEMPLATE.md -->
+```
+
+The conductor renders the slice-specific header and then concatenates the verbatim contents of `.github/PULL_REQUEST_TEMPLATE.md`. No drift: if the PR template changes, future runs pick up the new version automatically.
+
+### Issue section template (`templates/issue-breakdown-issue-section.md`)
+
+```markdown
+## Work packages
+
+<!-- BEGIN issue-breakdown:<slug> -->
+Generated <YYYY-MM-DD> by `/issue:breakdown`.
+
+- [ ] #<PR1> — slice 01: <goal>
+- [ ] #<PR2> — slice 02: <goal>
+- ...
+
+Spec: `specs/<slug>/`. Re-run with `/issue:breakdown <n>` to refresh.
+<!-- END issue-breakdown:<slug> -->
+```
+
+The `<!-- BEGIN ... -->` / `<!-- END ... -->` sentinel comments delimit the conductor-managed re-edit zone. Anything outside this block in the issue body is preserved on re-runs. GitHub's native task-list-link feature auto-strikes `- [ ] #<PRn>` entries when the referenced PR closes — no polling required.
+
+### Phase 2 — operational bot
+
+`agents/operational/issue-breakdown-bot/PROMPT.md` is the source-of-truth prompt loaded by the scheduled GitHub Action. Same logic as the conductor agent, with these differences:
+
+- Headless: no `AskUserQuestion`. Auto-picks "Open drafts" at confirm step; auto-picks "Resume" at idempotency check.
+- Reads issue context from the GitHub Action environment (`GITHUB_EVENT_PATH` issue payload).
+- On finish: removes `breakdown-me` label, comments `Created N draft PRs: #x #y …`.
+- On error: comments error trace, leaves the label so the issue is visibly stuck.
+
+Workflow `.github/workflows/issue-breakdown-bot.yml`:
+
+```yaml
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  decompose:
+    if: github.event.label.name == 'breakdown-me'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: write
+    concurrency:
+      group: issue-breakdown-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+      # Run Claude Code action with PROMPT.md + issue context.
+```
+
+Bot ships in a follow-up PR after the conductor stabilises. The two share `PROMPT.md` content via reference (bot's `PROMPT.md` includes the conductor agent body and overrides the gating sections).
+
+## Data flow
+
+```
+GitHub issue #<n>
+        │
+        │ gh issue view
+        ▼
+issue-breakdown agent
+        │
+        ├─ reads ──► specs/<slug>/{workflow-state.md,
+        │                          requirements.md,
+        │                          design.md,
+        │                          spec.md,
+        │                          tasks.md}
+        │
+        ├─ dispatches ──► tracer-bullet skill
+        │                       │
+        │                       └─► slice list
+        │
+        ├─ writes ──► specs/<slug>/issue-breakdown-log.md  (audit)
+        ├─ appends ─► specs/<slug>/workflow-state.md       (## Hand-off notes line)
+        ├─ git push ─► origin feat/<slug>-slice-NN-...     (per slice)
+        ├─ gh pr create ─► draft PR per slice
+        │                       │
+        │                       ▼
+        │                  GitHub PRs (draft, body-only, 1 empty commit)
+        │
+        └─ gh issue edit ─► parent issue body
+                                │
+                                ▼
+                         ## Work packages section (sentinel-bracketed)
+```
+
+## Edge cases
+
+| Case | Handling |
+|---|---|
+| `tasks.md` not complete | Hard-stop, message: "run /spec:tasks first". |
+| Issue closed | Hard-stop, refuse. |
+| Issue already has `<!-- BEGIN issue-breakdown:<slug> -->` block | Idempotent re-edit (replace block contents); preserve outside. |
+| Existing PRs `Refs #<n>` | Skip those slices; only open missing ones. Surface count to user. |
+| Dirty working tree | Abort before any branch creation. Surface `git status` to user. |
+| Branch name collides with existing remote | Append `-NN` numeric suffix. |
+| `verify` hook fails on empty commit | Triage; never `--no-verify`. Empty commit means no source diff; failures indicate a hook misconfiguration to fix. |
+| `gh pr create` fails (rate limit / perms) | Abort run; partial state recoverable via re-run idempotency. Audit log records what got created before the failure. |
+| User has 2+ candidate `specs/<slug>/` matches | `AskUserQuestion` to disambiguate. |
+| `tracer-bullet` returns 0 slices | Surface to user; abort. |
+| `tracer-bullet` returns 1 slice | Confirm — single PR may not need this skill. Offer to abort. |
+| Issue body has no `specs/` link AND no `spec:` label | `AskUserQuestion` lists all `tasks.md`-complete features. |
+| User aborts confirmation | No git or gh side-effects. |
+
+## Verify-gate impact
+
+The new track adds files registered by these existing checks:
+
+- `scripts/check-agents.ts` — register `issue-breakdown` agent.
+- `scripts/check-command-docs.ts` — register `/issue:breakdown` command.
+- `scripts/check-frontmatter.ts` — frontmatter on new templates + skill + agent + ADR.
+- `scripts/check-adr-index.ts` — auto-indexed.
+- `scripts/check-markdown-links.ts` — all new cross-links resolve.
+- `scripts/check-token-budget.ts` — unaffected. Skill is on-demand, not always-loaded; not in `MEMORY.md`.
+
+No new check scripts are required for v1.
+
+## Decisions (filed via `/adr:new`)
+
+ADR-NNNN — `add-issue-breakdown-track`. Required because the new track is not in the canonical 11-stage Specorator list (Article II separation), introduces a new conductor surface (touches `AGENTS.md`'s "agent classes" table), and adds a new sink for `specs/<slug>/issue-breakdown-log.md` (touches `docs/sink.md`).
+
+ADR captures:
+
+- **Context.** Multiple-implementer issue work today is manual; tasks.md → draft-PR translation has no integration.
+- **Decision.** Add `issue-breakdown` as a *post-stage-6* opt-in track with conductor skill + slash command + agent + bot, mirroring the shape of `discovery`, `stock-taking`, `sales`, etc.
+- **Alternatives.**
+  1. Extend `/spec:tasks` to auto-open PRs (rejected: couples planning to GitHub).
+  2. Operational bot only, no conductor (rejected: inconsistent with every other workflow's shape).
+  3. Mechanical 1:1 task→PR (rejected: ignores blockedBy chains, produces tiny PRs).
+- **Consequences.**
+  - **Positive.** Standard surface for parallelisable work; preserves spec lineage in PR bodies; idempotent.
+  - **Negative.** Extra skill+agent+bot to maintain; coupled to `tracer-bullet` shape (drift risk); empty-commit per slice is mildly noisy in `git log`.
+  - **Neutral.** New audit-log artifact under `specs/<slug>/`; no schema change.
+
+## Testing strategy
+
+- **Unit-equivalent.** No new TS code in v1 (skill + templates + markdown). The `verify` gate covers frontmatter, links, agent registration, command registration, ADR indexing.
+- **Integration.** Dogfood: open a tracking issue for *this* feature, run the workflow through `/orchestrate` to `/spec:tasks`, then run `/issue:breakdown <n>` against itself. The first slice PR will be the conductor skill + agent + slash command; subsequent slices will be templates, ADR, docs, bot. This exercises every code path on a real repo.
+- **Idempotency.** Re-run `/issue:breakdown <n>` after first run; assert no duplicate PRs and parent issue body is unchanged outside the sentinel block.
+- **Edge-case scripts.** Smoke-tests for the conductor against a fixture `specs/<slug>/` repo (under `examples/`) optional but not required for v1.
+
+## Phasing
+
+| Phase | Deliverable | PR |
+|---|---|---|
+| Phase 1 | Conductor skill + slash command + agent + templates + methodology doc + ADR | This feature |
+| Phase 2 | Operational bot + Action workflow | Follow-up |
+| Phase 3 | Optional refinements (e.g., GitHub Project board sync, CODEOWNERS-aware PR assignees) | Backlog |
+
+## Open questions
+
+None at design time. All material questions resolved during brainstorming. Surfaces to revisit during planning:
+
+- Exact format of `tracer-bullet`'s output that the conductor parses (heading-based regex vs. structured emit).
+- Whether the empty scaffold commit should be `chore(<area>):` or `scaffold(<area>):` (existing repo uses `chore` for non-functional commits — go with `chore`).
+- Whether to emit the audit log in YAML frontmatter + body, or pure markdown (markdown for v1; promote to YAML if downstream tooling needs it).
+
+## References
+
+- `docs/specorator.md` — workflow contract.
+- `docs/sink.md` — sink layout.
+- `docs/discovery-track.md` — opt-in track shape (mirrored here).
+- `.claude/skills/orchestrate/SKILL.md` — conductor pattern.
+- `.claude/skills/_shared/conductor-pattern.md` — gating + escalation.
+- `.claude/skills/tracer-bullet/SKILL.md` — slice decomposition (dispatched by this skill).
+- `agents/operational/review-bot/` — operational-bot shape (mirrored for Phase 2).
+- `templates/adr-template.md` — ADR template.
+- `.claude/memory/feedback_pr_hygiene.md` — branch-per-concern rule.
+- `.claude/memory/feedback_no_main_commits.md` — no direct commits to main.


### PR DESCRIPTION
## Summary

Spec + plan for the new **issue-breakdown** opt-in track. No code yet — this PR ships only the design spec and implementation plan so reviewers can sign off the shape before any artifacts land.

The track decomposes a GitHub issue (post `/spec:tasks`) into independent draft PRs by parsing `tasks.md`'s `## Parallelisable batches` section, opens one body-only draft PR per slice with an empty scaffold commit, and edits the parent issue body to add a sentinel-bracketed `## Work packages` checklist.

Tracking issue: #183 (v0.5.1 milestone).

## Artifacts in this PR

- `docs/superpowers/specs/2026-05-02-issue-breakdown-design.md` — design spec (3 review rounds, approved cosmetic-only at round 3).
- `docs/superpowers/plans/2026-05-02-issue-breakdown.md` — Phase 1 implementation plan (2 review rounds, approved cosmetic-only at round 2).
- `.gitignore` — `.issue-breakdown-staging/` entry.

Phase 1 deliverables in the plan (not yet built):
- `.claude/skills/issue-breakdown/SKILL.md` (conductor)
- `.claude/commands/issue/breakdown.md` (`/issue:breakdown <n>`)
- `.claude/agents/issue-breakdown.md` (specialist subagent)
- `templates/issue-breakdown-pr-body-template.md`
- `templates/issue-breakdown-issue-section.md`
- `docs/issue-breakdown-track.md`
- `docs/adr/0022-add-issue-breakdown-track.md`
- Cross-references in `AGENTS.md`, `CLAUDE.md`, `docs/sink.md`, `.claude/commands/README.md`, `.claude/skills/README.md`, plus regenerated command-inventory blocks in `README.md` and `docs/workflow-overview.md`.

Phase 2 (operational bot at `agents/operational/issue-breakdown-bot/`) is deferred to a follow-up PR.

## Notes for reviewers

- **Conductor pattern deviation.** `/issue:breakdown` intentionally skips the canonical `inputs/` intake gate (input is the issue + an already-completed `tasks.md`, not a new work package). Documented in the methodology doc and ADR-0022.
- **Empty-commit per slice.** GitHub requires `head ≠ base` for `gh pr create --draft`. Each slice branch carries one empty `chore(<area>): scaffold T-<AREA>-NNN slice` commit. CI implications are enumerated in the spec's "CI implications" section.
- **Idempotency.** Re-runs key off the `<!-- issue-breakdown-slice: issue-<n>-<NN> -->` HTML comment in PR bodies and a sentinel-bracketed re-edit zone in the parent issue. Concurrent run during Phase 2 = hard refuse with run URL surfaced.
- **Bootstrap caveat.** First `/issue:breakdown` run on the dogfood tracking issue requires the bootstrap PRs (which build the conductor itself) to have the slice-tag pasted into their bodies by hand.

## Spec / plan review history

- Spec: 3 rounds (initial → 7 issues → 4 blockers → cosmetic) → approved.
- Plan: 2 rounds (initial → 3 blockers → cosmetic) → approved.

## Test plan

- [x] `npm run verify` green locally.
- [x] `check:agents`, `check:commands`, `check:frontmatter`, `check:adr-index`, `check:links` all pass.
- [ ] Reviewer-driven dogfood (after Phase 1 lands): open a tracking issue, run `/issue:breakdown <n>` against it, observe N draft PRs + an updated `## Work packages` section.

## Follow-up

Refs #183 (v0.5.1 tracking issue). Once this PR merges, Phase 1 implementation lands as a single bootstrap PR per the plan's Bootstrap section; subsequent issues use `/issue:breakdown <n>` end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)