### PR TITLE
docs: resolve CLAR decision slate

### DIFF
--- a/specs/project-consistency-hardening/workflow-state.md
+++ b/specs/project-consistency-hardening/workflow-state.md
@@ -3,8 +3,8 @@ feature: project-consistency-hardening
 area: CONS
 current_stage: requirements
 status: active
-last_updated: 2026-05-01
-last_agent: pm
+last_updated: 2026-05-02
+last_agent: codex
 artifacts:
   idea.md: skipped
   research.md: complete
@@ -52,9 +52,17 @@ artifacts:
 ```text
 2026-05-01 (pm): Baseline review executed with `npm run verify` and `npm run self-check`.
                  Requirements draft tracks consistency hardening follow-ups.
+2026-05-02 (Decider): CLAR-CONS-001 and CLAR-CONS-002 resolved in the cross-plan
+                       clarification slate. Historical completed workflows without
+                       captured test evidence are template-era exceptions, not targets
+                       for invented backfill. Going forward, completed workflows need
+                       explicit test-report evidence or an approved exception marker.
+                       Active release-blocking clarification debt takes priority over
+                       new release feature work; after this slate, resume v0.6
+                       unblockers, then v0.7.1/Zod, then v0.8/v0.9 implementation.
 ```
 
 ## Open clarifications
 
-- [ ] CLAR-CONS-001 — Confirm whether completed historical workflows should be backfilled with explicit test-report evidence or intentionally marked as template-era exceptions.
-- [ ] CLAR-CONS-002 — Confirm priority ordering across clarification debt (v0.5, v0.6, v0.8, v0.9) versus new release feature work.
+- [x] CLAR-CONS-001 — Historical completed workflows without captured test evidence are intentionally marked as template-era exceptions; do not invent backfilled evidence. New completed workflows require machine-checkable test-report evidence or an approved exception marker.
+- [x] CLAR-CONS-002 — Active release-blocking clarification debt takes priority over new release feature work. After this slate, sequence work as v0.6 unblockers, then v0.7.1/Zod, then v0.8/v0.9 implementation.

--- a/specs/version-0-6-plan/workflow-state.md
+++ b/specs/version-0-6-plan/workflow-state.md
@@ -4,7 +4,7 @@ area: V06
 current_stage: implementation
 status: active
 last_updated: 2026-05-02
-last_agent: codex-dev
+last_agent: codex
 artifacts:
   idea.md: complete
   research.md: complete
@@ -52,9 +52,10 @@ artifacts:
 - 2026-05-01 (codex): Planned v0.6 through Stage 6 from the product research pass. Recommended implementation order is steering profile, live golden-path demo, cross-tool adapters, hook pack, agentic security workflow, proof-first public positioning, adoption profiles, ISO 9001:2026 watch item, then release readiness verification.
 - 2026-05-02 (codex, T-V06-001/T-V06-002): PR-A selected the additive steering split: downstream starter templates stay in `docs/steering/`, while Specorator's own product steering lives in `docs/specorator-product/`. No ADR required because existing template ownership was preserved. Implementation evidence lives in `implementation-log.md`.
 - 2026-05-02 (codex, CLAR-V06-002): ADR-0026 freezes the v1.0 track taxonomy and resolves agentic security as a QA/reviewer extension, not a new optional track. T-V06-010 should add an OWASP-aligned review path as an opt-in checklist/skill usable from Quality Assurance, Review, or Release readiness without creating a new state-bearing workflow.
+- 2026-05-02 (Decider): CLAR-V06-001 and CLAR-V06-003 resolved in the cross-plan clarification slate. v0.6 ships a thin first-class adapter set: Claude Code baseline, Codex, Copilot, and one editor-agent path through Cursor/Aider-style guidance; fuller native adapters or generation are deferred. Golden-path proof starts as maintainer-run evidence plus CI validation of artifacts/scripts; full CI execution of the interactive demo is deferred until the path is stable.
 
 ## Open clarifications
 
-- [ ] CLAR-V06-001 - Confirm whether v0.6 should implement the full cross-tool adapter set or start with Claude Code, Codex, and Copilot only.
+- [x] CLAR-V06-001 - v0.6 does not implement the full cross-tool adapter set. Ship a thin first-class set: Claude Code baseline, Codex, Copilot, and one editor-agent path through Cursor/Aider-style guidance. Defer fuller native adapters or generation.
 - [x] CLAR-V06-002 - Confirm whether the agentic security review is a new optional track, a QA checklist extension, or both. *(resolved 2026-05-02: QA/reviewer extension, not a new track; see ADR-0026.)*
-- [ ] CLAR-V06-003 - Confirm whether the golden-path demo should be fully automated in CI or documented as a maintainer-run release evidence check first.
+- [x] CLAR-V06-003 - Start with maintainer-run golden-path evidence plus CI validation of artifacts/scripts. Defer fully automated CI execution of the interactive demo until the path is stable.

