### PR TITLE
docs: warn on implementation log task headings

### DIFF
--- a/specs/version-0-5-plan/review.md
+++ b/specs/version-0-5-plan/review.md
@@ -91,7 +91,7 @@ Each article checked against the diff:
 - **IV — Quality gates.** All 18 verify gates green. Two-layer validation honoured: deterministic checks (typecheck, tests, schema, link, traceability, frontmatter) + critic-agent review (Codex on every PR; the round-by-round narrative shows real findings, not rubber-stamping).
 - **V — Traceability.** Every artifact links upstream. Some downstream — see traceability matrix. No requirement is orphan; no test is orphan.
 - **VI — Agent specialisation.** Boundaries respected. Review-fix commits are owned by `orchestrator` per the documented pattern. No agent broadened its tool list.
-- **VII — Human oversight.** Two open items are explicitly Decider-owned (CLAR-V05-003 + remote workflow dispatch). No agent pre-empted either.
+- **VII — Human oversight.** Two open items are explicitly Decider-owned (CLAR-V05-003 + remote workflow dispatch). No agent preempted either.
 - **VIII — Plain language.** Functional requirements use EARS notation; ADRs use active voice. Verified by `check:frontmatter` + EARS coverage 100% in quality metrics.
 - **IX — Reversibility.** Operator-authorised remote dispatch is correctly out of agent scope. The release workflow itself enforces irreversibility through `dry_run: true` default + `confirm` gate + `--verify-tag` defence-in-depth.
 - **X — Iteration.** REQ-V05-012 escalation is a textbook Article X application: implementation surfaced a missing requirement → spec updated first → propagated forward consistently.

--- a/templates/implementation-log-template.md
+++ b/templates/implementation-log-template.md
@@ -18,6 +18,8 @@ A running record of *what* was implemented, *why* a deviation was taken, and *wh
 
 ## Entry template
 
+Avoid starting nested task subsections with a bare `### T-<AREA>-NNN` heading at column 0. Traceability validators treat that pattern as a task definition and may report duplicate-definition or area-validation failures. Use the dated entry heading below, or use a non-definition form such as `#### Task: T-<AREA>-NNN` inside an entry.
+
 ```
 ### YYYY-MM-DD — T-<AREA>-NNN — <short title>
 - **Files changed:** path1:lines, path2:lines


### PR DESCRIPTION
## Summary

- Completes #213 by adding implementation-log template guidance for nested task headings.
- Warns contributors that bare `### T-<AREA>-NNN` headings at column 0 can be interpreted as task definitions by traceability validation.
- Recommends the existing dated entry heading or `#### Task: T-<AREA>-NNN` for nested sections.

## Verification

- `npm run verify`

## Linked issue

Closes #213

## Known limitations

- None.