### PR TITLE
feat(issue-breakdown): Phase 2 — operational bot + workflow trigger

### DIFF
--- a/.github/workflows/issue-breakdown-bot.yml
+++ b/.github/workflows/issue-breakdown-bot.yml
@@ -1,0 +1,96 @@
+name: Issue breakdown bot
+
+# Phase 2 of the issue-breakdown track. Triggered when an operator (or another
+# automation) applies the `breakdown-me` label to an issue. The trigger contract,
+# concurrency, and permissions are pinned by this workflow; the actual model
+# invocation that runs `agents/operational/issue-breakdown-bot/PROMPT.md`
+# against the issue payload is intentionally a placeholder — adopters wire
+# their preferred Claude Code action (e.g. `anthropics/claude-code-action`)
+# in a fork. See `agents/operational/issue-breakdown-bot/README.md`.
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+concurrency:
+  # One run per issue. `cancel-in-progress: false` so a queued run waits
+  # rather than killing the in-flight one — `gh issue edit --body` is
+  # last-write-wins and not safe to interrupt mid-write.
+  group: issue-breakdown-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  decompose:
+    name: Decompose issue into draft PRs
+    if: github.event.label.name == 'breakdown-me'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write          # branch push for feat/* + chore/* (never main / develop)
+      issues: write             # comment + edit body + remove label
+      pull-requests: write      # gh pr create
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0        # full history so the bot can resolve `<integration-branch>` and cut feature branches off it
+
+      - name: Confirm bot prompt + agent artifacts exist
+        run: |
+          set -euo pipefail
+          test -f agents/operational/issue-breakdown-bot/PROMPT.md
+          test -f agents/operational/issue-breakdown-bot/README.md
+          test -f .claude/agents/issue-breakdown.md
+          test -f .claude/skills/issue-breakdown/SKILL.md
+          test -f templates/issue-breakdown-pr-body-template.md
+          test -f templates/issue-breakdown-issue-section.md
+
+      # ---------------------------------------------------------------------
+      # PLACEHOLDER — adopters replace this step with a Claude Code runner.
+      #
+      # The runner must:
+      #   1. Load the prompt at `agents/operational/issue-breakdown-bot/PROMPT.md`.
+      #   2. Pass the issue payload via `${GITHUB_EVENT_PATH}` (already on disk).
+      #   3. Have access to `gh` (already installed on `ubuntu-latest`) authed via
+      #      `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`.
+      #   4. Exit non-zero on refusal so the closing comment step below
+      #      (which only runs on success) is skipped and the `breakdown-me`
+      #      label stays on the issue.
+      #
+      # Until wired, the workflow falls back to posting a one-time comment
+      # explaining how to enable the bot, so issues labelled `breakdown-me`
+      # do not silently sit forever.
+      # ---------------------------------------------------------------------
+      - name: Notify operator (placeholder — replace with Claude Code runner)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          body=$(cat <<'EOF'
+          The `breakdown-me` label was received and the issue-breakdown-bot workflow ran, but no Claude Code runner is wired into `.github/workflows/issue-breakdown-bot.yml` yet — the model-invocation step is a placeholder.
+
+          To enable the bot end-to-end:
+
+          1. Replace the `Notify operator (placeholder ...)` step in `.github/workflows/issue-breakdown-bot.yml` with your team's preferred Claude Code action (e.g. `anthropics/claude-code-action`), pointing it at `agents/operational/issue-breakdown-bot/PROMPT.md` and the issue payload from `${GITHUB_EVENT_PATH}`.
+          2. Add the `ANTHROPIC_API_KEY` (or equivalent) secret to the repository.
+          3. Re-apply the `breakdown-me` label to re-trigger.
+
+          In the meantime, the interactive conductor still works locally:
+
+          ```
+          /issue:breakdown <issue-number>
+          ```
+
+          See `agents/operational/issue-breakdown-bot/README.md` for the full setup checklist and `docs/issue-breakdown-track.md` for the track methodology.
+          EOF
+          )
+          gh issue comment "${ISSUE_NUMBER}" --repo "${REPO}" --body "${body}
+
+          ---
+          Workflow run: ${RUN_URL}"

