### PR TITLE
docs(v06): record scope-cut verdicts

### DIFF
--- a/specs/version-0-6-plan/implementation-log.md
+++ b/specs/version-0-6-plan/implementation-log.md
@@ -38,12 +38,23 @@ A running record of what was implemented, why a deviation was taken, and what wa
 - **Deviation from spec:** none
 - **Notes:** Added product, UX, technical, quality, and operations steering for Specorator itself. The downstream steering files remain blank starter templates; their README now points agents to the correct steering source for template-improvement work.
 
+### 2026-05-02 - #195 - Record v0.6 scope-cut verdicts
+
+- **Files changed:** `specs/version-0-6-plan/workflow-state.md`; `specs/version-0-6-plan/implementation-log.md`
+- **Commit:** this PR.
+- **Spec reference:** T-V06-003 through T-V06-014 scope governance
+- **Owner:** codex
+- **Outcome:** done
+- **Deviation from spec:** PR-D hook packs (T-V06-008/T-V06-009) slips to v0.7.
+- **Notes:** To protect the v1.0 timeline, v0.6 keeps PR-B golden-path proof, PR-C thin adapter set, PR-E QA/reviewer security path, PR-F adoption profiles, and PR-G ISO watch item. PR-D remains valuable but is optional automation hardening and should not block v0.6, PR-H positioning, PR-I release readiness, or v1.0 readiness.
+
 ## Deviations summary
 
 | Date | Task | Deviation | Reason | ADR |
 |---|---|---|---|---|
 | 2026-05-02 | T-V06-001 | None | Existing template ownership preserved. | - |
 | 2026-05-02 | T-V06-002 | None | Implementation follows SPEC-V06-001. | - |
+| 2026-05-02 | T-V06-008/T-V06-009 | Slipped to v0.7 | Optional hook automation expands pre-v1.0 surface area and is not required for v1.0 readiness. | - |
 
 ## Quality gate
 

--- a/specs/version-0-6-plan/implementation-log.md
+++ b/specs/version-0-6-plan/implementation-log.md
@@ -40,13 +40,13 @@ A running record of what was implemented, why a deviation was taken, and what wa
 
 ### 2026-05-02 - #195 - Record v0.6 scope-cut verdicts
 
-- **Files changed:** `specs/version-0-6-plan/workflow-state.md`; `specs/version-0-6-plan/implementation-log.md`
+- **Files changed:** `specs/version-0-6-plan/workflow-state.md`; `specs/version-0-6-plan/tasks.md`; `specs/version-0-6-plan/implementation-log.md`
 - **Commit:** this PR.
 - **Spec reference:** T-V06-003 through T-V06-014 scope governance
 - **Owner:** codex
 - **Outcome:** done
 - **Deviation from spec:** PR-D hook packs (T-V06-008/T-V06-009) slips to v0.7.
-- **Notes:** To protect the v1.0 timeline, v0.6 keeps PR-B golden-path proof, PR-C thin adapter set, PR-E QA/reviewer security path, PR-F adoption profiles, and PR-G ISO watch item. PR-D remains valuable but is optional automation hardening and should not block v0.6, PR-H positioning, PR-I release readiness, or v1.0 readiness.
+- **Notes:** To protect the v1.0 timeline, v0.6 keeps PR-B golden-path proof, PR-C thin adapter set, PR-E QA/reviewer security path, PR-F adoption profiles, and PR-G ISO watch item. PR-D remains valuable but is optional automation hardening and should not block v0.6, PR-H positioning, PR-I release readiness, or v1.0 readiness. T-V06-012 no longer depends on T-V06-009; hook-pack positioning waits for v0.7.
 
 ## Deviations summary
 

--- a/specs/version-0-6-plan/tasks.md
+++ b/specs/version-0-6-plan/tasks.md
@@ -100,7 +100,8 @@ updated: 2026-05-01
 
 - **Description:** Update README and product page language for live proof, cross-tool adapters, hook guardrails, agentic security, and comparison against lighter spec-driven or prompt-library alternatives.
 - **Satisfies:** REQ-V06-010, NFR-V06-005, SPEC-V06-007
-- **Depends on:** T-V06-004, T-V06-006, T-V06-009, T-V06-010, T-V06-011
+- **Depends on:** T-V06-004, T-V06-006, T-V06-010, T-V06-011
+- **Scope note:** Hook guardrail positioning is deferred until T-V06-009 lands in v0.7; v0.6 public positioning should omit hook-pack claims.
 - **Owner:** release-manager
 - **Estimate:** M
 

