### PR TITLE
docs: document meta-feature skip convention

### DIFF
--- a/docs/specorator.md
+++ b/docs/specorator.md
@@ -237,7 +237,9 @@ artifacts:                             # status enum: pending | in-progress | co
   retrospective.md: pending
 ```
 
-Plus the body sections (Skips, Blocks, Hand-off notes, Open clarifications) per the canonical template at [`templates/workflow-state-template.md`](../templates/workflow-state-template.md).
+Plus the body sections (Notes on meta-features, Skips, Blocks, Hand-off notes, Open clarifications) per the canonical template at [`templates/workflow-state-template.md`](../templates/workflow-state-template.md).
+
+Meta-features are plan-level features whose implementation is a sequence of sub-task PRs rather than a single source tree. They may skip Stage 7-9 canonical artifacts (`implementation-log.md`, `test-plan.md`, `test-report.md`, `review.md`, `traceability.md`) only when each sub-task PR carries its own implementation evidence, tests, review, and trace links. The `## Skips` section must name each skipped artifact, explain the rationale, and point to the per-PR evidence. See [`templates/_shared/state-file-sections.md`](../templates/_shared/state-file-sections.md) for the full rule and [`specs/version-0-3-plan/workflow-state.md`](../specs/version-0-3-plan/workflow-state.md) for the precedent.
 
 ### 5.2 Orchestrator responsibilities
 

--- a/templates/workflow-state-template.md
+++ b/templates/workflow-state-template.md
@@ -41,6 +41,10 @@ artifacts:              # canonical machine-readable map; the table below is its
 
 > **Statuses:** `pending` | `in-progress` | `complete` | `skipped` | `blocked`. Section semantics + status enums: see [`_shared/state-file-sections.md`](./_shared/state-file-sections.md).
 
+## Notes on meta-features
+
+Plan-level meta-features may skip Stage 7-9 canonical artifacts when each sub-task ships as its own PR with implementation evidence, tests, review, and trace links. Record the rationale under `## Skips` and point to the per-PR evidence. See [`_shared/state-file-sections.md`](./_shared/state-file-sections.md) for the full rule.
+
 ## Skips
 
 - e.g., `idea.md` — trivial copy fix


### PR DESCRIPTION
## Summary

- Adds an explicit `## Notes on meta-features` section to `templates/workflow-state-template.md`.
- Updates `docs/specorator.md` to document when Stage 7-9 canonical artifacts may be skipped for plan-level meta-features.
- Points readers at the existing shared state-file rule and the v0.3 workflow-state precedent.

## Verification

- `npm run check:content`
- `npm run verify`

## Links

- Addresses #212