### PR TITLE
chore(release): v0.5 Stage 10 release-notes + package-contract accepted

### DIFF
--- a/specs/version-0-5-plan/package-contract.md
+++ b/specs/version-0-5-plan/package-contract.md
@@ -3,7 +3,7 @@ id: PKG-CONTRACT-V05-001
 title: Version 0.5 package contract
 stage: implementation
 feature: version-0-5-plan
-status: draft
+status: accepted
 owner: pm
 inputs:
   - PRD-V05-001
@@ -176,3 +176,4 @@ Publishing is gated by explicit human authorization in the workflow dispatch inp
 | 2026-05-02 | Initial draft — T-V05-002 deliverable. Package identity, contents, exclusions, version source, consumer promise, install path, and open questions established. | pm |
 | 2026-05-02 | Clarified §3 lockfile shipping: the publication-canonical lockfile is `npm-shrinkwrap.json` (staged from `package-lock.json` by the release workflow), not `package-lock.json` directly. `npm pack` strips `package-lock.json` even when listed in `files`. T-V05-007 implementation surfaced the gap; resolves Codex round-3 P2 on PR #160 (lockfile actually ships under the canonical publication name, byte-equal to the codebase `package-lock.json`). | orchestrator |
 | 2026-05-02 | OQ-V05-003 closed by T-V05-013 — strip-and-stubify packaging step is now automated via `scripts/build-release-archive.ts` (with `scripts/lib/release-archive-builder.ts` and `scripts/lib/release-stubify.ts`). `.github/workflows/release.yml` step 5 calls the builder before `npm pack`; step 10 publishes the byte-identical staged tarball so the published archive equals the GitHub Release asset and reflects the build-time transform. Maintainers no longer strip manually. | dev |
+| 2026-05-02 | Status promoted from `draft` to `accepted`. All three open questions closed: OQ-V05-001 closed (repository is public, `publishConfig.access: "public"` confirmed); OQ-V05-002 closed by T-V05-007 (`package.json#files` glob aligned with `EXPECTED_PACKAGE_FILES`); OQ-V05-003 closed by T-V05-013 (build-time transform automated). Resolves review finding R-V05-005 (REVIEW-V05-001). | release-manager |