--- a/specs/version-0-8-plan/workflow-state.md
+++ b/specs/version-0-8-plan/workflow-state.md
@@ -3,8 +3,8 @@ feature: version-0-8-plan
 area: V08
 current_stage: implementation
 status: active
-last_updated: 2026-05-01
-last_agent: planner
+last_updated: 2026-05-02
+last_agent: codex
 artifacts:
   idea.md: complete
   research.md: complete
@@ -50,9 +50,10 @@ artifacts:
 ## Hand-off notes
 
 - 2026-05-01 (codex): Planned v0.8 through Stage 6 from the request for better product page creation. Recommended implementation order is decide the generator stack, define the content model, scaffold the static-site app, migrate the current product page into content files, add GitHub Pages deployment, add deterministic checks and docs, then update product-page agent/skill guidance.
+- 2026-05-02 (Decider): CLAR-V08-001, CLAR-V08-002, and CLAR-V08-003 resolved in the cross-plan clarification slate. v0.8 adopts Astro as the default generator without building a generator-neutral adapter layer. Canonical product-page source moves from `sites/index.html` to Markdown/content plus Astro source; generated output is build/deploy output, with direct-open behavior preserved after build and the changed contract documented. Downstream adopters receive the generator as an opt-in scaffold, while Specorator itself can use it by default.
 
 ## Open clarifications
 
-- [ ] CLAR-V08-001 - Confirm whether v0.8 should adopt Astro as the default generator or keep a generator-neutral adapter with Astro as the first implementation.
-- [ ] CLAR-V08-002 - Confirm whether the generated site must preserve `sites/index.html` as the canonical source file or may make it a generated artifact committed or built by CI.
-- [ ] CLAR-V08-003 - Confirm whether downstream adopters should get the product-page generator by default or as an opt-in scaffold.
+- [x] CLAR-V08-001 - Adopt Astro as the default generator. Keep content/source boundaries plain Markdown so downstream projects can replace Astro, but do not build a generator-neutral adapter layer in v0.8.
+- [x] CLAR-V08-002 - `sites/index.html` is no longer the canonical source. Canonical source becomes Markdown/content plus Astro source. Generated output is build/deploy output; preserve direct-open behavior after build and document the changed contract.
+- [x] CLAR-V08-003 - Downstream adopters get the product-page generator as an opt-in scaffold, not mandatory default weight for every fork. Specorator itself can use it by default.

--- a/specs/version-0-9-plan/workflow-state.md
+++ b/specs/version-0-9-plan/workflow-state.md
@@ -3,8 +3,8 @@ feature: version-0-9-plan
 area: V09
 current_stage: implementation
 status: active
-last_updated: 2026-05-01
-last_agent: planner
+last_updated: 2026-05-02
+last_agent: codex
 artifacts:
   idea.md: complete
   research.md: complete
@@ -51,9 +51,10 @@ artifacts:
 
 - Tracker issue: https://github.com/Luis85/agentic-workflow/issues/125
 - 2026-05-01 (codex): Planned v0.9 through Stage 6 from the request for a stakeholder sparring partner before v1.0. Recommended implementation order is define the `stakeholder-sparring.md` artifact contract, add the roadmap sparring command or skill, extend evidence collection, add named-stakeholder guardrails, update roadmap docs/agents/skills/command inventories, add validation and examples, then run full verification.
+- 2026-05-02 (Decider): CLAR-V09-001, CLAR-V09-002, and CLAR-V09-003 resolved in the cross-plan clarification slate. v0.9 uses a single append-oriented `roadmaps/<slug>/stakeholder-sparring.md` artifact. The first implementation exposes both `/roadmap:spar` as the command surface and a reusable skill/manual flow for non-Claude tools. Default evidence sources are committed roadmap/spec/project artifacts, communication logs, decision logs, issue/PR comments, and human-approved summaries; raw transcripts or private past conversations are excluded unless explicitly supplied or approved for that session.
 
 ## Open clarifications
 
-- [ ] CLAR-V09-001 - Confirm whether the preparation artifact should be named `stakeholder-sparring.md` or split into per-stakeholder files.
-- [ ] CLAR-V09-002 - Confirm whether the first implementation should expose `/roadmap:spar`, a skill-only flow, or both.
-- [ ] CLAR-V09-003 - Confirm which past-conversation sources are acceptable by default beyond committed communication and decision logs.
+- [x] CLAR-V09-001 - Use a single append-oriented `roadmaps/<slug>/stakeholder-sparring.md` artifact for v0.9. Defer per-stakeholder files until volume proves the need.
+- [x] CLAR-V09-002 - Expose both `/roadmap:spar` as the command surface and a reusable skill/manual flow for non-Claude tools. The command is the happy path; the skill preserves portability.
+- [x] CLAR-V09-003 - Default allowed sources are committed roadmap/spec/project artifacts, communication logs, decision logs, issue/PR comments, and human-approved summaries. Raw transcripts or private past conversations are excluded unless explicitly supplied or approved for that session.