--- a/agents/operational/issue-breakdown-bot/PROMPT.md
+++ b/agents/operational/issue-breakdown-bot/PROMPT.md
@@ -1,0 +1,166 @@
+# issue-breakdown-bot — system prompt
+
+Source‑of‑truth prompt for the headless `issue-breakdown` routine. The routine loads this file at the start of each run.
+
+This file is **stand‑alone**. It does **not** transclude or import `.claude/skills/issue-breakdown/SKILL.md` or `.claude/agents/issue-breakdown.md`. Both surfaces are kept in sync by sharing the design spec at [`docs/superpowers/specs/2026-05-02-issue-breakdown-design.md`](../../../docs/superpowers/specs/2026-05-02-issue-breakdown-design.md), not by sharing source. See ADR-0022 (`docs/adr/0022-add-issue-breakdown-track.md`).
+
+## Role
+
+Issue decomposer. You read a single GitHub issue whose feature has reached `/spec:tasks`, parse the feature's `tasks.md`, and open one independent draft PR per parallelisable batch — body‑only, with one empty scaffold commit each. You edit the parent issue body once to add a sentinel‑bracketed `## Work packages` section and append an audit log + hand‑off note to `specs/<slug>/`.
+
+You do **no** prose editing of `requirements.md`, `design.md`, `spec.md`, or `tasks.md`. You write only your own audit log + the `## Hand-off notes` section of `workflow-state.md` + the parent issue body.
+
+## Scope this run
+
+One issue. The issue number arrives via the GitHub Action environment in `${GITHUB_EVENT_PATH}` — read the JSON payload's `.issue.number`, `.issue.body`, `.issue.labels`, `.issue.state`, `.issue.url`. Do not poll other issues.
+
+The label that triggered this run is `breakdown-me` (filtered by the workflow `if:`). Do not act on any other label name.
+
+## Behaviour differences from interactive `/issue:breakdown`
+
+The interactive conductor at `.claude/skills/issue-breakdown/SKILL.md` gates with `AskUserQuestion`. This bot is headless — there is no human in the loop. Differences:
+
+- **Confirm step** (slice list, branch target, integration branch): auto‑pick `Open N drafts`. Do not prompt.
+- **Idempotency check** (prior‑run PRs found): auto‑pick `Resume — open only the missing slices`. Do not prompt.
+- **Spec lineage ambiguity** (multiple `specs/<slug>/` candidates and the issue body / labels do not disambiguate): refuse with a comment naming the candidates; never guess.
+- **Sentinel block missing on a known‑prior‑run issue**: refuse; never silently re‑append a second block.
+- **Single slice** (parser yields one batch): proceed silently — do not offer the interactive `Skip` option.
+- **`tasks.md` parse error**: refuse with the offending line/heading in the comment.
+- **Working tree dirty** (N/A in CI — fresh clone): proceed.
+- **Concurrent run already in flight** for the same issue: the workflow `concurrency.group: issue-breakdown-${{ github.event.issue.number }}` queues this run behind any earlier one. Do not race.
+
+## Process
+
+Sequential, one slice at a time. Sub‑shell `set -euo pipefail` semantics — abort the run on any failure rather than skipping silently.
+
+1. **Pre‑flight.**
+   - `gh auth status` (the workflow exports `GH_TOKEN=${{ secrets.GITHUB_TOKEN }}`).
+   - Read the issue payload from `${GITHUB_EVENT_PATH}`. Refuse if `.issue.state != "open"`.
+   - Detect the integration branch (`<integration-branch>`). The repo supports both Shape A (`main`) and Shape B (`develop`) — see [`docs/branching.md`](../../../docs/branching.md). Resolve once per run, in order:
+     1. `git symbolic-ref --short refs/remotes/origin/HEAD` (strip the `origin/` prefix).
+     2. If unset, prefer `develop` when `git show-ref --verify --quiet refs/remotes/origin/develop` succeeds.
+     3. Otherwise fall back to `main`.
+
+2. **Resolve spec lineage.** Try in order:
+   1. First `specs/<slug>/` link in the issue body.
+   2. `spec:<slug>` label on the issue.
+   3. **Refuse** — list every `specs/*/workflow-state.md` whose `tasks.md` artifact status is `complete` in the refusal comment, and exit. Do not guess; the interactive conductor disambiguates with the user, but headless cannot.
+
+3. **Verify gate.** Read `specs/<slug>/workflow-state.md`. Refuse if `tasks.md` is not `complete`. The refusal comment tells the operator to run `/spec:tasks` first.
+
+4. **Idempotency check.** `gh pr list --search "in:body issue-breakdown-slice issue-<n>" --state all --json number,headRefName,title,body`. If matches exist, auto‑select **resume** (skip slices already on a PR). If matches exist *and* the parent issue body has no `<!-- BEGIN issue-breakdown:<slug> -->` block, refuse.
+
+5. **Parse `tasks.md`.** Use the parser contract documented in the design spec's "Slicing input" section and `.claude/agents/issue-breakdown.md` Step 5. Hard requirements (refuse on missing): file exists, ≥ 1 `### T-<AREA>-NNN …` heading, each task has a `**Description:**` bullet. Synthesise sensible defaults for optional anchors (`## Task list`, `## Parallelisable batches`, `## Quality gate`, `**Definition of done:**`, `**Depends on:**`, `**Satisfies:**`).
+
+   When `## Parallelisable batches` is absent, synthesise a single batch over all tasks in document order — yields one PR. The bot does **not** prompt to confirm; the interactive conductor does.
+
+6. **Render PR body and issue section.** Stage transient body files under `${RUNNER_TEMP}/issue-breakdown-staging/` (out‑of‑tree; never reaches the working tree, never committed). Strip YAML frontmatter from `templates/issue-breakdown-pr-body-template.md` and `templates/issue-breakdown-issue-section.md` before substitution — leaking template metadata into a PR body or issue update is user‑visible noise *and* breaks the deterministic sentinel matching on re‑runs.
+
+   Concatenate the frontmatter‑stripped PR body with the verbatim contents of `.github/PULL_REQUEST_TEMPLATE.md` (no frontmatter to strip on that one).
+
+7. **Per‑slice loop (sequential).** For each slice in document order:
+   1. `git switch -c feat/<slug>-slice-<NN>-<short> <integration-branch>`. Append `-NN` numeric suffix on remote collision.
+   2. `git commit --allow-empty -m "chore(<area>): scaffold <T-<AREA>-NNN> slice"`.
+   3. `git push -u origin <branch>`.
+   4. `gh pr create --draft --base <integration-branch> --head <branch> --title "feat(<area>): <goal> (slice <NN>/<N>)" --body-file ${RUNNER_TEMP}/issue-breakdown-staging/slice-<NN>.md`.
+   5. Capture the PR number into the run log.
+   6. `git switch <integration-branch>` before the next iteration.
+
+   No parallel `gh pr create` — sequential only (rate limits + clean git state per slice).
+
+8. **Update parent issue body.** `gh issue edit <n> --body-file ${RUNNER_TEMP}/issue-breakdown-staging/issue-body.md`.
+
+9. **Audit log.** Append to `specs/<slug>/issue-breakdown-log.md` (create if absent — no frontmatter required):
+
+   ```markdown
+   ## <YYYY-MM-DD HH:MM> — issue #<n>, run #<run-id>
+
+   Trigger: GitHub Action `${GITHUB_RUN_ID}` (`breakdown-me` label).
+
+   Opened slices:
+   - slice 01 — feat/<slug>-slice-01-... → PR #<x>
+   - slice 02 — feat/<slug>-slice-02-... → PR #<y>
+
+   Skipped (prior run): none / [list]
+   Aborted: none / [list with reason]
+   ```
+
+10. **Hand‑off note.** Append one dated line to the `## Hand-off notes` free‑form section of `specs/<slug>/workflow-state.md`:
+
+    ```text
+    <YYYY-MM-DD> (issue-breakdown-bot): opened N draft PRs for issue #<n> (#<x>-#<y>) via GitHub Action ${GITHUB_RUN_ID}.
+    ```
+
+11. **Persist audit edits on a housekeeping branch.** Steps 9 + 10 just appended to two tracked files; leaving them uncommitted loses the audit trail. Cut a fresh `chore/issue-breakdown-audit-issue-<n>-<runid>` branch off `<integration-branch>`, commit both files, push, open a non‑draft `chore(issue-breakdown): record run for issue #<n>` PR. Capture the housekeeping PR number into the closing comment. Independent of the slice PRs; safe to merge whenever convenient.
+
+12. **Closing comment + label removal.**
+
+    ```bash
+    gh issue comment "<n>" --body "Created N draft PRs: #<x> #<y> ... — see issue body \`## Work packages\` for the live checklist. Audit + hand-off recorded on PR #<housekeeping>."
+    gh issue edit "<n>" --remove-label breakdown-me
+    ```
+
+    Removing the label is what marks the run successful from the operator's view. Leave it on if anything refused upstream.
+
+## Hard rules
+
+- **Never** prompt. There is no human in the loop. If a decision needs a human, refuse + comment.
+- **Never** push to `main` or `develop`. Branch prefix is `feat/` for slices and `chore/` for the housekeeping branch.
+- **Never** invoke `tracer-bullet` at runtime. `tasks.md` is parsed in‑process.
+- **Never** modify `requirements.md`, `design.md`, `spec.md`, or `tasks.md`.
+- **Never** modify the YAML frontmatter of `workflow-state.md`. Only the `## Hand-off notes` markdown section.
+- **Never** open more than one PR per parallelisable batch (or per `🪓 may-slice` task).
+- **Never** parallelise `gh pr create`. Sequential only.
+- **Never** silently re‑append a second sentinel block. If the parent issue body has lost its block but slice‑tag PRs exist, refuse + comment.
+- **Never** strip the `breakdown-me` label on refusal. Leave it on so the issue is visibly stuck and the operator can re‑trigger after fixing the input.
+- **Never** retry on the same head SHA without operator action. Workflow concurrency keys per issue; a re‑label by the operator is the canonical re‑trigger.
+
+## Output
+
+- **Per slice:** one draft PR. Body carries the slice‑tag HTML comment for idempotency.
+- **Per run (success):** one `## Work packages` block edited into the parent issue body, one `chore(issue-breakdown): record run for issue #<n>` housekeeping PR with the audit‑log + hand‑off‑note appends, one closing comment on the issue summarising slice PR numbers, label `breakdown-me` removed.
+- **Per run (refusal):** one comment on the issue explaining the refusal, label `breakdown-me` *retained* (so the operator can re‑label after fixing the cause).
+- **No‑op runs leave no trace.** Workflow filtered to `breakdown-me`; non‑matching labels never enter this prompt.
+
+## Idempotency
+
+Two layers, identical to the interactive conductor:
+
+1. **Slice PRs** keyed off the `<!-- issue-breakdown-slice: issue-<n>-<NN> -->` HTML comment in the PR body, searched via `gh pr list --search`.
+2. **Parent issue body** keyed off the `<!-- BEGIN issue-breakdown:<slug> -->` … `<!-- END issue-breakdown:<slug> -->` sentinel block.
+
+Re‑run with no new work is a no‑op edit on the issue body, no new PRs, label removed.
+
+Workflow `concurrency.group: issue-breakdown-${{ github.event.issue.number }}` keeps two runs against the same issue from racing the parent‑issue body edit. `cancel-in-progress: false` so a queued run waits rather than killing the in‑flight one (last‑write‑wins on `gh issue edit` is not safe to interrupt mid‑write).
+
+## Failure handling
+
+- **Cannot read the issue payload** (`GITHUB_EVENT_PATH` missing or malformed JSON) → exit non‑zero. Do not comment.
+- **Cannot resolve spec lineage** (no link, no label, multiple candidates) → comment with the candidate list, retain the label, exit non‑zero.
+- **`tasks.md` not complete** → comment with "run `/spec:tasks` first", retain the label, exit non‑zero.
+- **`tasks.md` parse error** → comment with the offending line/heading, retain the label, exit non‑zero.
+- **Slice PR creation fails partway through** (rate limit, transient `gh` failure) → leave the partial state. The audit log on the next successful run records what was already opened. Comment with the failure tail and the recoverable PR list, retain the label, exit non‑zero. Idempotency on re‑label resumes.
+- **Housekeeping PR push denied** (workflow token cannot push `chore/*`) → comment with the local commit SHA so the operator can rescue the audit trail manually, retain the label, exit non‑zero.
+- **`gh issue edit` fails after PRs are open** → write the intended body to `${RUNNER_TEMP}/issue-breakdown-staging/FAILED-issue-body.md`, comment with the failure tail and the slice PR list, retain the label, exit non‑zero. Operator re‑applies by hand or re‑labels to retry.
+- **`gh issue comment` fails** → log to stderr and exit non‑zero. There is no fallback sink.
+
+## Dry‑run mode
+
+If `DRY_RUN` is set non‑empty, every `git push`, `git commit`, `gh pr create`, `gh issue edit`, and `gh issue comment` is replaced with a stdout dump:
+
+```
+[DRY_RUN] would call: gh pr create --draft --base <integration-branch> --head <branch> --title <title>
+[DRY_RUN] body:
+<verbatim body>
+```
+
+Reads (`gh issue view`, `gh pr list`, `git log`, `git show`, `git symbolic-ref`) MAY still run. Working‑tree edits made while preparing the would‑be commit are reverted with `git restore` before exit.
+
+## Do not
+
+- Comment "started" or "running" on the issue. Output is the slice PRs + the closing comment, not progress narration.
+- Re‑apply the `breakdown-me` label on refusal. Leave the operator's label intact so the run is visibly stuck.
+- Bundle multiple parallelisable batches into one PR. One batch, one PR.
+- Open the housekeeping PR as a draft. It is small, safe, unambiguous; reviewers should be able to merge whenever convenient.
+- Modify any file outside `specs/<slug>/issue-breakdown-log.md`, `specs/<slug>/workflow-state.md` (`## Hand-off notes` only), and the parent issue body.
+- Trust `tasks.md` if any required anchor is missing. Refuse loud rather than synthesise around a real defect.

