### PR TITLE
fix(scripts): improve worktree prune guidance

### DIFF
--- a/docs/scripts/lib/doctor/type-aliases/WorktreeHygieneInput.md
+++ b/docs/scripts/lib/doctor/type-aliases/WorktreeHygieneInput.md
@@ -22,6 +22,12 @@
 
 ***
 
+### registeredWorktreeBranches?
+
+> `optional` **registeredWorktreeBranches?**: `Record`\<`string`, `string`\>
+
+***
+
 ### registeredWorktrees
 
 > **registeredWorktrees**: `string`[]

--- a/scripts/doctor.ts
+++ b/scripts/doctor.ts
@@ -125,16 +125,14 @@ function checkWorktrees(): Check {
       const result = run("git", ["worktree", "list", "--porcelain"]);
       if (result.status !== 0) return { name: "worktrees", status: "fail", detail: "git worktree list failed" };
 
-      const registeredWorktrees = result.stdout
-        .split(/\r?\n/)
-        .filter((line) => line.startsWith("worktree "))
-        .map((line) => line.slice("worktree ".length));
+      const { registeredWorktrees, registeredWorktreeBranches } = parseWorktreePorcelain(result.stdout);
       const worktreeDirectories = worktreeDirectoryNames();
       const mergedBranches = mergedLocalBranches();
       const branch = run("git", ["branch", "--show-current"]);
 
       return worktreeHygieneCheck({
         registeredWorktrees,
+        registeredWorktreeBranches,
         worktreeDirectories,
         mergedBranches,
         currentBranch: branch.status === 0 ? firstLine(branch.stdout) : "",
@@ -192,6 +190,28 @@ function worktreeDirectoryNames(): string[] {
     .readdirSync(worktreesPath, { withFileTypes: true })
     .filter((entry) => entry.isDirectory())
     .map((entry) => entry.name);
+}
+
+function parseWorktreePorcelain(output: string): {
+  registeredWorktrees: string[];
+  registeredWorktreeBranches: Record<string, string>;
+} {
+  const registeredWorktrees: string[] = [];
+  const registeredWorktreeBranches: Record<string, string> = {};
+  let currentPath = "";
+
+  for (const line of output.split(/\r?\n/)) {
+    if (line.startsWith("worktree ")) {
+      currentPath = line.slice("worktree ".length);
+      registeredWorktrees.push(currentPath);
+      continue;
+    }
+    if (currentPath && line.startsWith("branch ")) {
+      registeredWorktreeBranches[currentPath] = line.slice("branch ".length).replace(/^refs\/heads\//, "");
+    }
+  }
+
+  return { registeredWorktrees, registeredWorktreeBranches };
 }
 
 function mergedLocalBranches(): string[] {

--- a/scripts/lib/doctor.ts
+++ b/scripts/lib/doctor.ts
@@ -20,6 +20,7 @@ export type BranchReadinessInput = {
 
 export type WorktreeHygieneInput = {
   registeredWorktrees: string[];
+  registeredWorktreeBranches?: Record<string, string>;
   worktreeDirectories: string[];
   mergedBranches: string[];
   currentBranch: string;
@@ -199,14 +200,30 @@ export function branchReadinessCheck(input: BranchReadinessInput): CheckResult {
  */
 export function worktreeHygieneCheck(input: WorktreeHygieneInput): CheckResult {
   const registeredNames = new Set(input.registeredWorktrees.map((entry) => normalizeWorktreeName(entry)).filter(Boolean));
+  const registeredBranches = input.registeredWorktreeBranches || {};
   const unregisteredDirectories = input.worktreeDirectories.filter((directory) => !registeredNames.has(directory));
   const staleBranches = input.mergedBranches.filter(
     (branch) => branch !== input.currentBranch && branch !== "main" && branch !== "develop",
   );
+  const registeredStaleWorktrees = input.registeredWorktrees
+    .map((worktreePath) => ({
+      path: worktreePath,
+      name: normalizeWorktreeName(worktreePath),
+      branch: registeredBranches[worktreePath] || "",
+    }))
+    .filter((entry) => entry.branch && staleBranches.includes(entry.branch));
+  const registeredStaleBranches = new Set(registeredStaleWorktrees.map((entry) => entry.branch));
 
   const warnings = [
-    ...unregisteredDirectories.map((directory) => `.worktrees/${directory} is not registered`),
-    ...staleBranches.map((branch) => `${branch} is already merged into origin/main`),
+    ...unregisteredDirectories.map(
+      (directory) => `.worktrees/${directory} is not registered (branch unknown; merge state unknown)`,
+    ),
+    ...registeredStaleWorktrees.map(
+      (entry) => `.worktrees/${entry.name} uses ${entry.branch}, already merged into origin/main`,
+    ),
+    ...staleBranches
+      .filter((branch) => !registeredStaleBranches.has(branch))
+      .map((branch) => `${branch} is already merged into origin/main`),
   ];
 
   if (warnings.length > 0) {
@@ -214,7 +231,7 @@ export function worktreeHygieneCheck(input: WorktreeHygieneInput): CheckResult {
       name: "worktrees",
       status: "warn",
       detail: `${input.registeredWorktrees.length} registered; ${warnings.length} hygiene warning(s)`,
-      hint: `${warnings.join("; ")}. After merged PRs are confirmed, remove stale worktrees/branches with the cleanup workflow.`,
+      hint: `${warnings.join("; ")}. Suggested action: run \`git worktree prune\`, then remove confirmed stale worktrees/branches with the cleanup workflow.`,
     };
   }
 

--- a/templates/release-notes-template.md
+++ b/templates/release-notes-template.md
@@ -95,3 +95,4 @@ How to confirm the release is healthy in production.
 - [ ] Rollback plan documented.
 - [ ] Observability hooks in place.
 - [ ] Communication plan ready.
+- [ ] Merged worktrees pruned (`git worktree prune`) and stale topic worktrees/branches cleaned up.

--- a/tests/scripts/doctor.test.ts
+++ b/tests/scripts/doctor.test.ts
@@ -491,20 +491,26 @@ test("worktreeHygieneCheck warns for unregistered .worktrees directories", () =>
 
   assert.equal(result.status, "warn");
   assert.equal(result.detail, "2 registered; 1 hygiene warning(s)");
-  assert.match(result.hint || "", /\.worktrees\/stale-empty is not registered/);
+  assert.match(result.hint || "", /\.worktrees\/stale-empty is not registered \(branch unknown; merge state unknown\)/);
+  assert.match(result.hint || "", /git worktree prune/);
 });
 
-test("worktreeHygieneCheck warns for merged local branches", () => {
+test("worktreeHygieneCheck warns for merged local branches and registered stale worktrees", () => {
   const result = worktreeHygieneCheck({
-    registeredWorktrees: ["/repo"],
+    registeredWorktrees: ["/repo", "/repo/.worktrees/old"],
+    registeredWorktreeBranches: {
+      "/repo/.worktrees/old": "feat/old",
+    },
     worktreeDirectories: [],
-    mergedBranches: ["main", "feat/old", "feat/current"],
+    mergedBranches: ["main", "feat/old", "feat/other", "feat/current"],
     currentBranch: "feat/current",
   });
 
   assert.equal(result.status, "warn");
-  assert.equal(result.detail, "1 registered; 1 hygiene warning(s)");
-  assert.match(result.hint || "", /feat\/old is already merged into origin\/main/);
+  assert.equal(result.detail, "2 registered; 2 hygiene warning(s)");
+  assert.match(result.hint || "", /\.worktrees\/old uses feat\/old, already merged into origin\/main/);
+  assert.match(result.hint || "", /feat\/other is already merged into origin\/main/);
+  assert.match(result.hint || "", /git worktree prune/);
 });
 
 function tempRepo(): string {


### PR DESCRIPTION
## Summary

- Parse `git worktree list --porcelain` branch metadata so `doctor` can report registered stale worktrees with their branch and merged state.
- Keep unregistered `.worktrees/*` directories visible with explicit unknown branch/merge state wording.
- Add a `git worktree prune` suggested action to the worktree hygiene hint.
- Add the worktree-prune cleanup reminder to the release notes quality gate.

Closes #199.

## Verification

- `npm run test:scripts -- tests/scripts/doctor.test.ts`
- `npm run check:script-docs`
- `npm run verify`

## Known limitations

- Unregistered physical directories cannot expose a branch name through `git worktree list`; doctor reports their branch and merge state as unknown until they are inspected or removed manually.