### PR TITLE
docs: clarify may-slice task traceability

### DIFF
--- a/specs/version-0-5-plan/review.md
+++ b/specs/version-0-5-plan/review.md
@@ -91,7 +91,7 @@ Each article checked against the diff:
 - **IV — Quality gates.** All 18 verify gates green. Two-layer validation honoured: deterministic checks (typecheck, tests, schema, link, traceability, frontmatter) + critic-agent review (Codex on every PR; the round-by-round narrative shows real findings, not rubber-stamping).
 - **V — Traceability.** Every artifact links upstream. Some downstream — see traceability matrix. No requirement is orphan; no test is orphan.
 - **VI — Agent specialisation.** Boundaries respected. Review-fix commits are owned by `orchestrator` per the documented pattern. No agent broadened its tool list.
-- **VII — Human oversight.** Two open items are explicitly Decider-owned (CLAR-V05-003 + remote workflow dispatch). No agent pre-empted either.
+- **VII — Human oversight.** Two open items are explicitly Decider-owned (CLAR-V05-003 + remote workflow dispatch). No agent preempted either.
 - **VIII — Plain language.** Functional requirements use EARS notation; ADRs use active voice. Verified by `check:frontmatter` + EARS coverage 100% in quality metrics.
 - **IX — Reversibility.** Operator-authorised remote dispatch is correctly out of agent scope. The release workflow itself enforces irreversibility through `dry_run: true` default + `confirm` gate + `--verify-tag` defence-in-depth.
 - **X — Iteration.** REQ-V05-012 escalation is a textbook Article X application: implementation surfaced a missing requirement → spec updated first → propagated forward consistently.

--- a/templates/tasks-template.md
+++ b/templates/tasks-template.md
@@ -18,7 +18,7 @@ Each task ≤ ~½ day, has a stable ID, references ≥ 1 requirement, and has a 
 
 > **TDD ordering:** test tasks for a requirement come **before** the implementation task for that requirement.
 
-> **"May slice" annotation:** A task that touches more than one independent code path or artifact may legitimately ship as several PRs rather than one. Mark such tasks with 🪓 in the heading (in addition to the task-type emoji), and add a `**Slice plan:**` line under the task sketching the expected slices. PR planners should expect the task to land in pieces. (Convention filed by the v0.3 retrospective after multiple plan-level tasks shipped in slices that were not anticipated by the original `tasks.md`. See [`specs/version-0-3-plan/retrospective.md`](../specs/version-0-3-plan/retrospective.md) for the originating examples.)
+> **"May slice" annotation:** A task that touches more than one independent code path or artifact may legitimately ship as several PRs rather than one. Mark such tasks with 🪓 in the heading (in addition to the task-type emoji), and add a `**Slice plan:**` line under the task sketching the expected slices. PR planners should expect the task to land in pieces; each slice PR must reference the parent task ID and name the slice it completes so traceability stays attached to the original task. (Convention filed by the v0.3 retrospective after multiple plan-level tasks shipped in slices that were not anticipated by the original `tasks.md`. See [`specs/version-0-3-plan/retrospective.md`](../specs/version-0-3-plan/retrospective.md) for the originating examples.)
 
 ## Legend
 


### PR DESCRIPTION
## Summary

- Completes #217 by tightening the may-slice task guidance in `templates/tasks-template.md`.
- Keeps the existing marker and slice-plan convention.
- Adds explicit PR handoff guidance: each slice PR must reference the parent task ID and name the completed slice so traceability remains attached to the original task.

## Verification

- `npm run verify`

## Linked issue

Closes #217

## Known limitations

- None.