### PR TITLE
docs: freeze v1 track taxonomy

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -44,6 +44,8 @@ Skills MAY include supporting files (templates, scripts, fixtures) next to `SKIL
 
 ### Workflow conductors
 
+The canonical v1.0 track taxonomy is frozen in [ADR-0026](../../docs/adr/0026-freeze-v1-workflow-track-taxonomy.md). This table lists conductor skills for that taxonomy; practice and operational skills below are not tracks by themselves.
+
 | Skill | Triggers when… | What it does |
 |---|---|---|
 | [`orchestrate/`](orchestrate/SKILL.md) | "start a feature", "kick off", "from scratch", "what's next?", "orchestrate" | Drive full 11-stage Specorator workflow conversationally. Read `workflow-state.md`, gate with `AskUserQuestion`, dispatch `/spec:*` commands in sequence. |
@@ -51,7 +53,11 @@ Skills MAY include supporting files (templates, scripts, fixtures) next to `SKIL
 | [`specorator-improvement/`](specorator-improvement/SKILL.md) | "improve Specorator", "add script", "add tooling", "add workflow", "quality drift review" | Guide improvements to template itself across scripts, tooling, workflows, docs, agents, skills, generated references, verification, PR delivery. |
 | [`project-scaffolding/`](project-scaffolding/SKILL.md) | "scaffold this project", "seed from docs", "fresh install with existing documentation", "guided setup" | Drive source-led Project Scaffolding Track. Inventory provided folders or Markdown files, extract evidence-backed context, assemble starter pack, route to right downstream track. |
 | [`discovery-sprint/`](discovery-sprint/SKILL.md) | "design sprint", "ideation", "brainstorm new product ideas", "blank page", "discovery sprint" | Drive 5-phase Discovery Track (Frame → Diverge → Converge → Prototype → Validate → Handoff) conversationally. Dispatch `facilitator` and 6 specialist consults. Output: `chosen-brief.md` feed `/spec:idea`. **Skip when brief already exists — go to `orchestrate`.** |
+| [`stock-taking/`](stock-taking/SKILL.md) | "brownfield", "legacy audit", "inventory existing system", "stock taking" | Drive the Stock-taking Track. Scope, audit, synthesize, and hand off an inventory before new feature work. |
+| [`sales-cycle/`](sales-cycle/SKILL.md) | "sales", "proposal", "RFP", "SOW", "qualify this lead" | Drive the Sales Cycle Track from qualification through order handoff for service-provider work. |
+| [`project-run/`](project-run/SKILL.md) | "project manager", "client engagement", "weekly report", "change request" | Drive the Project Manager Track for P3.Express-style engagement governance. |
 | [`roadmap-management/`](roadmap-management/SKILL.md) | "roadmap", "product roadmap", "project roadmap", "stakeholder update", "communicate roadmap", "align the team" | Drive Roadmap Management Track. Maintain outcome roadmaps, delivery-plan signals, stakeholder maps, communication logs, roadmap decisions. |
+| [`portfolio-track/`](portfolio-track/SKILL.md) | "portfolio", "program", "multi-feature", "portfolio review" | Drive the Portfolio Track for P5 Express X/Y/Z cycles above individual specs. |
 | [`issue-breakdown/`](issue-breakdown/SKILL.md) | post-/spec:tasks; "break this issue down", "decompose issue", /issue:breakdown <n> | Decompose a GitHub issue into independent draft PRs by parsing tasks.md ## Parallelisable batches. |
 
 ### Practice skills (used by stage agents)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,8 @@ Repo = **template for spec-driven, agentic software development**. Defines workf
 
 ## Agent classes
 
