### PR TITLE
docs(product-box): reallocate ADR slot to 0023

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -40,6 +40,7 @@ Records of architecturally significant decisions. Format follows Michael Nygard'
 ## Conventions
 
 - Files are named `NNNN-imperative-title.md`. Numbers are zero-padded, monotonic, never reused.
+- Long-lived implementation plans should use `ADR-NEXT` until execution, or re-check the next free number immediately before opening the PR that files the ADR. Do not reserve numeric slots in stale plans without verifying the index.
 - Title is in the imperative mood: *"Use PostgreSQL"*, not *"PostgreSQL was chosen"*.
 - Status is one of: `Proposed`, `Accepted`, `Deprecated`, `Superseded by ADR-NNNN`.
 - ADR **bodies** are immutable. To change a decision, supersede it; only the predecessor's `status` and `superseded-by` pointer fields may be updated.

--- a/docs/superpowers/plans/2026-05-01-product-box.md
+++ b/docs/superpowers/plans/2026-05-01-product-box.md
@@ -35,7 +35,7 @@ sites/box/styles.css                               box-page styles (lifts brand 
 sites/box/og-card.svg                              static social-share image
 sites/box/README.md                                folder entry doc
 docs/product-box.md                                methodology doc
-docs/adr/0019-add-product-box-feature.md           ADR
+docs/adr/0023-add-product-box-feature.md           ADR
 
 scripts/lib/product-box/types.ts                   TypeScript types for box.yml
 scripts/lib/product-box/validate.ts                schema validator
@@ -121,15 +121,15 @@ Expected: both paths exist. No copy or restore needed — these are tracked on `
 
 If either file is missing, the design PR has not yet merged; abort and wait for it to land before continuing.
 
-### Task 1.2: File ADR-0019
+### Task 1.2: File ADR-0023
 
 **Files:**
-- Create: `docs/adr/0019-add-product-box-feature.md`
+- Create: `docs/adr/0023-add-product-box-feature.md`
 
 - [ ] **Step 1: Run the new-adr skill or copy the template**
 
 ```bash
-cp templates/adr-template.md docs/adr/0019-add-product-box-feature.md
+cp templates/adr-template.md docs/adr/0023-add-product-box-feature.md
 ```
 
 - [ ] **Step 2: Fill ADR content**
@@ -138,7 +138,7 @@ Replace the template body with:
 
 ```markdown
 ---
-id: ADR-0019
+id: ADR-0023
 title: Add product-box feature for early-stage envisioned-product visualization
 status: accepted
 date: 2026-05-01
@@ -153,7 +153,7 @@ superseded-by: []
 tags: [product-page, visualization, agent, skill]
 ---
 
-# ADR-0019 — Add product-box feature for early-stage envisioned-product visualization
+# ADR-0023 — Add product-box feature for early-stage envisioned-product visualization
 
 ## Status
 
@@ -242,7 +242,7 @@ Cons: no agent judgment for tone or brand voice; hard to extend; contradicts exi
 npm run fix:adr-index
 ```
 
-Expected: `docs/adr/README.md` regenerated with ADR-0019 entry.
+Expected: `docs/adr/README.md` regenerated with ADR-0023 entry.
 
 - [ ] **Step 4: Verify ADR check passes**
 
@@ -255,8 +255,8 @@ Expected: exit 0, no output errors.
 - [ ] **Step 5: Commit**
 
 ```bash
-git add docs/adr/0019-add-product-box-feature.md docs/adr/README.md
-git commit -m "docs(adr): file ADR-0019 for product-box feature"
+git add docs/adr/0023-add-product-box-feature.md docs/adr/README.md
+git commit -m "docs(adr): file ADR-0023 for product-box feature"
 ```
 
 ### Task 1.3: Write methodology doc
@@ -323,7 +323,7 @@ The box agent owns this slot. The product-page agent must not strip or rewrite c
 
 ## See also
 
-- ADR-0019 — `docs/adr/0019-add-product-box-feature.md`
+- ADR-0023 — `docs/adr/0023-add-product-box-feature.md`
 - Spec — `docs/superpowers/specs/2026-05-01-product-box-design.md`
 - Plan — `docs/superpowers/plans/2026-05-01-product-box.md`
 - Skill — `.claude/skills/product-box/SKILL.md`
@@ -1497,7 +1497,7 @@ You do **not** resolve sources, prompt the user, or write `box.yml`. Those are t
 - `.claude/skills/product-box/SKILL.md` (contract).
 - `.claude/skills/specorator-design/SKILL.md` (brand tokens).
 - `docs/superpowers/specs/2026-05-01-product-box-design.md` (spec).
-- `docs/adr/0019-add-product-box-feature.md` (decision).
+- `docs/adr/0023-add-product-box-feature.md` (decision).
 
 ## Brand dependency
 
@@ -1636,7 +1636,7 @@ The `orchestrate` skill calls `/product:box` after `/spec:idea`, `/discovery:han
 - Don't strip or rewrite `sites/index.html` content outside the slot markers.
 - Don't invent tokens, customer logos, integrations, metrics, or roadmap commitments.
 - Don't bypass the schema. Box is concept-tier but still bounded.
-- Don't carry feature-level scope. One box per repo, project-level only (per ADR-0019).
+- Don't carry feature-level scope. One box per repo, project-level only (per ADR-0023).
 ```
 
 - [ ] **Step 2: Write `README.md`**
@@ -1654,7 +1654,7 @@ entry_point: false
 See `SKILL.md` (this folder) for the contract and procedure. Pairs with `.claude/agents/product-box-designer.md` (rendering) and `scripts/lib/product-box/` (libs).
 
 Spec: `docs/superpowers/specs/2026-05-01-product-box-design.md`.
-ADR: `docs/adr/0019-add-product-box-feature.md`.
+ADR: `docs/adr/0023-add-product-box-feature.md`.
 Methodology: `docs/product-box.md`.
 ```
 
@@ -2104,7 +2104,7 @@ Standalone, deployable visualization of the envisioned product. Owned by the `pr
 
 Do not edit the HTML, CSS, or SVG by hand — they are regenerated from `box.yml` by the agent. Edit `box.yml`, then run `/product:box`.
 
-See `docs/product-box.md` for the methodology, `docs/adr/0019-add-product-box-feature.md` for the decision, and `docs/superpowers/specs/2026-05-01-product-box-design.md` for the spec.
+See `docs/product-box.md` for the methodology, `docs/adr/0023-add-product-box-feature.md` for the decision, and `docs/superpowers/specs/2026-05-01-product-box-design.md` for the spec.
 ```
 
 - [ ] **Step 3: Compute skill hash and patch box.yml**
@@ -2253,7 +2253,7 @@ Under `## Workflow rules` (or a new `## Public surface` section if it makes more
 In the existing skills/track table, add:
 
 ```markdown
-| **Product box** | new project, brief written, envisioned product visualization | `.claude/skills/product-box/SKILL.md` | `/product:box` | `docs/product-box.md` (ADR-0019) |
+| **Product box** | new project, brief written, envisioned product visualization | `.claude/skills/product-box/SKILL.md` | `/product:box` | `docs/product-box.md` (ADR-0023) |
 ```
 
 - [ ] **Step 4: docs/sink.md — register destinations**

--- a/docs/superpowers/specs/2026-05-01-product-box-design.md
+++ b/docs/superpowers/specs/2026-05-01-product-box-design.md
@@ -3,7 +3,7 @@
 **Status:** Draft for review.
 **Date:** 2026-05-01.
 **Author:** Brainstorming session, Specorator template repo.
-**Related ADR:** `docs/adr/0019-add-product-box-feature.md` (to be filed alongside implementation).
+**Related ADR:** `docs/adr/0023-add-product-box-feature.md` (to be filed alongside implementation).
 **Pairs with:** [`product-page` skill](../../../.claude/skills/product-page/SKILL.md), [`product-page-designer` agent](../../../.claude/agents/product-page-designer.md).
 
 ---
@@ -45,7 +45,7 @@ sites/box/styles.css                        box-specific styles (lifts specorato
 sites/box/og-card.svg                       static SVG mirror of the box front face for og:image
 sites/index.html                            product page; gets <!-- product-box-embed --> slot + card link
 docs/product-box.md                         methodology doc
-docs/adr/0019-add-product-box-feature.md    decision record
+docs/adr/0023-add-product-box-feature.md    decision record
 ```
 
 ### 4.2 Skill-orchestrates / agent-renders split
@@ -243,7 +243,7 @@ sites/box/index.html
 sites/box/styles.css
 sites/box/og-card.svg
 docs/product-box.md
-docs/adr/0019-add-product-box-feature.md
+docs/adr/0023-add-product-box-feature.md
 tests/scripts/product-box/fixtures/*.yml
 tests/scripts/product-box/snapshots/*.html
 tests/scripts/product-box/README.md
@@ -266,7 +266,7 @@ docs/sink.md                           + sites/box/ + box.yml destinations
 
 ## 11. ADR
 
-ADR-0019 records:
+ADR-0023 records:
 
 - Rationale — early-stage envisioned-product visualization fills the gap before product page is grounded.
 - New agent role + new slash namespace `product:box` (load-bearing per AGENTS.md).


### PR DESCRIPTION
## Summary

- Reallocate the product-box plan and design spec from the occupied ADR-0019 slot to ADR-0023.
- Update all product-box ADR path references to `docs/adr/0023-add-product-box-feature.md`.
- Add an ADR index convention note to avoid reserving stale numeric slots in long-lived plans.

Closes #187.

## Verification

- `npm run check:links`
- `npm run check:adr-index`
- `npm run check:frontmatter`
- `npm run verify`

## Known limitations

- This PR corrects the tracked plan/spec references. The actual ADR file is still intentionally filed later by product-box Chunk 1.