--- a/specs/version-0-6-plan/workflow-state.md
+++ b/specs/version-0-6-plan/workflow-state.md
@@ -53,6 +53,19 @@ artifacts:
 - 2026-05-02 (codex, T-V06-001/T-V06-002): PR-A selected the additive steering split: downstream starter templates stay in `docs/steering/`, while Specorator's own product steering lives in `docs/specorator-product/`. No ADR required because existing template ownership was preserved. Implementation evidence lives in `implementation-log.md`.
 - 2026-05-02 (codex, CLAR-V06-002): ADR-0026 freezes the v1.0 track taxonomy and resolves agentic security as a QA/reviewer extension, not a new optional track. T-V06-010 should add an OWASP-aligned review path as an opt-in checklist/skill usable from Quality Assurance, Review, or Release readiness without creating a new state-bearing workflow.
 - 2026-05-02 (Decider): CLAR-V06-001 and CLAR-V06-003 resolved in the cross-plan clarification slate. v0.6 ships a thin first-class adapter set: Claude Code baseline, Codex, Copilot, and one editor-agent path through Cursor/Aider-style guidance; fuller native adapters or generation are deferred. Golden-path proof starts as maintainer-run evidence plus CI validation of artifacts/scripts; full CI execution of the interactive demo is deferred until the path is stable.
+- 2026-05-02 (codex, #195): Scope-cut verdicts recorded to protect the v1.0 timeline. PR-B, PR-C, PR-E, PR-F, and PR-G ship in v0.6 with the CLAR constraints below. PR-D hook packs slips to v0.7 because it is optional automation hardening and not required for v1.0 readiness. PR-H public positioning should cite shipped evidence from PR-B, PR-C, PR-E, and PR-F, with hook-pack claims omitted until v0.7. PR-I release readiness should verify the ISO watch item from PR-G and record PR-D as a planned v0.7 follow-up, not a v0.6 blocker.
+
+## Scope-cut verdicts
+
+| PR | Tasks | Verdict | v0.6 scope |
+|---|---|---|---|
+| #175 PR-A steering profile | T-V06-001, T-V06-002 | Shipped in v0.6 | Merged. No further scope decision needed. |
+| #176 PR-B golden-path proof | T-V06-003, T-V06-004 | Ships in v0.6 | Maintainer-run evidence plus CI validation of artifacts/scripts. Fully automated interactive CI demo is deferred until stable. |
+| #177 PR-C cross-tool adapters | T-V06-005, T-V06-006, T-V06-007 | Ships in v0.6 | Thin first-class set only: Claude Code baseline, Codex, Copilot, and one Cursor/Aider-style editor-agent guidance path. Fuller native adapters or generation are deferred beyond v0.6. |
+| #178 PR-D hook packs | T-V06-008, T-V06-009 | Slips to v0.7 | Keep as opt-in automation hardening. Do not block v0.6 or v1.0 readiness on advisory hook examples. |
+| #179 PR-E agentic security review path | T-V06-010 | Ships in v0.6 | QA/reviewer extension only. No new optional track or state-bearing workflow. |
+| #180 PR-F adoption profiles | T-V06-011 | Ships in v0.6 | Lightweight persona routing to existing surfaces. No duplicate manuals. |
+| #181 PR-G ISO 9001:2026 watch item | T-V06-013 | Ships in v0.6 | Watch item and follow-up trigger only. No premature ISO requirement or compliance change. |
 
 ## Open clarifications
 


### PR DESCRIPTION
## Summary

- Records explicit v0.6 ship/slip verdicts for the remaining Wave 1 PRs from #195.
- Marks PR-D hook packs as slipped to v0.7 while keeping PR-B, PR-C, PR-E, PR-F, and PR-G in v0.6 with the existing CLAR constraints.
- Adds an implementation-log entry noting the only scope deviation: T-V06-008/T-V06-009 move out of v0.6.

## Verification

- `npm run check:workflow`
- `npm run verify`

## Linked Work

- Closes #195
- Updates v0.6 tracker #91 after PR creation

## Known Limitations

- This PR records the scope-cut decision in repo artifacts. The linked GitHub tracker body is updated separately because it is not stored in the repository.