### PR TITLE
docs: mention npm test in release notes template

### DIFF
--- a/specs/version-0-5-plan/review.md
+++ b/specs/version-0-5-plan/review.md
@@ -91,7 +91,7 @@ Each article checked against the diff:
 - **IV — Quality gates.** All 18 verify gates green. Two-layer validation honoured: deterministic checks (typecheck, tests, schema, link, traceability, frontmatter) + critic-agent review (Codex on every PR; the round-by-round narrative shows real findings, not rubber-stamping).
 - **V — Traceability.** Every artifact links upstream. Some downstream — see traceability matrix. No requirement is orphan; no test is orphan.
 - **VI — Agent specialisation.** Boundaries respected. Review-fix commits are owned by `orchestrator` per the documented pattern. No agent broadened its tool list.
-- **VII — Human oversight.** Two open items are explicitly Decider-owned (CLAR-V05-003 + remote workflow dispatch). No agent pre-empted either.
+- **VII — Human oversight.** Two open items are explicitly Decider-owned (CLAR-V05-003 + remote workflow dispatch). No agent preempted either.
 - **VIII — Plain language.** Functional requirements use EARS notation; ADRs use active voice. Verified by `check:frontmatter` + EARS coverage 100% in quality metrics.
 - **IX — Reversibility.** Operator-authorised remote dispatch is correctly out of agent scope. The release workflow itself enforces irreversibility through `dry_run: true` default + `confirm` gate + `--verify-tag` defence-in-depth.
 - **X — Iteration.** REQ-V05-012 escalation is a textbook Article X application: implementation surfaced a missing requirement → spec updated first → propagated forward consistently.

--- a/templates/release-notes-template.md
+++ b/templates/release-notes-template.md
@@ -61,7 +61,7 @@ One paragraph for end users / stakeholders. What's new and why they care.
 
 How to confirm the release is healthy in production.
 
-1. …
+1. Run the standard script test suite with `npm test` when the release changes scripts or validators.
 2. …
 
 ## Rollback plan


### PR DESCRIPTION
## Summary

- Completes #211 by adding `npm test` to the release-notes template verification guidance.
- Confirmed current `package.json` on `origin/main` already includes the `test` alias delegating to `test:scripts`.
- The v0.3 retrospective already links the follow-up issue.

## Verification

- `npm test`
- `npm run verify`

## Linked issue

Closes #211

## Known limitations

- None.