### PR TITLE
docs(adr): accept shipped workflow decisions

### DIFF
--- a/docs/adr/0010-shard-glossary-into-one-file-per-term.md
+++ b/docs/adr/0010-shard-glossary-into-one-file-per-term.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-0010
 title: Shard the glossary into one file per term under docs/glossary/
-status: proposed
+status: accepted
 date: 2026-04-28
 deciders:
   - human
@@ -20,7 +20,7 @@ tags: [docs, glossary, terminology, ubiquitous-language]
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/docs/adr/0011-add-project-scaffolding-track.md
+++ b/docs/adr/0011-add-project-scaffolding-track.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-0011
 title: Add a Project Scaffolding Track for source-led template adoption
-status: proposed
+status: accepted
 date: 2026-04-28
 deciders:
   - human
@@ -20,7 +20,7 @@ tags: [workflow, onboarding, scaffolding, documentation]
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/docs/adr/0012-add-roadmap-management-track.md
+++ b/docs/adr/0012-add-roadmap-management-track.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-0012
 title: Add a Roadmap Management Track for product and project planning
-status: proposed
+status: accepted
 date: 2026-04-28
 deciders:
   - human
@@ -21,7 +21,7 @@ tags: [workflow, roadmap, product-management, project-management, stakeholder-ma
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/docs/adr/0015-codify-codex-pr-review-loop.md
+++ b/docs/adr/0015-codify-codex-pr-review-loop.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-0015
 title: Codify a bounded Codex review loop on every pull request
-status: proposed
+status: accepted
 date: 2026-05-01
 deciders:
   - human
@@ -21,7 +21,7 @@ tags: [workflow, github, review, automation, codex]
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/docs/adr/0016-design-system-as-skill.md
+++ b/docs/adr/0016-design-system-as-skill.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-0016
 title: Adopt the specorator-design skill as the canonical brand source
-status: proposed
+status: accepted
 date: 2026-05-01
 deciders:
   - human
@@ -20,7 +20,7 @@ tags: [design-system, brand, skill, sites, tokens]
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/docs/adr/0017-adopt-inputs-folder-as-canonical-ingestion-zone.md
+++ b/docs/adr/0017-adopt-inputs-folder-as-canonical-ingestion-zone.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-0017
 title: Adopt `inputs/` as the canonical ingestion folder for new work packages
-status: proposed
+status: accepted
 date: 2026-05-01
 deciders:
   - human
@@ -28,7 +28,7 @@ tags: [workflow, intake, ingestion, conventions, methodology]
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/docs/adr/0018-sites-consumes-tokens.md
+++ b/docs/adr/0018-sites-consumes-tokens.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-0018
 title: Flip sites/styles.css to consume design-system tokens
-status: proposed
+status: accepted
 date: 2026-05-01
 deciders:
   - human
@@ -19,7 +19,7 @@ tags: [design-system, brand, sites, tokens, refactor]
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/docs/adr/0019-add-design-track.md
+++ b/docs/adr/0019-add-design-track.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-0019
 title: Add a Design Track as an opt-in first-party workflow
-status: proposed
+status: accepted
 date: 2026-05-01
 deciders:
   - human
@@ -20,7 +20,7 @@ tags: [design-system, brand, track, workflow, design]
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,16 +22,16 @@ Records of architecturally significant decisions. Format follows Michael Nygard'
 | [0007](0007-add-stock-taking-track-for-legacy-projects.md) | Add a Stock-taking Track for projects that build on existing systems | Accepted |
 | [0008](0008-add-project-manager-track.md) | Add an opt-in Project Manager Track based on P3.Express | Accepted |
 | [0009](0009-add-portfolio-manager-role.md) | Add opt-in Portfolio Manager role and P5 Express portfolio track | Accepted |
-| [0010](0010-shard-glossary-into-one-file-per-term.md) | Shard the glossary into one file per term under docs/glossary/ | Proposed |
-| [0011](0011-add-project-scaffolding-track.md) | Add a Project Scaffolding Track for source-led template adoption | Proposed |
-| [0012](0012-add-roadmap-management-track.md) | Add a Roadmap Management Track for product and project planning | Proposed |
+| [0010](0010-shard-glossary-into-one-file-per-term.md) | Shard the glossary into one file per term under docs/glossary/ | Accepted |
+| [0011](0011-add-project-scaffolding-track.md) | Add a Project Scaffolding Track for source-led template adoption | Accepted |
+| [0012](0012-add-roadmap-management-track.md) | Add a Roadmap Management Track for product and project planning | Accepted |
 | [0013](0013-add-obsidian-as-ui-layer.md) | Add Obsidian as an opt-in UI layer | Proposed |
 | [0014](0014-shard-log-shaped-artifacts-for-bases.md) | Shard log-shaped artifacts for Bases | Proposed |
-| [0015](0015-codify-codex-pr-review-loop.md) | Codify a bounded Codex review loop on every pull request | Proposed |
-| [0016](0016-design-system-as-skill.md) | Adopt the specorator-design skill as the canonical brand source | Proposed |
-| [0017](0017-adopt-inputs-folder-as-canonical-ingestion-zone.md) | Adopt `inputs/` as the canonical ingestion folder for new work packages | Proposed |
-| [0018](0018-sites-consumes-tokens.md) | Flip sites/styles.css to consume design-system tokens | Proposed |
-| [0019](0019-add-design-track.md) | Add a Design Track as an opt-in first-party workflow | Proposed |
+| [0015](0015-codify-codex-pr-review-loop.md) | Codify a bounded Codex review loop on every pull request | Accepted |
+| [0016](0016-design-system-as-skill.md) | Adopt the specorator-design skill as the canonical brand source | Accepted |
+| [0017](0017-adopt-inputs-folder-as-canonical-ingestion-zone.md) | Adopt `inputs/` as the canonical ingestion folder for new work packages | Accepted |
+| [0018](0018-sites-consumes-tokens.md) | Flip sites/styles.css to consume design-system tokens | Accepted |
+| [0019](0019-add-design-track.md) | Add a Design Track as an opt-in first-party workflow | Accepted |
 | [0020](0020-v05-release-branch-strategy.md) | Adopt Shape A with release/vX.Y.Z branches for v0.5 releases | Accepted |
 | [0021](0021-release-package-fresh-surface.md) | Ship the released template package as a fresh-surface starter | Accepted |
 | [0022](0022-add-issue-breakdown-track.md) | Adopt issue-breakdown track for parallelising post-tasks issue work | Proposed |


### PR DESCRIPTION
## Summary

- Mark shipped ADRs 0010, 0011, 0012, 0015, 0016, 0017, 0018, and 0019 as accepted.
- Regenerate the ADR index so the status table matches the files.
- Leave ADR-0013 and ADR-0014 proposed because #190 identifies them as speculative and needing explicit product decisions.

Partially closes #190; remaining decision items are ADR-0013 and ADR-0014.

## Verification

- `npm run check:adr-index`
- `npm run verify`

## Known limitations

- This PR intentionally does not decide the Obsidian UI layer or log-sharding ADRs. Those need a human direction: defer, close, accept, or supersede.