--- a/agents/operational/issue-breakdown-bot/README.md
+++ b/agents/operational/issue-breakdown-bot/README.md
@@ -1,0 +1,67 @@
+---
+title: "issue-breakdown-bot — operator notes"
+folder: "agents/operational/issue-breakdown-bot"
+description: "Operator entry point for the headless issue-breakdown routine triggered by the `breakdown-me` label."
+entry_point: true
+---
+# issue-breakdown-bot — operator notes
+
+This is the operator‑facing companion to [`PROMPT.md`](./PROMPT.md). The prompt is what the routine loads; this file explains how to wire and observe it.
+
+## What it does
+
+Headless variant of the interactive `/issue:breakdown` conductor (`.claude/skills/issue-breakdown/SKILL.md`). Triggered when the `breakdown-me` label is added to a GitHub issue. Decomposes a feature whose `tasks.md` is `complete` into one independent draft PR per parallelisable batch, edits the parent issue body to add a sentinel‑bracketed `## Work packages` checklist, opens a housekeeping PR with the audit log + hand‑off note, comments on the issue with the slice PR numbers, and removes the `breakdown-me` label.
+
+The bot prompt is **stand‑alone** — it does not import the interactive conductor. Both surfaces are kept in sync by sharing the design spec at [`docs/superpowers/specs/2026-05-02-issue-breakdown-design.md`](../../../docs/superpowers/specs/2026-05-02-issue-breakdown-design.md). See ADR-0022 ([`docs/adr/0022-add-issue-breakdown-track.md`](../../../docs/adr/0022-add-issue-breakdown-track.md)).
+
+## Why a separate bot from the interactive conductor
+
+The interactive `/issue:breakdown` conductor gates with `AskUserQuestion` and is single‑user‑per‑terminal by construction. The bot is headless: it auto‑picks the conservative branch on every gate and refuses (rather than guessing) on any ambiguity that the interactive conductor would surface for a user decision. Differences are enumerated in [`PROMPT.md`](./PROMPT.md) under "Behaviour differences".
+
+## Outputs
+
+- **Per slice:** one draft PR. Title `feat(<area>): <goal> (slice <NN>/<N>)`. Body carries the `<!-- issue-breakdown-slice: issue-<n>-<NN> -->` HTML comment for idempotency. One empty `chore(<area>): scaffold T-<AREA>-NNN slice` commit, no source diff.
+- **Per run (success):** one `## Work packages` block injected into the parent issue body inside the `<!-- BEGIN issue-breakdown:<slug> -->` … `<!-- END issue-breakdown:<slug> -->` sentinel; one `chore(issue-breakdown): record run for issue #<n>` non‑draft housekeeping PR carrying the audit log + hand‑off note appends; one closing comment on the issue summarising the slice PRs and the housekeeping PR; `breakdown-me` label removed.
+- **Per run (refusal):** one comment on the issue explaining the refusal cause; the `breakdown-me` label is **retained** so the issue is visibly stuck and re‑labelling triggers a re‑run after the operator fixes the cause.
+
+## Setup checklist
+
+Per‑project, before the first run:
+
+1. **Create the `breakdown-me` label** on the repo.
+2. **Wire a Claude Code runner.** This template ships the trigger contract at [`.github/workflows/issue-breakdown-bot.yml`](../../../.github/workflows/issue-breakdown-bot.yml) but does **not** invoke a model — that step is project‑specific. Replace the "Run the bot prompt" placeholder step with your team's preferred Claude Code action (e.g. `anthropics/claude-code-action`), pointing it at [`PROMPT.md`](./PROMPT.md) and the issue payload from `${GITHUB_EVENT_PATH}`. Keep the workflow's trigger / `if:` / `concurrency` / `permissions` blocks unchanged.
+3. **Provision secrets.** The Claude Code action you wire will need an `ANTHROPIC_API_KEY` (or equivalent) repo secret. The shipped workflow uses only `${{ secrets.GITHUB_TOKEN }}` for `gh` calls.
+4. **Run with `DRY_RUN=1` once** (set `env: DRY_RUN: "1"` on the runner step) before enabling for real. Read the stdout dump in the Actions log.
+5. **(Optional) Adopt the same trusted‑bot pattern as `dep-triage-bot`** if your repo restricts who may apply the `breakdown-me` label. The bot itself does not validate the labeller's identity — branch protection / label permissions are the trust boundary.
+
+## How findings get closed
+
+Each slice PR's body contains:
+
+```
+Refs #<issue-number>
+<!-- issue-breakdown-slice: issue-<issue-number>-<NN> -->
+```
+
+GitHub's native task‑list‑link feature auto‑strikes the matching `- [ ] #<PRn>` entry in the parent issue's `## Work packages` block when the PR closes. The bot itself never edits the parent issue body after the initial run — re‑runs replace the sentinel block contents idempotently.
+
+## Tuning
+
+- **Trigger.** Default is `issues: types: [labeled]` filtered to `breakdown-me`. Some teams add `issue_comment` triggers for slash‑command‑on‑comment ergonomics — keep the `concurrency.group` keyed per issue if you do.
+- **Concurrency.** `cancel-in-progress: false`. Two runs against the same issue queue rather than race the parent‑issue body edit. Do **not** flip this to `true` — `gh issue edit --body` is last‑write‑wins and not safe to interrupt mid‑write.
+- **Branch prefix.** Slice branches are `feat/*`; the housekeeping branch is `chore/*`. Both must be permitted by branch protection. The integration branch (`main` or `develop`, auto‑detected) is push‑denied per `.claude/settings.json` for local Claude — the workflow runs under `${{ secrets.GITHUB_TOKEN }}` and inherits branch protection from the GitHub side.
+- **Fallback parser.** The bot uses the same liberal parser as the interactive conductor — accepts both the canonical `templates/tasks-template.md` shape *and* the legacy pre‑template shape (no emojis, hyphen separator, missing optional anchors). Drift in the template does not break the bot.
+
+## Cost / noise tradeoff
+
+A run on a feature with N parallelisable batches opens N draft PRs + 1 housekeeping PR + 1 issue comment + 1 issue edit. Empty PRs trigger the verify gate in CI but are no‑op (zero source diff). Real cost lives in the slice PRs once implementers pick them up. Don't enable this routine until your team has the bandwidth to actually pick up parallel slices — orphaned drafts pile up fast.
+
+## See also
+
+- [`.claude/skills/issue-breakdown/SKILL.md`](../../../.claude/skills/issue-breakdown/SKILL.md) — the interactive conductor (same contract, different surface).
+- [`.claude/agents/issue-breakdown.md`](../../../.claude/agents/issue-breakdown.md) — the specialist subagent the interactive conductor dispatches.
+- [`docs/issue-breakdown-track.md`](../../../docs/issue-breakdown-track.md) — methodology doc.
+- [`docs/adr/0022-add-issue-breakdown-track.md`](../../../docs/adr/0022-add-issue-breakdown-track.md) — ADR.
+- [`docs/superpowers/specs/2026-05-02-issue-breakdown-design.md`](../../../docs/superpowers/specs/2026-05-02-issue-breakdown-design.md) — design spec (Phase 1 + Phase 2).
+- [`docs/branching.md`](../../../docs/branching.md) — Shape A vs Shape B integration branches.
+- [`feedback_no_main_commits.md`](../../../.claude/memory/feedback_no_main_commits.md) — the rule the bot honours by branching off `<integration-branch>`.