+The canonical v1.0 track taxonomy is frozen in [`ADR-0026`](docs/adr/0026-freeze-v1-workflow-track-taxonomy.md). Agent classes below implement the core lifecycle and the opt-in/companion tracks in that taxonomy.
+
 | Class | Location | Purpose | Methodology |
 |---|---|---|---|
 | **Lifecycle (Stage 1–11 specialists)** | `.claude/agents/` | Build one feature: analyst, pm, ux/ui-designer, architect, planner, dev, qa, reviewer, release-manager, sre, retrospective. | [`docs/specorator.md`](docs/specorator.md) |
@@ -55,6 +57,8 @@ Repo = **template for spec-driven, agentic software development**. Defines workf
 | **Project scaffolder** *(opt-in)* | `.claude/agents/project-scaffolder.md` | Source-led onboarding from collected docs/folders. State lives `scaffolding/<slug>/`. | [`docs/project-scaffolding-track.md`](docs/project-scaffolding-track.md) ([ADR-0011](docs/adr/0011-add-project-scaffolding-track.md)) |
 | **Quality assurance** *(opt-in)* | `.claude/skills/quality-assurance/SKILL.md` | ISO 9001-aligned readiness review. State lives `quality/<slug>/`. | [`docs/quality-assurance-track.md`](docs/quality-assurance-track.md) |
 | **Issue-breakdown** *(opt-in)* | `.claude/agents/issue-breakdown.md` | Post-tasks. Issue → draft PRs. Appends log + hand-off. | [`docs/issue-breakdown-track.md`](docs/issue-breakdown-track.md) |