--- a/specs/version-0-5-plan/release-notes.md
+++ b/specs/version-0-5-plan/release-notes.md
@@ -1,0 +1,150 @@
+---
+id: RELEASE-V05-001
+title: Specorator v0.5.0 — Release and distribution
+stage: release
+feature: version-0-5-plan
+version: 0.5.0
+status: draft
+owner: release-manager
+inputs:
+  - REVIEW-V05-001
+created: 2026-05-02
+updated: 2026-05-02
+---
+
+# Release notes — Specorator v0.5.0
+
+## Summary
+
+v0.5.0 adds the release and distribution infrastructure for Specorator. You can now publish a versioned release of the workflow template — as a GitHub Release with generated release notes and an attached tarball, and (when you choose to enable it) as an installable GitHub Package at `@luis85/agentic-workflow`. All publish operations are manually authorized: no version is cut or package pushed without an explicit operator decision and a confirm gate. The release package ships as a clean starter — intake folders empty, ADRs excluded, docs in stub form — so consumers who install it get a blank slate, not this repository's history.
+
+The `release/v0.5.0` branch carries the lifecycle release-notes finalization and `package-contract.md` status flip. Once this PR merges to `main` and the operator cuts the `v0.5.0` tag, the two-step publish sequence described below is ready to run.
+
+## Changes
+
+### Added
+
+- **Release workflow** (`.github/workflows/release.yml`): manual `workflow_dispatch` only. Inputs: `version`, `dry_run` (default `true`), `prerelease`, `draft`, `confirm`, `publish_package`. Includes a confirm gate that refuses to run any irreversible step unless `confirm == version`. Satisfies REQ-V05-002, SPEC-V05-002.
+- **Release readiness check** (`npm run check:release-readiness`): Layer 1 validates version, tag, changelog, `.github/release.yml` shape, `package.json` metadata against `package-contract.md`, workflow permissions, and v0.4 quality signals. Layer 2 runs the fresh-surface assertions against the candidate archive. Satisfies REQ-V05-007, REQ-V05-010, SPEC-V05-005, SPEC-V05-008.
+- **Fresh-surface build tool** (`npm run build:release-archive`): builds a staged tree under `.release-staging/` by filtering numbered ADRs, clearing intake folders, and converting every shipping `docs/**/*.md` to stub form. `npm pack ./.release-staging` (not `npm pack`) is the canonical pack invocation. Satisfies REQ-V05-012, SPEC-V05-010, ADR-0021.
+- **Prepack guard** (`scripts/release-prepack-guard.mjs`): refuses `npm pack @luis85/agentic-workflow` from any directory that lacks the staging marker, preventing accidental direct-pack of the repository root. Defence-in-depth per ADR-0021.
+- **Package contract** (`specs/version-0-5-plan/package-contract.md`): the accepted, human-reviewed contract for `@luis85/agentic-workflow` — registry target, package name, include list, exclude list (numbered ADRs, per-feature spec folders, all 10 intake folder hierarchies), version source, consumer promise, and install prerequisites. Satisfies REQ-V05-005, SPEC-V05-004, PKG-CONTRACT-V05-001.
+- **Generated release notes config** (`.github/release.yml`): 11 categories mapped from Conventional Commit PR-title types; excludes `dependabot` and `github-actions` author handles. Satisfies REQ-V05-003, REQ-V05-004, SPEC-V05-003.
+- **Release operator guide** (`docs/release-operator-guide.md`): runnable, version-by-version pre-conditions, dry-run path, stable-publish path, rollback rules, six failed-publish recovery scenarios (including the `gh release create` non-idempotency constraint), post-release cleanup, quick-reference command bundle, and diagnostic code table. Satisfies REQ-V05-008, SPEC-V05-006, NFR-V05-004, NFR-V05-005.
+- **Release package contents doc** (`docs/release-package-contents.md`): template-wide reference for the fresh-surface include/exclude enumeration (maintenance rule: any new intake folder must be added here and to ADR-0021 in the same PR). Satisfies SPEC-V05-007.
+- **ADR-0020**: Adopt Shape A with `release/vX.Y.Z` branches — `main` is the canonical tag source; `develop` is not introduced. Satisfies REQ-V05-001.
+- **ADR-0021**: Ship the released template package as a fresh-surface starter — docs as stubs, ADRs excluded, all 10 intake folders empty. Satisfies REQ-V05-012.
+- **Release scripts** in `scripts/` and `scripts/lib/`: `release-readiness.ts`, `release-package-contract.ts`, `release-archive-builder.ts`, `release-stubify.ts`, `release-staging-safety.ts`. All wired into `tools/automation-registry.yml`; typedoc shells in `docs/scripts/` regenerated.
+- **Automation registry entries** in `tools/automation-registry.yml`: `workflow:release`, `check:release-readiness`, `check:release-package-contents`, `build:release-archive`.
+- **Product page and public docs**: `sites/index.html` updated with a new FAQ item and step-1 mention of the GitHub Release and GitHub Package channels. `README.md`, `docs/specorator.md` §3.10, and `docs/release-package-contents.md` cross-referenced. Satisfies REQ-V05-009, SPEC-V05-007.
+
+### Changed
+
+- `package.json`: `name` → `@luis85/agentic-workflow`; `version` → `0.5.0`; added `publishConfig.registry`, `repository`, `files`, `description`, `license`, `homepage`, `bugs`, `keywords`, `author`; dropped `private: true`. The package is now npm-publish-ready.
+- `docs/branching.md`: documents the `release/vX.Y.Z` convention per ADR-0020.
+- `docs/specorator.md` §3.10: documents distribution channels and operator path.
+- `CHANGELOG.md`: `[v0.5.0]` entry promoted from `[Unreleased]`.
+- `tools/automation-registry.yml`: release workflow and readiness checks registered.
+
+### Removed
+
+Nothing removed in this release. `private: true` was removed from `package.json` as part of enabling publish.
+
+## User-visible impact
+
+**Template adopters (new users installing from GitHub Packages or cloning from a release tag):**
+
+- The first release of `@luis85/agentic-workflow` ships as a clean starter. Install via `npm install --save-dev @luis85/agentic-workflow` with the GitHub Packages auth prerequisites from `package-contract.md` §7. Manual file copy is the supported install path for v0.5; a scaffolder CLI is a post-v0.5 goal.
+- The published archive includes no numbered ADRs, no per-feature spec folders, and no in-flight workflow state. Intake folders (`specs/`, `inputs/`, `discovery/`, `projects/`, `portfolio/`, `roadmaps/`, `quality/`, `scaffolding/`, `stock-taking/`, `sales/`) ship empty. Your first feature's spec folder will be `specs/<your-feature>/`, not `specs/version-0-5-plan/`.
+- GitHub Packages requires authentication even for public packages. A GitHub Personal Access Token (Classic) with `read:packages` scope is required. See `package-contract.md` §7 for the exact `~/.npmrc` and `.npmrc` configuration.
+- No breaking changes to the workflow stages (1–11), slash commands, skill entry points, templates, or governance files. These surfaces are stable within major releases.
+
+**Maintainers and contributors:**
+
+- Every release from v0.5 forward goes through the operator guide (`docs/release-operator-guide.md`). The workflow enforces `dry_run: true` and `confirm` gate by default — a run cannot accidentally publish.
+- `npm pack` from the repository root is now blocked by the prepack guard. Use `npm run build:release-archive && npm pack ./.release-staging` instead (covered in §7.1 of the operator guide).
+- `package-contract.md` is now `accepted`; all three open questions (OQ-V05-001 to OQ-V05-003) are closed.
+
+**No action required** for existing users of the repository who work in topic branches: the workflow stages, agent prompts, verify gate, and CI are unchanged.
+
+## Readiness summary
+
+- Release readiness guide: not used (this release has no multi-stakeholder gate conditions or compliance risks that require the full readiness guide template; the review verdict and conditions summary below are sufficient).
+- Go/no-go verdict: **Approved with conditions met**. REVIEW-V05-001 verdict was "Approved with conditions" on 2026-05-02. Both Decider-owned conditions have been resolved:
+  1. CLAR-V05-003 closed by Decider — first publish is draft + prerelease, then promoted to stable (two-step path).
+  2. `RELEASE_CI_STATUS=green` and `RELEASE_VALIDATION_STATUS=green` repo vars set by Decider.
+- Quality metrics at review time: `overallScore` 97.1 / 100, maturity level 3 (Traceable), `requirementCoverage` 100%, `earsCoverage` 100%, 0 blockers. Note: `requirementsWithTests` metric reported 0 due to a tooling miscount (R-V05-001) — the actual test coverage is confirmed by 94/94 release-surface tests passing; a follow-up issue is filed against `scripts/quality-metrics.ts`.
+- All 18 verify gates passed at 14.6 s; 94/94 release-surface tests passed (re-run by reviewer).
+- R-V05-005 resolved in this PR: `package-contract.md` status flipped from `draft` to `accepted`.
+
+## Known limitations
+
+- **TEST-V05-006 deferred (R-V05-002):** the live publish acceptance test ("publish a package from an authorized release run") cannot be exercised until the first stable publish is complete. Coverage gap is documented in `test-report.md` §10 Gap 1. The Stage 11 retrospective will backfill the test record from the operator-authorized run.
+- **GitHub Packages auth required for public packages:** consumers must configure `read:packages` token even though the package and repository are public. `npm install` returns `401 Unauthorized` without it. This is a GitHub Packages platform constraint, not a package bug. See `package-contract.md` §7.
+- **Manual install path for v0.5:** there is no scaffolder CLI (`npm create @luis85/agentic-workflow`). Manual copy from `node_modules/@luis85/agentic-workflow/` is the only supported path. A scaffolder is a post-v0.5 goal and is not promised in this release.
+- **First publish is the first end-to-end exercise:** the release workflow, readiness checks, and build-time transform have been fully tested locally and in CI; the remote workflow dispatch with `publish_package: true` has not been run before (RISK-V05-006). Dry run is the default; the two-step CLAR-V05-003 path (draft+prerelease, then stable) is designed to let the operator inspect the artifact before the irreversible npm publish.
+- **`quality-metrics` undercounts test coverage (R-V05-001):** the `requirementsWithTests: 0` metric is a tooling miscount; the real REQ → TEST chain is fully traced in `traceability.md` and `spec.md`. A post-v0.5 follow-up issue targets `scripts/quality-metrics.ts`.
+- **`gh release create` is not re-runnable** once it has succeeded on a given tag. If the release workflow fails after `gh release create` but before the asset upload or npm publish, use the manual recovery commands in `docs/release-operator-guide.md` §7.1. Do not rerun the full workflow.
+- **ADR-0021 glob notation errata:** the `docs/adr/0\d{3}-*.md` pattern used in the ADR body is not a valid shell glob. The operational form is `[0-9][0-9][0-9][0-9]-*.md`. The decision is unchanged; see ADR-0021 §Errata.
+
+## Verification steps
+
+1. From the worktree or a fresh clone of `main` at the `v0.5.0` tag, run `npm run verify` — all 18 gates must pass.
+2. Run `npm run quality:metrics -- --feature version-0-5-plan` and confirm `overallScore` >= 97 and `blockers: 0`.
+3. Run the pre-flight readiness check:
+   ```
+   RELEASE_VERSION=0.5.0 RELEASE_CI_STATUS=green RELEASE_VALIDATION_STATUS=green npm run check:release-readiness -- --json
+   ```
+   Expect `{"diagnostics": []}`.
+4. Trigger the dry-run workflow dispatch from GitHub Actions UI (`dry_run: true`, `confirm` empty) and confirm all four steps pass: Layer 1 readiness, candidate archive build, Layer 2 fresh-surface, dry-run candidate log.
+5. Inspect the dry-run candidate log for correct generated release notes body and absence of numbered ADR filenames or per-feature spec paths in the tarball listing.
+6. After the dry-run passes, trigger the first publish (CLAR-V05-003 two-step path):
+   - Step 1 — draft + prerelease: `dry_run=false prerelease=true draft=true confirm=0.5.0 publish_package=false`. Inspect the draft Release on GitHub.
+   - Step 2 — stable + npm publish: `dry_run=false prerelease=false draft=false confirm=0.5.0 publish_package=true`. Verify `https://github.com/Luis85/agentic-workflow/releases/tag/v0.5.0` and `@luis85/agentic-workflow@0.5.0` on GitHub Packages.
+7. Smoke-test consumer install with the subshell pattern in `docs/release-operator-guide.md` §5 (requires a `read:packages` PAT).
+
+## Rollback plan
+
+Rollback for this release is forward-only per Article IX of the constitution and the rules in `docs/release-operator-guide.md` §6. Tags, GitHub Releases, and GitHub Packages publishes are irreversible under repository settings (force-push and tag deletion denied by `.claude/settings.json`).
+
+- **Trigger criteria:** use the rollback path if (a) the released artifact violates the fresh-surface contract (numbered ADRs or per-feature spec folders present in the published tarball), (b) the published package produces `npm install` failures unrelated to auth configuration, (c) a license violation or secret leak is confirmed, or (d) the release notes are materially wrong in a way that causes consumer harm.
+- **Mechanism:**
+  - Release notes content wrong but artifact correct: edit the GitHub Release body in the UI. No new version needed.
+  - Artifact wrong, package not yet published: set the Release to draft in the GitHub UI, then cut `v0.5.1` with the fix. Update the `v0.5.0` Release notes to point at `v0.5.1`. Do not delete or move the `v0.5.0` tag.
+  - Artifact and package published, consumers affected: cut `v0.5.1` with a fix, run `npm deprecate @luis85/agentic-workflow@0.5.0 "<reason>"`, update `v0.5.0` Release notes to point at `v0.5.1`. Do not force-push or rewrite tags.
+  - Catastrophic issue (secret leak, license violation): run `npm unpublish @luis85/agentic-workflow@0.5.0` within the registry's allowed window, make the Release a draft, file an incident, and cut `v0.5.1`. This escape hatch is for emergencies only.
+  - In every case: append an entry to this file and to `specs/version-0-5-plan/implementation-log.md` naming the rollback action and the superseding version.
+- **Data implications:** no persistent data is created by this release. Consumers who have already installed `@luis85/agentic-workflow@0.5.0` and copied files into their repository are not automatically affected by a package deprecation or supersession; they need to re-copy updated files manually.
+- **Communication:** notify via the `v0.5.0` GitHub Release notes (edit in place) and, for a package deprecation or yanked publish, via the GitHub Packages page and a pinned issue on `Luis85/agentic-workflow`. Internal note: append to `specs/version-0-5-plan/implementation-log.md` and update `CHANGELOG.md` with a `[v0.5.1]` entry describing the corrective action.
+
+## Observability
+
+This is a template repository; there are no production services or runtime metrics. Observability is through CI and repository tooling:
+
+- **CI:** GitHub Actions logs at `https://github.com/Luis85/agentic-workflow/actions` — every `npm run verify` run, every release workflow run.
+- **Quality metrics:** `npm run quality:metrics -- --feature version-0-5-plan` for feature-level KPI snapshot. `npm run quality:metrics` for repo-level health.
+- **Release readiness:** `npm run check:release-readiness -- --version 0.5.0 --json` for pre-publish diagnostic codes.
+- **Fresh-surface check:** `npm run check:release-package-contents -- --archive .release-staging --json` after `npm run build:release-archive` to confirm the staged tree meets SPEC-V05-010 assertions.
+- **Package presence:** `npm view @luis85/agentic-workflow@0.5.0 version --json` (requires `read:packages` token) confirms the package is live on GitHub Packages.
+- No new persistent dashboards or alert thresholds are introduced by this release.
+
+## Communication
+
+- **Internal:** workflow-state.md hand-off note (below) summarizes the remaining operator sequence. The reviewer's hand-off in `specs/version-0-5-plan/workflow-state.md` and `review.md` §Recommendation are the pre-publish checklist.
+- **External:** the GitHub Release notes (generated by `gh release create --generate-notes` from `.github/release.yml` categories) are the public-facing announcement. `sites/index.html` and `README.md` were updated in PR #161 to describe the v0.5 distribution channels.
+- **Support:** `docs/release-operator-guide.md` is the runnable operator reference for any maintainer executing a publish or recovery action.
+- No embargo. The release is public once the stable workflow run completes.
+
+---
+
+## Quality gate
+
+- [x] Summary written for the audience (users / stakeholders, not engineers).
+- [x] User-visible impact stated.
+- [x] Readiness conditions and approvals summarized, or guide marked not used.
+- [x] Known limitations disclosed.
+- [x] Verification steps documented.
+- [x] Rollback plan documented (all four fields: Trigger criteria, Mechanism, Data implications, Communication).
+- [x] Observability hooks in place.
+- [x] Communication plan ready.
+- [ ] Merged worktrees pruned (`git worktree prune`) and stale topic worktrees/branches cleaned up. — Pending operator action post-merge.