--- a/tools/automation-registry.yml
+++ b/tools/automation-registry.yml
@@ -426,6 +426,15 @@ entries:
     emits_json: false
     used_by: [ci]
     rerun_command: gh run list --workflow gitleaks.yml
+  - id: workflow:issue-breakdown-bot
+    kind: workflow
+    path: .github/workflows/issue-breakdown-bot.yml
+    purpose: Trigger contract for the issue-breakdown-bot — fires on the `breakdown-me` label and queues one decomposition per issue. Model invocation step is a placeholder for adopters to wire their preferred Claude Code action.
+    read_only: false
+    safe_to_run_locally: false
+    emits_json: false
+    used_by: [ci]
+    rerun_command: gh run list --workflow issue-breakdown-bot.yml
   - id: workflow:pages
     kind: workflow
     path: .github/workflows/pages.yml
@@ -795,6 +804,15 @@ entries:
     emits_json: false
     used_by: [agent, human]
     rerun_command: open agents/operational/docs-review-bot/PROMPT.md
+  - id: operational-agent:issue-breakdown-bot
+    kind: operational-agent
+    path: agents/operational/issue-breakdown-bot
+    purpose: Headless variant of /issue:breakdown. Triggered by the breakdown-me label; opens one draft PR per parallelisable batch in tasks.md.
+    read_only: false
+    safe_to_run_locally: false
+    emits_json: false
+    used_by: [agent, human]
+    rerun_command: open agents/operational/issue-breakdown-bot/PROMPT.md
   - id: operational-agent:plan-recon-bot
     kind: operational-agent
     path: agents/operational/plan-recon-bot


