### PR TITLE
fix(commands): use haiku for trivial bootstrap cmds

### DIFF
--- a/.claude/commands/design/start.md
+++ b/.claude/commands/design/start.md
@@ -2,7 +2,7 @@
 description: Design Track — Bootstrap. Scaffold a new design folder under designs/<slug>/ with design-state.md initialised.
 argument-hint: <design-slug>
 allowed-tools: [Read, Edit, Write, Bash]
-model: sonnet
+model: haiku
 ---
 
 # /design:start

--- a/.claude/commands/discovery/start.md
+++ b/.claude/commands/discovery/start.md
@@ -2,7 +2,7 @@
 description: Discovery Track — Bootstrap. Scaffold a new sprint folder under discovery/<slug>/ with discovery-state.md initialised.
 argument-hint: <sprint-slug>
 allowed-tools: [Read, Edit, Write, Bash]
-model: sonnet
+model: haiku
 ---
 
 # /discovery:start

--- a/.claude/commands/portfolio/start.md
+++ b/.claude/commands/portfolio/start.md
@@ -2,7 +2,7 @@
 description: Portfolio Track — Bootstrap. Scaffold a new portfolio folder under portfolio/<slug>/ with portfolio-state.md and portfolio-definition.md initialised.
 argument-hint: <portfolio-slug>
 allowed-tools: [Read, Edit, Write, Bash]
-model: sonnet
+model: haiku
 ---
 
 # /portfolio:start

--- a/.claude/commands/project/start.md
+++ b/.claude/commands/project/start.md
@@ -2,7 +2,7 @@
 description: Project Manager Track — Bootstrap. Scaffold a new project folder under projects/<slug>/ with project-state.md initialised.
 argument-hint: <project-slug>
 allowed-tools: [Read, Edit, Write, Bash]
-model: sonnet
+model: haiku
 ---
 
 # /project:start

--- a/.claude/commands/quality/start.md
+++ b/.claude/commands/quality/start.md
@@ -2,7 +2,7 @@
 description: Start an ISO 9001-aligned quality assurance review for a project, portfolio, or active feature.
 argument-hint: "<quality-review-slug> [scope]"
 allowed-tools: [Read, Edit, Write, Bash, Grep]
-model: sonnet
+model: haiku
 ---
 
 # /quality:start

--- a/.claude/commands/roadmap/start.md
+++ b/.claude/commands/roadmap/start.md
@@ -2,7 +2,7 @@
 description: Roadmap Management Track - Bootstrap. Scaffold a roadmap workspace under roadmaps/<slug>/ with state and strategy artifacts.
 argument-hint: <roadmap-slug>
 allowed-tools: [Read, Edit, Write, Bash]
-model: sonnet
+model: haiku
 ---
 
 # /roadmap:start

--- a/.claude/commands/sales/start.md
+++ b/.claude/commands/sales/start.md
@@ -2,7 +2,7 @@
 description: Sales Cycle — Bootstrap. Scaffold a new deal folder under sales/<deal-slug>/ with deal-state.md initialised.
 argument-hint: <deal-slug> [client-name]
 allowed-tools: [Read, Edit, Write]
-model: sonnet
+model: haiku
 ---
 
 # /sales:start

--- a/.claude/commands/scaffold/start.md
+++ b/.claude/commands/scaffold/start.md
@@ -2,7 +2,7 @@
 description: Project Scaffolding Track — Bootstrap. Scaffold a source-led onboarding folder under scaffolding/<slug>/ with scaffolding-state.md initialised.
 argument-hint: <project-slug> <source-pointer>
 allowed-tools: [Read, Edit, Write, Bash]
-model: sonnet
+model: haiku
 ---
 
 # /scaffold:start

--- a/.claude/commands/spec/start.md
+++ b/.claude/commands/spec/start.md
@@ -2,7 +2,7 @@
 description: Scaffold a new feature folder under specs/<slug>/ with workflow-state.md initialised.
 argument-hint: <feature-slug> [AREA]
 allowed-tools: [Read, Edit, Write, Bash]
-model: sonnet
+model: haiku
 ---
 
 # /spec:start

--- a/.claude/commands/stock-taking/start.md
+++ b/.claude/commands/stock-taking/start.md
@@ -2,7 +2,7 @@
 description: Stock-taking Track — Bootstrap. Scaffold a new project folder under stock-taking/<slug>/ with stock-taking-state.md initialised.
 argument-hint: <project-slug>
 allowed-tools: [Read, Edit, Write, Bash]
-model: sonnet
+model: haiku
 ---
 
 # /stock:start


### PR DESCRIPTION
## Summary

- Downgrade `model: sonnet` → `model: haiku` for 10 trivial bootstrap commands (`*/start.md`).
- Removes a hard failure for users without **1M-context tier** entitlement: harness was routing `sonnet` to a 1M-context model and emitting `API Error: Extra usage is required for 1M context`, which broke `/spec:start` and the other scaffolders end-to-end.
- Bootstrap procedures are mechanical (slug validation, `mkdir -p`, template copy, summary print). Haiku 4.5 handles them without quality loss; reasoning-heavy stages (`/spec:design`, `/spec:specify`, `/spec:implement`, `/spec:review`, etc.) keep their existing model.

## Files

- `.claude/commands/spec/start.md`
- `.claude/commands/discovery/start.md`
- `.claude/commands/design/start.md`
- `.claude/commands/sales/start.md`
- `.claude/commands/project/start.md`
- `.claude/commands/portfolio/start.md`
- `.claude/commands/scaffold/start.md`
- `.claude/commands/stock-taking/start.md`
- `.claude/commands/quality/start.md`
- `.claude/commands/roadmap/start.md`

## Why not bump session `/model` instead

Session `/model` toggle is a per-user workaround. This PR is the durable repo fix so adopters of the template don't trip the same failure on first contact.

## Test plan

- [x] Local `npm run verify` green (24.7 s).
- [ ] CI `verify` green on PR.
- [ ] Manual smoke: invoke `/spec:start <slug>` on a standard-context-tier session and confirm it scaffolds without API error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)