--- a/specs/version-0-5-plan/workflow-state.md
+++ b/specs/version-0-5-plan/workflow-state.md
@@ -2,9 +2,9 @@
 feature: version-0-5-plan
 area: V05
 current_stage: release
-status: active
+status: paused
 last_updated: 2026-05-02
-last_agent: reviewer
+last_agent: release-manager
 artifacts:
   idea.md: complete
   research.md: complete
@@ -17,7 +17,7 @@ artifacts:
   test-report.md: complete
   review.md: complete
   traceability.md: complete
-  release-notes.md: pending
+  release-notes.md: complete
   retrospective.md: pending
 ---
 
@@ -36,7 +36,7 @@ artifacts:
 | 7. Implementation | `implementation-log.md` + code | in-progress |
 | 8. Testing | `test-plan.md`, `test-report.md` | complete |
 | 9. Review | `review.md`, `traceability.md` | complete |
-| 10. Release | `release-notes.md` | pending |
+| 10. Release | `release-notes.md` | complete |
 | 11. Learning | `retrospective.md` | pending |
 
 ## Skips
@@ -78,6 +78,8 @@ artifacts:
 - 2026-05-02 (qa): T-V05-010 + T-V05-011 complete locally. All 209 unit tests pass (26 release-readiness, 18 release-package-contract, 165 pre-existing). `npm run verify` green (18 gates, 14.6 s). Layer 1 readiness (`check:release-readiness`) correctly blocks on pre-release gaps (`RELEASE_READINESS_TAG_MISSING`, `RELEASE_READINESS_CHANGELOG_MISSING`) and quality signals — expected states on a feature branch; waiver suppresses Quality codes leaving only structural blockers. `npm pack` candidate: `luis85-agentic-workflow-0.5.0.tgz`, 864,582 bytes, SHA-256 `2b9a4d2c5a43acf05df7f3c8d2f7f12757d49bf081defaa302713e25d27e62a4`, 814 extracted files. Layer 2 (`check:release-package-contents`) correctly fails — **DEFECT-V05-001 raised (dev-owned)**: 22 numbered ADR files and multiple built-up docs pages ship in the candidate archive (SPEC-V05-010 assertions 1 and 3 violated; OQ-V05-003 automation gap). Operator guide §7.1 internal consistency confirmed. `test-plan.md` and `test-report.md` written. Artifacts complete for Stage 8. **Next step:** (1) `dev` resolves DEFECT-V05-001 (fresh-surface preparation — exclude ADR files from archive, convert docs to stubs); (2) orchestrator merges PR #162; (3) operator cuts `v0.5.0` tag on `main`, promotes CHANGELOG entry; (4) operator runs the exact remote dry-run command documented in `test-report.md` §7: `gh workflow run release.yml --ref main -f version=0.5.0 -f dry_run=true -f prerelease=false -f draft=false -f confirm="" -f publish_package=false`; (5) CLAR-V05-003 closed; (6) PR #162 ready-for-review.
 
 - 2026-05-02 (Decider): CLAR-V05-003 resolved — first publish is **draft + prerelease**, then promoted to stable in a second workflow run. Repo vars `RELEASE_CI_STATUS=green` and `RELEASE_VALIDATION_STATUS=green` set on `Luis85/agentic-workflow` so Layer 1 readiness can pass in non-quality-waiver mode (item 7 of the v0.5 closeout punch list).