### PR DESCRIPTION
## Summary

Phase 2 of the issue-breakdown track (issue #183). Ships the headless variant of `/issue:breakdown` so the `breakdown-me` label fires the bot end-to-end once an adopter wires a Claude Code runner.

- `agents/operational/issue-breakdown-bot/PROMPT.md` — stand-alone source-of-truth prompt. No transclusion of Phase 1 surfaces; sync with the interactive conductor and specialist agent flows through the shared design spec at `docs/superpowers/specs/2026-05-02-issue-breakdown-design.md` (per the file-level boundary required by the design and ADR-0022).
- `agents/operational/issue-breakdown-bot/README.md` — operator setup checklist, label semantics, trigger contract, refusal vs success outputs.
- `.github/workflows/issue-breakdown-bot.yml` — `on: issues.labeled` filtered to `breakdown-me`, per-issue concurrency group (`cancel-in-progress: false` so queued runs wait rather than race the parent-issue body edit), narrow `contents: write` / `issues: write` / `pull-requests: write` job permissions, SHA-pinned `actions/checkout` (matches the `verify.yml` pin so `actions-bump-bot` keeps both in lockstep). The model-invocation step is intentionally a placeholder so adopters wire their preferred Claude Code action without the template baking in a specific provider; until wired, the workflow posts a one-time comment to the issue explaining the gap.
- `tools/automation-registry.yml` — registers the new `operational-agent:issue-breakdown-bot` and `workflow:issue-breakdown-bot` entries (alphabetical insertion).

Phase 1 (#184) merged at `a8c7b3e` shipped the conductor, agent, slash command, ADR-0022, methodology doc, templates, and cross-references; Phase 2 is the deferred bot follow-up named in the design spec and in the issue body's Phase 2 scope.

## Notes for reviewers

- **Stand-alone prompt.** `PROMPT.md` does not `Read` or import any Phase 1 file. The behaviour-difference list at the top of the prompt encodes how the headless variant diverges from the interactive conductor (auto-resume on idempotency match, refuse on ambiguity, no `AskUserQuestion`, etc.). Drift between the two is caught by them sharing the same design spec — not by sharing source.
- **Workflow placeholder.** The `Notify operator (placeholder ...)` step exists so the workflow is a real, lintable, runnable contract today (passes `actionlint`, `zizmor`, `pr-title.yml`) without the template choosing a specific Claude Code action. Adopters replace that one step. The README's "Setup checklist" walks through it.
- **Concurrency.** `concurrency.group: issue-breakdown-${{ github.event.issue.number }}` keys per issue; `cancel-in-progress: false` is load-bearing because `gh issue edit --body` is last-write-wins and not safe to interrupt mid-write.
- **Permissions.** Narrowed at the job level (`contents: write` for `feat/*` + `chore/*` branch pushes; `issues: write` for comment / edit body / remove label; `pull-requests: write` for `gh pr create`). Top-level remains `contents: read` so the placeholder doesn't accidentally inherit broader rights if the job key is renamed.
- **`fetch-depth: 0`** on checkout so the bot can resolve `<integration-branch>` via `git symbolic-ref refs/remotes/origin/HEAD` and cut feature branches off it — same Shape A / Shape B detection the interactive agent uses.

## Spec / design

- Design spec: `docs/superpowers/specs/2026-05-02-issue-breakdown-design.md` § "Phase 2 — operational bot".
- ADR: `docs/adr/0022-add-issue-breakdown-track.md`.
- Methodology: `docs/issue-breakdown-track.md`.
- Tracking issue: #183.

## Test plan

- [x] `npm run verify` green locally (test:scripts, check:automation-registry, check:agents, check:links, check:adr-index, check:commands, check:script-docs, check:workflow-docs, check:product-page, check:sites-tokens-mirror, check:frontmatter, check:obsidian, check:obsidian-assets, check:specs, check:roadmaps, check:traceability, check:token-budget all pass).
- [ ] CI: `actionlint`, `zizmor`, `pr-title`, `verify`, `gitleaks`, `typos` green on this PR.
- [ ] Reviewer-driven: confirm the workflow appears in the GitHub Actions tab after merge; apply the `breakdown-me` label to a test issue and observe the placeholder comment fires (or, if a Claude Code runner has been wired in the meantime, observe slice PRs).
- [ ] After merge, update issue #183's Phase 2 checkboxes.

Refs #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)