--- a/tests/scripts/quality-metrics.test.ts
+++ b/tests/scripts/quality-metrics.test.ts
@@ -99,15 +99,14 @@ test("collectQualityMetrics counts skipped canonical artifacts as expected-compl
 });
 
 test("collectQualityMetrics surfaces open clarifications in workflow counts and signals", () => {
-  const fixtureDir = path.join("specs", "__quality-metrics-open-clarification-fixture");
-  fs.rmSync(fixtureDir, { recursive: true, force: true });
-  fs.mkdirSync(fixtureDir, { recursive: true });
+  const fixtureDir = fs.mkdtempSync(path.join("specs", "__quality-metrics-open-clarification-fixture-"));
+  const feature = path.basename(fixtureDir);
 
   try {
     fs.writeFileSync(
       path.join(fixtureDir, "workflow-state.md"),
       `---
-feature: __quality-metrics-open-clarification-fixture
+feature: ${feature}
 area: QMO
 current_stage: idea
 status: active
@@ -155,13 +154,11 @@ artifacts:
 `,
     );
 
-    const metrics = collectQualityMetrics({ feature: "__quality-metrics-open-clarification-fixture" });
+    const metrics = collectQualityMetrics({ feature });
     const workflow = metrics.workflows[0];
     assert.equal(workflow.openClarifications, 1);
     assert.equal(
-      metrics.signals.openClarifications.some((signal) =>
-        signal.includes("__quality-metrics-open-clarification-fixture"),
-      ),
+      metrics.signals.openClarifications.some((signal) => signal.includes(feature)),
       true,
     );
   } finally {

--- a/tests/scripts/quality-metrics.test.ts
+++ b/tests/scripts/quality-metrics.test.ts
@@ -99,14 +99,74 @@ test("collectQualityMetrics counts skipped canonical artifacts as expected-compl
 });
 
 test("collectQualityMetrics surfaces open clarifications in workflow counts and signals", () => {
-  const metrics = collectQualityMetrics({ feature: "project-consistency-hardening" });
-  const workflow = metrics.workflows[0];
-  // Two unresolved CLAR-CONS-* checklist items in workflow-state.md §Open clarifications.
-  assert.equal(workflow.openClarifications >= 2, true);
-  assert.equal(
-    metrics.signals.openClarifications.some((signal) => signal.includes("project-consistency-hardening")),
-    true,
-  );
+  const fixtureDir = path.join("specs", "__quality-metrics-open-clarification-fixture");
+  fs.rmSync(fixtureDir, { recursive: true, force: true });
+  fs.mkdirSync(fixtureDir, { recursive: true });
+
+  try {
+    fs.writeFileSync(
+      path.join(fixtureDir, "workflow-state.md"),
+      `---
+feature: __quality-metrics-open-clarification-fixture
+area: QMO
+current_stage: idea
+status: active
+last_updated: 2026-05-02
+last_agent: test
+artifacts:
+  idea.md: pending
+  research.md: pending
+  requirements.md: pending
+  design.md: pending
+  spec.md: pending
+  tasks.md: pending
+  implementation-log.md: pending
+  test-plan.md: pending
+  test-report.md: pending
+  review.md: pending
+  traceability.md: pending
+  release-notes.md: pending
+  retrospective.md: pending
+---
+
+# Workflow state - quality metrics open clarification fixture
+
+## Stage progress
+
+| Stage | Artifact | Status |
+|---|---|---|
+| 1. Idea | \`idea.md\` | pending |
+
+## Skips
+
+- None.
+
+## Blocks
+
+- None.
+
+## Hand-off notes
+
+- Test fixture.
+
+## Open clarifications
+
+- [ ] CLAR-QMO-001 - Fixture open question.
+`,
+    );
+
+    const metrics = collectQualityMetrics({ feature: "__quality-metrics-open-clarification-fixture" });
+    const workflow = metrics.workflows[0];
+    assert.equal(workflow.openClarifications, 1);
+    assert.equal(
+      metrics.signals.openClarifications.some((signal) =>
+        signal.includes("__quality-metrics-open-clarification-fixture"),
+      ),
+      true,
+    );
+  } finally {
+    fs.rmSync(fixtureDir, { recursive: true, force: true });
+  }
 });
 
 test("collectQualityMetrics ignores resolved clarification checklist items", () => {


### PR DESCRIPTION
## Summary

- Records the approved cross-plan CLAR decision slate across consistency hardening, v0.6, v0.8, and v0.9 workflow state.
- Clears the remaining unresolved CLAR checklist items from tracked workflow-state files.
- Updates the quality-metrics open-clarification test so it uses an isolated fixture instead of depending on live repo clarification debt.

## Verification

- `rg -n "^- \\[ \\] CLAR-" specs -g "workflow-state.md"` returned no matches.
- `npm run check:workflow` passed.
- `npm run quality:metrics -- --json` passed and reported no open clarification signals.
- `npm run test:scripts` passed, 264/264 tests.
- `npm run verify` passed in 18.4s after `npm ci` in the fresh worktree.

## Linked Issues

- Resolves the repo-state side of #196.
- Unblocks #195 scope-cut decisions for v0.6.

docs-only state update plus one test hardening change.