+
+- 2026-05-02 (release-manager): Stage 10 release-prep complete. Produced `specs/version-0-5-plan/release-notes.md` (RELEASE-V05-001, status `draft`); flipped `package-contract.md` (PKG-CONTRACT-V05-001) from `draft` to `accepted` with changelog entry confirming all three OQs closed (resolves R-V05-005 from REVIEW-V05-001). Quality KPI at review time: overallScore 97.1, maturity level 3 (Traceable), requirementCoverage 100%, earsCoverage 100%, 0 blockers; 94/94 release-surface tests green; all 18 verify gates green at 14.6 s. Readiness guide not used (single-maintainer release, no multi-stakeholder conditions beyond the two Decider items already resolved). **Remaining operator sequence (all Decider/operator actions — Article IX):** (1) Decider reviews this PR (`release/v0.5.0`), approves, and merges to `main`. (2) Operator cuts the `v0.5.0` tag on `main` at the merge commit: `git tag v0.5.0 <merge-sha> && git push origin v0.5.0`. (3) Operator runs the dry-run dispatch: `gh workflow run release.yml --ref main -f version=0.5.0 -f dry_run=true -f confirm="" -f publish_package=false` and confirms all four steps pass. (4) Operator runs step-1 publish (draft+prerelease, no npm publish): `gh workflow run release.yml --ref main -f version=0.5.0 -f dry_run=false -f prerelease=true -f draft=true -f confirm=0.5.0 -f publish_package=false`. Inspect the draft Release on GitHub. (5) Operator promotes to stable + npm publish: `gh workflow run release.yml --ref main -f version=0.5.0 -f dry_run=false -f prerelease=false -f draft=false -f confirm=0.5.0 -f publish_package=true`. (6) After stable publish is confirmed, advance to Stage 11: `/spec:retro` — retrospective agent pulls R-V05-002 (backfill TEST-V05-006 from live publish) and R-V05-003 (PR #202 loop-length / "when a flag is a code smell") as retro inputs. (7) After retro complete, delete the `release/v0.5.0` branch per ADR-0020 §5 and run `git worktree prune`.
 
 - 2026-05-02 (reviewer): Stage 9 complete. `review.md` (`REVIEW-V05-001`) and `traceability.md` (`RTM-V05-001`) written. **Verdict:** Approved with conditions — technical work is green; remaining blockers are Decider-owned. Quality metrics: `overallScore` 97.1, maturity level 3 (Traceable), `requirementCoverage` 100%, `earsCoverage` 100%, 0 blockers, 1 open clarification (CLAR-V05-003). All 12 functional REQs have a downstream Spec → Tasks → Code → Tests chain; all 5 NFRs have surface evidence. 94/94 release-surface tests pass on this branch (re-run by reviewer); `npm run verify` was reported green on `main` at 14.6 s across all 18 gates. Five findings raised, none blocking: R-V05-001 (medium, tooling — `quality-metrics` undercounts test coverage; post-v0.5 follow-up); R-V05-002 (low, accepted-as-is — TEST-V05-006 deferred to live publish); R-V05-003 (low, retro lesson — PR #202 ran 6 review-fix rounds; "when a flag is a code smell" learning); R-V05-004 (low, accepted-as-is — REQ-V05-012 EARS wording style nit); R-V05-005 (low, scheduled — `package-contract.md` `status: draft` should flip to `accepted` during release prep). DEFECT-V05-001 from Stage 8 confirmed resolved on the technical surface across PR #202 rounds 1–6. Round-1 → round-6 evolution consistent with `design.md` build-time-transform pattern; `--no-clean` removal in round-6 is a correct simplification because `package.json#files` whitelists whole directories. **Hand-off to Decider (Article IX):** (1) close CLAR-V05-003 — draft+prerelease vs stable for first publish; (2) authorise operator-led `gh workflow run release.yml --ref main -f version=0.5.0 -f dry_run=true …` after PR sequence merged + `v0.5.0` tag on `main` + `CHANGELOG.md [v0.5.0]` heading promoted + `RELEASE_CI_STATUS=green` / `RELEASE_VALIDATION_STATUS=green` repo vars set. **Hand-off to release-manager (Stage 10):** consume `review.md` §Recommendation as the release-prep checklist; have `pm` flip `package-contract.md` to `accepted` (R-V05-005) in the same PR that promotes the CHANGELOG heading; write `release-notes.md` and proceed once Decider items 1–2 are done. **Hand-off to retrospective agent (Stage 11):** R-V05-002 (backfill TEST-V05-006 from live publish) and R-V05-003 (PR #202 loop-length learning) are inputs to retro.
 

--- a/tests/scripts/quality-metrics.test.ts
+++ b/tests/scripts/quality-metrics.test.ts
@@ -58,9 +58,10 @@ test("renderQualityMetrics includes the headline KPIs and attention signals", ()
 test("collectQualityMetrics scores active workflows by current stage", () => {
   const metrics = collectQualityMetrics({ feature: "version-0-5-plan" });
   const workflow = metrics.workflows[0];
-  assert.equal(workflow.status, "active");
-  // v0.5 is past Stage 9 (review.md + traceability.md complete) and currently
-  // at Stage 10 (release). Expectations track the live `current_stage` so this
+  assert.equal(workflow.status, "paused");
+  // v0.5 is at Stage 10 (release) with release-notes.md complete; status is
+  // paused while waiting for the operator to cut the v0.5.0 tag and run the
+  // release workflow. Expectations track the live `current_stage` so this
   // test must be updated when the feature advances.
   assert.equal(workflow.currentStage, "release");
   assert.equal(workflow.testCoverageExpected, true);


### PR DESCRIPTION
## Summary

Stage 10 (Release) prep for `specs/version-0-5-plan/`. Cuts `release/v0.5.0` off `main` per ADR-0020. Tag `v0.5.0` will be cut on `main` after this PR merges.

- **Add** `specs/version-0-5-plan/release-notes.md` (RELEASE-V05-001): scope, Added/Changed/Removed mirroring CHANGELOG `[v0.5.0]` entry, user-visible impact for adopters + maintainers, six known limitations (TEST-V05-006 deferred, GitHub Packages auth requirement, manual install path, first-publish risk, quality-metrics undercount, `gh release create` non-idempotency), seven verification steps, fully populated rollback plan (trigger criteria, mechanism, data implications, communication), observability hooks, communication plan. Satisfies REQ-V05-008, SPEC-V05-006.
- **Flip** `specs/version-0-5-plan/package-contract.md` frontmatter `status: draft` → `status: accepted`. All three open questions closed (OQ-V05-001 visibility, OQ-V05-002 files glob, OQ-V05-003 stub-form automation). Resolves R-V05-005 from REVIEW-V05-001.
- **Update** `specs/version-0-5-plan/workflow-state.md`: `last_agent: release-manager`, `artifacts.release-notes.md: complete`, `status: paused` (waiting on operator tag + dispatch). Adds Stage 10 hand-off note describing the remaining operator sequence.
- **Update** `tests/scripts/quality-metrics.test.ts` to expect `workflow.status === "paused"` per the test's own self-update rule.

REVIEW-V05-001 verdict was "Approved with conditions". Both Decider conditions resolved on 2026-05-02:
1. CLAR-V05-003 closed — first publish ships draft + prerelease then promoted to stable.
2. `RELEASE_CI_STATUS=green` + `RELEASE_VALIDATION_STATUS=green` repo vars set.

## Remaining sequence (post-merge)

1. Operator cuts `v0.5.0` tag on `main` (lightweight tag, `--target main`).
2. Operator runs dry-run dispatch: `gh workflow run release.yml --ref main -f version=0.5.0 -f dry_run=true …`
3. Operator runs first publish (CLAR-V05-003 step 1): draft + prerelease, no npm publish.
4. After draft inspection, operator runs CLAR-V05-003 step 2: stable + npm publish.
5. Stage 11 retro (`/spec:retro`) backfills TEST-V05-006 and captures PR #202 loop-length learning.
6. Closeout PR — workflow-state → complete, README roadmap row v0.5 → Done, close issue #90.

## Test plan

- [x] `npm run verify` green (18 gates, 16.9s)
- [x] 264 tests pass
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)