+| **Design** *(opt-in)* | `.claude/agents/design-lead.md` | Brand-aware surface creation. State lives `designs/<slug>/`. | [`docs/design-track.md`](docs/design-track.md) ([ADR-0019](docs/adr/0019-add-design-track.md)) |
+| **Specorator improvement** *(companion)* | `.claude/skills/specorator-improvement/SKILL.md` | Improve this template's scripts, tooling, workflows, docs, agents, skills, templates, state, or operations. | [`docs/specorator.md`](docs/specorator.md#14-improving-specorator-itself) |
 | **Operational bots** | `agents/operational/` | Scheduled routines (review-bot, docs-review-bot, plan-recon-bot, dep-triage-bot, actions-bump-bot). `PROMPT.md` + `README.md` per bot. | — |
 
 Skills (`.claude/skills/`) = reusable how-tos any agent invokes (`verify`, `new-adr`, `review-fix`). Eleven workflow-conductor skills are the conversational entry points — see [`.claude/skills/README.md`](.claude/skills/README.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,18 +22,9 @@ The **lifecycle workflow** (Stages 1–11) has two equivalent entry points:
 
 State lives in `specs/<feature-slug>/workflow-state.md`. Each `/spec:*` command spawns its specialist subagent from `.claude/agents/` — don't bypass; agent scoping is intentional. Slash commands update `workflow-state.md` on stage completion — don't edit by hand mid-workflow.
 
-### Other tracks (opt-in)
+### Other tracks
 
-| Track | When to use | Conductor skill | Manual entry | Reference |
-|---|---|---|---|---|
-| **Discovery** | blank-page ideation, no brief | [`discovery-sprint`](.claude/skills/discovery-sprint/SKILL.md) | `/discovery:start` | [`docs/discovery-track.md`](docs/discovery-track.md) ([ADR-0005](docs/adr/0005-add-discovery-track-before-stage-1.md)) |
-| **Stock-taking** | brownfield, inventory existing system | [`stock-taking`](.claude/skills/stock-taking/SKILL.md) | `/stock:start` | [`docs/stock-taking-track.md`](docs/stock-taking-track.md) ([ADR-0007](docs/adr/0007-add-stock-taking-track-for-legacy-projects.md)) |
-| **Sales** | service provider, pre-contract (RFP / SOW) | [`sales-cycle`](.claude/skills/sales-cycle/SKILL.md) | `/sales:start` | [`docs/sales-cycle.md`](docs/sales-cycle.md) ([ADR-0006](docs/adr/0006-add-sales-cycle-track-before-discovery.md)) |
-| **Project Manager** | client engagement governance (P3.Express) | [`project-run`](.claude/skills/project-run/SKILL.md) | `/project:start` | [`docs/project-track.md`](docs/project-track.md) ([ADR-0008](docs/adr/0008-add-project-manager-track.md)) |
-| **Portfolio** | multi-feature / multi-program (P5 Express) | [`portfolio-track`](.claude/skills/portfolio-track/SKILL.md) | `/portfolio:start` | [`docs/portfolio-track.md`](docs/portfolio-track.md) ([ADR-0009](docs/adr/0009-add-portfolio-manager-role.md)) |
-| **Issue-breakdown** | post-/spec:tasks, issue → draft PRs | [`issue-breakdown`](.claude/skills/issue-breakdown/SKILL.md) | `/issue:breakdown <n>` | [`docs/issue-breakdown-track.md`](docs/issue-breakdown-track.md) ([ADR-0022](docs/adr/0022-add-issue-breakdown-track.md)) |
-
-Each track produces a handoff artifact that feeds the next: `chosen-brief.md`, `stock-taking-inventory.md`, `order.md`. See the per-track methodology doc for details.
+The v1.0 track taxonomy is frozen in [ADR-0026](docs/adr/0026-freeze-v1-workflow-track-taxonomy.md). Besides the core lifecycle, opt-in / companion tracks are: Discovery (`/discovery:start`), Stock-taking (`/stock-taking:start`), Sales (`/sales:start`), Project Manager (`/project:start`), Roadmap (`/roadmap:start`), Portfolio (`/portfolio:start`), Quality Assurance (`/quality:start`), Project Scaffolding (`/scaffold:start`), Design (`/design:start`), Issue-breakdown (`/issue:breakdown`), and Specorator Improvement (`/specorator:update`). See `docs/*-track.md`, `docs/specorator.md`, and `.claude/skills/README.md` for methodology and conductor details.
 
 ## Conventions specific to Claude Code
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Claude Code gets the native commands, agents, and skills. Other tools use the sa
 ## What You Get
 
 - An 11-stage lifecycle: Idea, Research, Requirements, Design, Specification, Tasks, Implementation, Testing, Review, Release, Retrospective.
-- Optional tracks for Discovery, Stock-taking, Sales, Project Management, Roadmap, Portfolio, Quality Assurance, Project Scaffolding, and Issue Breakdown.
+- Optional and companion tracks for Discovery, Stock-taking, Sales, Project Management, Roadmap, Portfolio, Quality Assurance, Project Scaffolding, Design, Issue Breakdown, and Specorator Improvement. The canonical v1.0 track taxonomy is frozen in [ADR-0026](docs/adr/0026-freeze-v1-workflow-track-taxonomy.md).
 - Markdown artifacts in `specs/<feature>/`, stable IDs (`REQ-*`, `T-*`, `TEST-*`, `ADR-*`), and `npm run verify` as the local and CI gate.
 - Claude Code agents, skills, and slash commands in `.claude/`, with shared root context in `AGENTS.md`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,6 +56,8 @@ Look-it-up, normative. Authoritative; not narrative.
 
 - [`specorator.md`](./specorator.md) — the full workflow definition.
 - [`project-scaffolding-track.md`](./project-scaffolding-track.md) — source-led onboarding track for turning collected docs into starter artifacts.
+- [`design-track.md`](./design-track.md) — brand-aware surface creation workflow.
+- [`issue-breakdown-track.md`](./issue-breakdown-track.md) — post-tasks issue-to-draft-PR decomposition workflow.
 - [`roadmap-management-track.md`](./roadmap-management-track.md) — product/project roadmap management, stakeholder alignment, and team communication workflow.
 - [`quality-assurance-track.md`](./quality-assurance-track.md) — ISO 9001-aligned quality assurance review workflow.
 - [`release-readiness-guide.md`](./release-readiness-guide.md) — Stage 10 go/no-go guide for product perspectives and stakeholder requirements.
@@ -103,6 +105,8 @@ Understanding-oriented. Background, rationale, and the *why* behind decisions.
 - [`quality-assurance-track.md`](./quality-assurance-track.md) — why project execution health needs evidence-backed QA checklists and corrective actions.
 - [`portfolio-track.md`](./portfolio-track.md) — why portfolios sit above the Specorator lifecycle.
 - [`stock-taking-track.md`](./stock-taking-track.md) — why brownfield projects need a separate inventory step.
+- [`design-track.md`](./design-track.md) — why branded surface creation is separate from feature-level Stage 4 design.
+- [`issue-breakdown-track.md`](./issue-breakdown-track.md) — why post-tasks issue work gets its own decomposition workflow.
 - [`adr/`](./adr/) — the rationale half of each ADR file. (The index lives under Reference above.)
 
 *Quadrant last reviewed: 2026-04-28.*

--- a/docs/adr/0026-freeze-v1-workflow-track-taxonomy.md
+++ b/docs/adr/0026-freeze-v1-workflow-track-taxonomy.md
@@ -1,0 +1,117 @@
+---
+id: ADR-0026
+title: Freeze the v1.0 workflow track taxonomy
+status: accepted
+date: 2026-05-02
+deciders:
+  - human maintainer
+consulted:
+  - architect
+  - release-manager
+informed:
+  - all agents
+supersedes: []
+superseded-by: []
+tags: [workflow, tracks, v1]
+---
+
+# ADR-0026 - Freeze the v1.0 workflow track taxonomy
+
+## Status
+
+Accepted
+
+## Context
+
+The repository now has several workflow surfaces that describe tracks from different angles: `AGENTS.md`, `CLAUDE.md`, `docs/specorator.md`, `.claude/skills/README.md`, `README.md`, and the public product page. Those surfaces drifted:
+
+- `CLAUDE.md` listed only a subset of opt-in tracks.
+- `AGENTS.md` listed most agent classes but did not identify one canonical v1.0 track set.
+- `sites/index.html` still said "Eight more tracks" while newer Design and Issue Breakdown work existed.
+- `.claude/skills/README.md` listed conductor skills but not every first-party track conductor.
+- v0.6 planning introduced an agentic security review path that could be misread as a new track.
+
+Issue #192 blocks v1.0 readiness until the project can name the final track set and stop adding implicit tracks through scattered documentation.
+
+## Decision
+
+We freeze the v1.0 workflow taxonomy at **12 first-party tracks**:
+
+| # | Track | Type | Primary entry | State home | Source |
+|---|---|---|---|---|---|
+| 1 | Lifecycle | Core | `/spec:start` | `specs/<slug>/workflow-state.md` | `docs/specorator.md` |
+| 2 | Discovery | Opt-in pre-workflow | `/discovery:start` | `discovery/<slug>/discovery-state.md` | ADR-0005 |
+| 3 | Stock-taking | Opt-in pre-workflow | `/stock-taking:start` | `stock-taking/<slug>/stock-taking-state.md` | ADR-0007 |
+| 4 | Sales Cycle | Opt-in pre-contract | `/sales:start` | `sales/<slug>/deal-state.md` | ADR-0006 |
+| 5 | Project Manager | Opt-in governance | `/project:start` | `projects/<slug>/project-state.md` | ADR-0008 |
+| 6 | Roadmap Management | Opt-in planning | `/roadmap:start` | `roadmaps/<slug>/roadmap-state.md` | ADR-0012 |
+| 7 | Portfolio | Opt-in governance | `/portfolio:start` | `portfolio/<slug>/portfolio-state.md` | ADR-0009 |
+| 8 | Quality Assurance | Opt-in readiness | `/quality:start` | `quality/<slug>/quality-state.md` | `docs/quality-assurance-track.md` |
+| 9 | Project Scaffolding | Opt-in onboarding | `/scaffold:start` | `scaffolding/<slug>/scaffolding-state.md` | ADR-0011 |
+| 10 | Design | Opt-in surface creation | `/design:start` | `designs/<slug>/design-state.md` | ADR-0019 |
+| 11 | Issue Breakdown | Opt-in post-tasks parallelisation | `/issue:breakdown` | `specs/<slug>/issue-breakdown-log.md` | ADR-0022 |
+| 12 | Specorator Improvement | Opt-in template improvement | `/specorator:update` | existing docs/spec artifacts | `docs/specorator.md` |
+
+No additional first-party track may enter the v1.0 set without a superseding ADR. New checklists, skills, commands, or docs that extend one of these tracks do not count as new tracks unless they add a new top-level workflow with its own state, entry point, and methodology.
+
+Two current ambiguity points are resolved:
+
+1. The **Design Track remains opt-in** for surface creation. It is not promoted into the core lifecycle, and Stage 4 remains the feature-level design stage.
+2. The v0.6 **agentic security review path is not a thirteenth track**. It is a QA/reviewer extension: a review checklist or skill that can be used inside Quality Assurance, Review, or Release readiness without adding a new state-bearing workflow.
+
+This ADR is the canonical source for track count and classification. Other docs may summarize the list, but they should link back here when they need to make a count claim.
+
+## Considered options
+
+### Option A - Freeze the current set and classify security as an extension
+
+- Pros: Stabilizes v1.0, avoids adding another track while v0.6 is still open, preserves ADR-0019's opt-in Design Track decision.
+- Cons: Agentic security does not get a standalone workflow identity.
+
+### Option B - Add agentic security as a thirteenth track
+
+- Pros: Gives security a visible entry point and state home.
+- Cons: Expands the pre-v1.0 surface area and conflicts with the goal of a stable mental model.
+
+### Option C - Collapse Design into Stage 4
+
+- Pros: Reduces the track count by one.
+- Cons: Supersedes ADR-0019 and conflates surface creation with feature-level design.
+
+## Consequences
+
+### Positive
+
+- v1.0 readiness has one canonical track inventory.
+- Public and agent-facing docs can stop carrying inconsistent counts.
+- v0.6 agentic security work can proceed as an extension without waiting for a new-track decision.
+
+### Negative
+
+- Future track proposals before v1.0 now require a superseding ADR.
+- Some existing docs must be updated to replace local counts with this ADR.
+
+### Neutral
+
+- Issue Breakdown remains proposed under ADR-0022 but is still counted because it has already shipped as a first-party opt-in track surface.
+- Quality Assurance remains a first-party track even though it was introduced through a methodology doc rather than a numbered ADR.
+
+## Compliance
+
+- `AGENTS.md`, `CLAUDE.md`, `README.md`, `docs/specorator.md`, `.claude/skills/README.md`, and `sites/index.html` link or align with this track taxonomy.
+- `specs/version-0-6-plan/workflow-state.md` resolves CLAR-V06-002 as a QA/reviewer extension, not a new track.
+- Reviewers treat any new state-bearing first-party workflow proposal before v1.0 as requiring a superseding ADR.
+
+## References
+
+- Issue #192 - Track-count freeze before v1.0.
+- Issue #195 - v0.6 scope-cut decision.
+- Issue #196 - unresolved clarification inventory.
+- ADR-0005, ADR-0006, ADR-0007, ADR-0008, ADR-0009, ADR-0011, ADR-0012, ADR-0019, ADR-0022.
+- `docs/specorator.md`
+- `docs/specorator-product/product.md`
+- `specs/version-0-6-plan/workflow-state.md`
+
+---
+
+> **ADR bodies are immutable.** To change a decision, supersede it with a new ADR; only the predecessor's `status` and `superseded-by` pointer fields may be updated.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,6 +38,7 @@ Records of architecturally significant decisions. Format follows Michael Nygard'
 | [0023](0023-adopt-zod-as-first-runtime-dependency.md) | Adopt zod as the first runtime dependency for script-layer validation | Accepted |
 | [0024](0024-lock-specorator-agentic-workflow-naming-contract.md) | Lock the Specorator and agentic-workflow naming contract | Accepted |
 | [0025](0025-adopt-doc-as-contract-review-protocol.md) | Adopt a doc-as-contract review protocol | Proposed |
+| [0026](0026-freeze-v1-workflow-track-taxonomy.md) | Freeze the v1.0 workflow track taxonomy | Accepted |
 <!-- END GENERATED: adr-index -->
 
 ## Conventions

--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -41,6 +41,12 @@ The full mermaid diagrams for each track live in [`workflow-overview.md`](./work
 - **Project Scaffolding Track** *(optional, source-led onboarding)* — Intake → Extract → Assemble → Handoff.
 - **Discovery Track** *(optional, blank-page ideation)* — Frame → Diverge → Converge → Prototype → Validate → Handoff.
 - **Lifecycle Track** *(11 stages, the core workflow)* — Idea → Research → Requirements → Design → Specification → Tasks → Implementation → Testing → Review → Release → Retrospective.
+- **Design Track** *(optional, surface creation)* — Frame → Sketch → Mock → Handoff.
+- **Quality Assurance Track** *(optional, readiness)* — Start → Plan → Check → Review → Improve.
+- **Roadmap Management Track** *(optional, planning)* — Start → Shape → Align → Communicate → Review.
+- **Issue Breakdown Track** *(optional, post-tasks)* — Issue → slices → draft PRs → handoff.
+
+The canonical v1.0 track taxonomy and count live in [ADR-0026](./adr/0026-freeze-v1-workflow-track-taxonomy.md).
 
 Each lifecycle stage has **one owner** (a specialist AI agent), **one output** (a Markdown file in `specs/<feature>/`), and **one quality gate** before the next stage can begin. No stage is skipped; quality gates are non-negotiable.
 
@@ -51,6 +57,8 @@ Each lifecycle stage has **one owner** (a specialist AI agent), **one output** (
 | [`docs/specorator.md`](./specorator.md) | Full workflow definition — read this before any non-trivial work |
 | [`docs/project-scaffolding-track.md`](./project-scaffolding-track.md) | Source-led onboarding detail for turning collected docs into starter artifacts |
 | [`docs/discovery-track.md`](./discovery-track.md) | Discovery Track detail and phase-by-phase guide |
+| [`docs/design-track.md`](./design-track.md) | Brand-aware surface creation workflow |
+| [`docs/issue-breakdown-track.md`](./issue-breakdown-track.md) | Post-tasks issue decomposition into independent draft PRs |
 | [`docs/roadmap-management-track.md`](./roadmap-management-track.md) | Product/project roadmap management, stakeholder alignment, and team communication workflow |
 | [`docs/quality-assurance-track.md`](./quality-assurance-track.md) | ISO 9001-aligned quality assurance review workflow |
 | [`docs/release-readiness-guide.md`](./release-readiness-guide.md) | Stage 10 go/no-go guide for product perspectives and stakeholder requirements |

--- a/docs/specorator-product/product.md
+++ b/docs/specorator-product/product.md
@@ -24,6 +24,8 @@ Specorator is a file-based operating system for agentic software delivery: specs
 4. Keep advanced controls optional and reversible until an ADR promotes them.
 5. Improve the template without breaking downstream starter value.
 
+The v1.0 workflow track taxonomy is frozen in [ADR-0026](../adr/0026-freeze-v1-workflow-track-taxonomy.md). New productization work may extend existing tracks, but it should not add another first-party track before v1.0 without a superseding ADR.
+
 ## Non-Goals
 
 - Do not turn Specorator into a hosted SaaS product.

--- a/docs/specorator.md
+++ b/docs/specorator.md
@@ -44,6 +44,8 @@ See [`memory/constitution.md`](../memory/constitution.md) for the full version. 
 
 ## 2. Workflow overview
 
+The canonical v1.0 workflow track taxonomy is frozen in [ADR-0026](adr/0026-freeze-v1-workflow-track-taxonomy.md). The core lifecycle is one track; 11 opt-in or companion tracks sit around it. Do not infer new tracks from new checklists, skills, or review paths unless a superseding ADR adds a new state-bearing workflow.
+
 ```mermaid
 flowchart LR
     scaffold["Project Scaffolding Track"]
@@ -97,6 +99,8 @@ flowchart LR
 - **Quality Assurance Track** — an ISO 9001-aligned evidence workflow for checking project execution health and delivery readiness. Produces `quality-plan.md`, checklists, `quality-review.md`, and `improvement-plan.md`. Defined in [`docs/quality-assurance-track.md`](quality-assurance-track.md). **Use for internal readiness, quality drift review, release readiness, supplier assurance, or audit preparation.**
 - **Roadmap Management Track** — an outcome-led product/project planning workflow for roadmaps, delivery confidence, stakeholder alignment, and team communication. Produces `roadmap-board.md`, `delivery-plan.md`, `stakeholder-map.md`, `communication-log.md`, and `decision-log.md` under `roadmaps/<slug>/`. Defined in [`docs/roadmap-management-track.md`](roadmap-management-track.md). **Use when product direction, project delivery constraints, stakeholder expectations, and team communication need one maintained source of truth.**
 - **Design Track** — a four-phase, brand-aware surface-creation workflow (Frame → Sketch → Mock → Handoff) for producing new user-visible surfaces under the Specorator brand system. Produces `design-brief.md`, `sketch.md`, an optional `mock.html`, and `design-handoff.md` under `designs/<slug>/`. Defined in [`docs/design-track.md`](design-track.md); rationale in [ADR-0019](adr/0019-add-design-track.md). **Use when creating a new surface (docs site, marketing page, onboarding flow, dashboard) or significantly redesigning an existing one. Do not use for feature-level UI work — use `/spec:design` (Stage 4) instead.**
+
+Agentic security review guidance is a QA/reviewer extension, not a separate track in the v1.0 taxonomy. See [ADR-0026](adr/0026-freeze-v1-workflow-track-taxonomy.md).
 
 ---
 

--- a/sites/index.html
+++ b/sites/index.html
@@ -310,7 +310,7 @@
 
       <section class="section tracks-section" id="tracks" aria-labelledby="tracks-title">
         <div class="section-header">
-          <h2 id="tracks-title">Eight more tracks. All opt-in.</h2>
+          <h2 id="tracks-title">Eleven companion tracks. All opt-in.</h2>
           <p class="section-kicker">Specorator stays small at the core and grows on demand. Each track is a separate set of slash commands and agents &mdash; invoke the ones that match your context.</p>
         </div>
         <div class="track-grid" aria-label="Opt-in workflow tracks">
@@ -428,8 +428,50 @@
             <p class="track-purpose">Turn folders and Markdown notes into a reviewable starter pack.</p>
             <code class="track-cmd">/scaffold:start</code>
           </article>
+          <article class="track-card">
+            <header class="track-card-head">
+              <span class="track-when">Surfaces</span>
+              <h3>Design</h3>
+            </header>
+            <ol class="track-phases">
+              <li>Frame</li>
+              <li>Sketch</li>
+              <li>Mock</li>
+              <li>Handoff</li>
+            </ol>
+            <p class="track-purpose">Create branded user-visible surfaces before implementation.</p>
+            <code class="track-cmd">/design:start</code>
+          </article>
+          <article class="track-card">
+            <header class="track-card-head">
+              <span class="track-when">Post-tasks</span>
+              <h3>Issue Breakdown</h3>
+            </header>
+            <ol class="track-phases">
+              <li>Slice</li>
+              <li>Draft PRs</li>
+              <li>Track</li>
+              <li>Handoff</li>
+            </ol>
+            <p class="track-purpose">Turn a completed task plan into independent draft PR work.</p>
+            <code class="track-cmd">/issue:breakdown</code>
+          </article>
+          <article class="track-card">
+            <header class="track-card-head">
+              <span class="track-when">Template</span>
+              <h3>Specorator Improvement</h3>
+            </header>
+            <ol class="track-phases">
+              <li>Classify</li>
+              <li>Design</li>
+              <li>Patch</li>
+              <li>Verify</li>
+            </ol>
+            <p class="track-purpose">Improve the workflow kit itself without losing traceability.</p>
+            <code class="track-cmd">/specorator:update</code>
+          </article>
         </div>
-        <p class="track-footnote">All eight tracks are optional and pluggable. <a href="#roster">See the agents that drive them &rarr;</a></p>
+        <p class="track-footnote">The v1.0 track taxonomy is frozen in ADR-0026. <a href="#roster">See the agents that drive them &rarr;</a></p>
       </section>
 
       <section class="section dark roster-section" id="roster" aria-labelledby="roster-title">

--- a/specs/version-0-6-plan/workflow-state.md
+++ b/specs/version-0-6-plan/workflow-state.md
@@ -51,9 +51,10 @@ artifacts:
 
 - 2026-05-01 (codex): Planned v0.6 through Stage 6 from the product research pass. Recommended implementation order is steering profile, live golden-path demo, cross-tool adapters, hook pack, agentic security workflow, proof-first public positioning, adoption profiles, ISO 9001:2026 watch item, then release readiness verification.
 - 2026-05-02 (codex, T-V06-001/T-V06-002): PR-A selected the additive steering split: downstream starter templates stay in `docs/steering/`, while Specorator's own product steering lives in `docs/specorator-product/`. No ADR required because existing template ownership was preserved. Implementation evidence lives in `implementation-log.md`.
+- 2026-05-02 (codex, CLAR-V06-002): ADR-0026 freezes the v1.0 track taxonomy and resolves agentic security as a QA/reviewer extension, not a new optional track. T-V06-010 should add an OWASP-aligned review path as an opt-in checklist/skill usable from Quality Assurance, Review, or Release readiness without creating a new state-bearing workflow.
 
 ## Open clarifications
 
 - [ ] CLAR-V06-001 - Confirm whether v0.6 should implement the full cross-tool adapter set or start with Claude Code, Codex, and Copilot only.
-- [ ] CLAR-V06-002 - Confirm whether the agentic security review is a new optional track, a QA checklist extension, or both.
+- [x] CLAR-V06-002 - Confirm whether the agentic security review is a new optional track, a QA checklist extension, or both. *(resolved 2026-05-02: QA/reviewer extension, not a new track; see ADR-0026.)*
 - [ ] CLAR-V06-003 - Confirm whether the golden-path demo should be fully automated in CI or documented as a maintainer-run release evidence check first.


### PR DESCRIPTION
## Summary

- Add ADR-0026 as the canonical v1.0 workflow track taxonomy: lifecycle plus 11 opt-in/companion tracks.
- Reconcile track-count language across `AGENTS.md`, `CLAUDE.md`, README, `docs/specorator.md`, `.claude/skills/README.md`, the docs hub/repo map, product steering, and the public page.
- Resolve `CLAR-V06-002` in `specs/version-0-6-plan/workflow-state.md`: agentic security is a QA/reviewer extension, not a new state-bearing track.

Closes #192.
Refs #195.
Refs #196.

## Verification

- `npm run check:content`
- `npm run check:workflow`
- `npm run verify:changed`
- `npm run check:token-budget`
- `npm run verify`

## Notes

`CLAR-V06-001` and `CLAR-V06-003` remain open human/product decisions. This PR only resolves the track-count freeze and `CLAR-V06-002`.