### PR TITLE
fix(release): relax tag-at-main check to first-parent history (#233)

### DIFF
--- a/docs/adr/0020-v05-release-branch-strategy.md
+++ b/docs/adr/0020-v05-release-branch-strategy.md
@@ -132,6 +132,10 @@ This convention is documented in `docs/branching.md` and is the single answer re
 - `.claude/settings.json` — push deny for `main` and `develop`.
 - CLAR-V05-001 — open clarification resolved by this ADR.
 
+## Errata
+
+- **2026-05-02.** §Compliance reads "the readiness check validates the release source by asserting the tag commit is reachable from `main` and that the version on `main` matches the release tag." The first iteration of `scripts/lib/release-readiness.ts` implemented this with a strict `tag SHA == main HEAD SHA` comparison rather than reachability. During the v0.5.1 recovery dispatch (#233 prevention F) this strict reading tripped twice — once when an unrelated PR merged to `main` after the tag was cut, and again when a follow-up direct commit landed on `main` between the draft and stable dispatches. The check has been corrected to assert that the tag commit is on `main`'s **first-parent history** (one SHA per merge / direct commit, walking left parents from HEAD). This matches §Compliance's "reachable from `main`" wording and removes the tag-chase failure mode without weakening the rule that tags must originate on `main` proper — a tag on a feature-branch tip merged via a PR is still rejected because it sits on the second-parent edge. The decision recorded by this ADR — Shape A plus `release/vX.Y.Z`, with tags cut from `main` — is unchanged.
+
 ---
 
 > **ADR bodies are immutable.** To change a decision, supersede it with a new ADR; only the predecessor's `status` and `superseded-by` pointer fields may be updated.

--- a/docs/scripts/lib/release-readiness/functions/checkReleaseReadiness.md
+++ b/docs/scripts/lib/release-readiness/functions/checkReleaseReadiness.md
@@ -13,7 +13,10 @@ Validate a release candidate against the v0.5 readiness contract.
 Runs Layer 1 (release metadata correctness) in fixed order:
 
 1. Version alignment — `package.json#version` matches the release version.
-2. Tag readiness — release tag points at `main` HEAD per ADR-0020.
+2. Tag readiness — release tag is on `main`'s first-parent history per
+   ADR-0020 §Compliance ("the tag commit is reachable from `main`"). The
+   earlier strict reading (tag SHA == `main` HEAD SHA) was relaxed in
+   #233 prevention F.
 3. CHANGELOG entry — `CHANGELOG.md` has a `## [vX.Y.Z]` heading.
 4. Lifecycle release notes — `.github/release.yml` shape per T-V05-003.
 5. Package metadata — name, registry, repository, files per package contract.

--- a/docs/scripts/lib/release-readiness/interfaces/GitInterface.md
+++ b/docs/scripts/lib/release-readiness/interfaces/GitInterface.md
@@ -8,14 +8,39 @@
 
 Minimal git facade for tag-readiness assertions.
 
-Implementations must return a **commit SHA** for the supplied ref,
+`resolveRef` must return a **commit SHA** for the supplied ref,
 dereferencing (peeling) annotated tags so an annotated `vX.Y.Z` and
 `refs/heads/main` are comparable. Real callers wire this with
 `git rev-parse <ref>^{commit}` so annotated and lightweight tags resolve
 the same way (Codex round-3 P1 on PR #158). Tests inject a stub mapping
 directly to commit SHAs.
 
+`firstParentChain` returns `main`'s first-parent ancestry as a list of
+commit SHAs starting at `main` HEAD and walking back through merge-commit
+left parents. Tag readiness uses this to assert the release tag sits on
+`main`'s first-parent history (ADR-0020 §Compliance), not strictly at
+`main` HEAD. The strict-HEAD reading made the v0.5.0 / v0.5.1 publish
+dispatches trip whenever an unrelated PR merged into `main` between the
+tag cut and the dispatch (#233 prevention F). Returns `null` when the
+chain cannot be resolved (ref missing, git error).
+
 ## Methods
+
+### firstParentChain()
+
+> **firstParentChain**(`ref`): readonly `string`[] \| `null`
+
+#### Parameters
+
+##### ref
+
+`string`
+
+#### Returns
+
+readonly `string`[] \| `null`
+
+***
 
 ### resolveRef()
 

--- a/scripts/check-release-readiness.ts
+++ b/scripts/check-release-readiness.ts
@@ -157,6 +157,28 @@ function realGit(): GitInterface {
         return null;
       }
     },
+    firstParentChain(ref: string): readonly string[] | null {
+      // `git rev-list --first-parent <ref>` walks merge commits via their
+      // left parent only — exactly the chain a release tag may sit on per
+      // ADR-0020 §Compliance. Output is one SHA per line, newest first.
+      // Used by `checkTagOnMainHistory` to relax the strict-HEAD reading
+      // that tripped during the v0.5.1 recovery dispatch (#233 prevention F).
+      try {
+        const out = execFileSync(
+          "git",
+          ["rev-list", "--first-parent", ref],
+          {
+            cwd: repoRoot,
+            encoding: "utf8",
+            windowsHide: true,
+            stdio: ["ignore", "pipe", "ignore"],
+          },
+        );
+        return out.split(/\r?\n/).map((s) => s.trim()).filter((s) => s !== "");
+      } catch {
+        return null;
+      }
+    },
   };
 }
 

--- a/scripts/lib/release-readiness.ts
+++ b/scripts/lib/release-readiness.ts
@@ -97,15 +97,25 @@ export const MIN_QUALITY_MATURITY_LEVEL = 3;
 /**
  * Minimal git facade for tag-readiness assertions.
  *
- * Implementations must return a **commit SHA** for the supplied ref,
+ * `resolveRef` must return a **commit SHA** for the supplied ref,
  * dereferencing (peeling) annotated tags so an annotated `vX.Y.Z` and
  * `refs/heads/main` are comparable. Real callers wire this with
  * `git rev-parse <ref>^{commit}` so annotated and lightweight tags resolve
  * the same way (Codex round-3 P1 on PR #158). Tests inject a stub mapping
  * directly to commit SHAs.
+ *
+ * `firstParentChain` returns `main`'s first-parent ancestry as a list of
+ * commit SHAs starting at `main` HEAD and walking back through merge-commit
+ * left parents. Tag readiness uses this to assert the release tag sits on
+ * `main`'s first-parent history (ADR-0020 §Compliance), not strictly at
+ * `main` HEAD. The strict-HEAD reading made the v0.5.0 / v0.5.1 publish
+ * dispatches trip whenever an unrelated PR merged into `main` between the
+ * tag cut and the dispatch (#233 prevention F). Returns `null` when the
+ * chain cannot be resolved (ref missing, git error).
  */
 export interface GitInterface {
   resolveRef(ref: string): string | null;
+  firstParentChain(ref: string): readonly string[] | null;
 }
 
 /**
@@ -230,7 +240,10 @@ export function parseReleaseReadinessArgs(
  * Runs Layer 1 (release metadata correctness) in fixed order:
  *
  * 1. Version alignment — `package.json#version` matches the release version.
- * 2. Tag readiness — release tag points at `main` HEAD per ADR-0020.
+ * 2. Tag readiness — release tag is on `main`'s first-parent history per
+ *    ADR-0020 §Compliance ("the tag commit is reachable from `main`"). The
+ *    earlier strict reading (tag SHA == `main` HEAD SHA) was relaxed in
+ *    #233 prevention F.
  * 3. CHANGELOG entry — `CHANGELOG.md` has a `## [vX.Y.Z]` heading.
  * 4. Lifecycle release notes — `.github/release.yml` shape per T-V05-003.
  * 5. Package metadata — name, registry, repository, files per package contract.
@@ -258,7 +271,7 @@ export function checkReleaseReadiness(opts: ReleaseReadinessOptions): ReleaseRea
   const pkg = readPackageJson(opts.repoRoot, packageJsonPath);
 
   diagnostics.push(...checkVersionAlignment(pkg, opts.version, packageJsonPath));
-  if (opts.git) diagnostics.push(...checkTagAtMain(opts.git, opts.version));
+  if (opts.git) diagnostics.push(...checkTagOnMainHistory(opts.git, opts.version));
   diagnostics.push(...checkChangelog(opts.repoRoot, changelogPath, opts.version));
   diagnostics.push(...checkReleaseNotesConfig(opts.repoRoot, releaseNotesPath));
   diagnostics.push(
@@ -333,7 +346,7 @@ function checkVersionAlignment(
   return [];
 }
 
-function checkTagAtMain(git: GitInterface, version: string): Diagnostic[] {
+function checkTagOnMainHistory(git: GitInterface, version: string): Diagnostic[] {
   const tagRef = `v${version}`;
   const tagSha = git.resolveRef(tagRef);
   if (!tagSha) {
@@ -353,11 +366,27 @@ function checkTagAtMain(git: GitInterface, version: string): Diagnostic[] {
       },
     ];
   }
-  if (tagSha !== mainSha) {
+  // Walk `main`'s first-parent chain. The tag may legitimately sit at any
+  // first-parent ancestor of HEAD — the strict-HEAD reading tripped twice
+  // during the v0.5.1 recovery dispatch when unrelated PRs merged between
+  // the tag cut and the dispatch (#233 prevention F). First-parent (not
+  // full reachability) keeps the rule "tag is on main proper" — a tag on
+  // a feature-branch tip merged via a PR is reachable but lives on the
+  // second-parent edge, which we still reject.
+  const chain = git.firstParentChain("refs/heads/main") ?? git.firstParentChain("main");
+  if (!chain) {
     return [
       {
         code: RELEASE_READINESS_DIAGNOSTIC_CODES.TagNotAtMain,
-        message: `tag \`${tagRef}\` (${tagSha.slice(0, 7)}) is not at \`main\` HEAD (${mainSha.slice(0, 7)}) — ADR-0020 requires tags cut from \`main\``,
+        message: "could not resolve `main` first-parent chain; tag readiness cannot be verified",
+      },
+    ];
+  }
+  if (!chain.includes(tagSha)) {
+    return [
+      {
+        code: RELEASE_READINESS_DIAGNOSTIC_CODES.TagNotAtMain,
+        message: `tag \`${tagRef}\` (${tagSha.slice(0, 7)}) is not on \`main\` first-parent history (HEAD ${mainSha.slice(0, 7)}) — ADR-0020 requires tags cut from \`main\``,
       },
     ];
   }

--- a/tests/scripts/release-readiness.test.ts
+++ b/tests/scripts/release-readiness.test.ts
@@ -113,6 +113,10 @@ const STUB_GIT: GitInterface = {
     if (ref === "refs/heads/main" || ref === "main") return TAG_SHA;
     return null;
   },
+  firstParentChain(ref) {
+    if (ref === "refs/heads/main" || ref === "main") return [TAG_SHA];
+    return null;
+  },
 };
 
 interface FixtureOverrides {
@@ -583,7 +587,7 @@ test("tag readiness: missing tag fails TagMissing", () => {
     const report = checkReleaseReadiness({
       version: VERSION,
       repoRoot,
-      git: { resolveRef: () => null },
+      git: { resolveRef: () => null, firstParentChain: () => null },
       qualitySignals: GREEN_QUALITY,
     });
     const d = report.diagnostics.find(
@@ -595,16 +599,27 @@ test("tag readiness: missing tag fails TagMissing", () => {
   }
 });
 
-test("tag readiness: tag SHA differs from main HEAD fails TagNotAtMain", () => {
+test("tag readiness: tag SHA off `main` first-parent chain fails TagNotAtMain", () => {
   const repoRoot = createFixture();
+  const TAG = "a".repeat(40);
+  const HEAD = "b".repeat(40);
+  const ANCESTOR = "c".repeat(40);
   try {
     const report = checkReleaseReadiness({
       version: VERSION,
       repoRoot,
       git: {
         resolveRef(ref) {
-          if (ref === `v${VERSION}`) return "a".repeat(40);
-          if (ref === "refs/heads/main" || ref === "main") return "b".repeat(40);
+          if (ref === `v${VERSION}`) return TAG;
+          if (ref === "refs/heads/main" || ref === "main") return HEAD;
+          return null;
+        },
+        firstParentChain(ref) {
+          // `main` first-parent ancestry omits the tag SHA — covers the
+          // "tag on a feature-branch tip merged via a PR" case where the
+          // tag is reachable via the second-parent edge but never lands on
+          // main proper.
+          if (ref === "refs/heads/main" || ref === "main") return [HEAD, ANCESTOR];
           return null;
         },
       },
@@ -613,7 +628,76 @@ test("tag readiness: tag SHA differs from main HEAD fails TagNotAtMain", () => {
     const d = report.diagnostics.find(
       (x) => x.code === RELEASE_READINESS_DIAGNOSTIC_CODES.TagNotAtMain,
     );
-    assert.ok(d, "expected TagNotAtMain when tag SHA != main HEAD");
+    assert.ok(d, "expected TagNotAtMain when tag SHA is not on main first-parent chain");
+    assert.match(
+      d!.message,
+      /first-parent history/,
+      "diagnostic message should explain the first-parent semantics",
+    );
+  } finally {
+    cleanup(repoRoot);
+  }
+});
+
+test("tag readiness: tag SHA on `main` first-parent ancestry (not at HEAD) passes — #233 prevention F", () => {
+  const repoRoot = createFixture();
+  const HEAD = "b".repeat(40);
+  const TAG = "a".repeat(40);
+  const ANCESTOR = "c".repeat(40);
+  try {
+    const report = checkReleaseReadiness({
+      version: VERSION,
+      repoRoot,
+      git: {
+        resolveRef(ref) {
+          if (ref === `v${VERSION}`) return TAG;
+          if (ref === "refs/heads/main" || ref === "main") return HEAD;
+          return null;
+        },
+        firstParentChain(ref) {
+          // `main` first-parent: HEAD → TAG → ANCESTOR. Tag is on chain,
+          // but main has advanced past it. Strict-HEAD reading would
+          // reject; first-parent-history reading accepts (ADR-0020 says
+          // "tag is reachable from main", not "tag is at HEAD").
+          if (ref === "refs/heads/main" || ref === "main") return [HEAD, TAG, ANCESTOR];
+          return null;
+        },
+      },
+      qualitySignals: GREEN_QUALITY,
+    });
+    const d = report.diagnostics.find(
+      (x) => x.code === RELEASE_READINESS_DIAGNOSTIC_CODES.TagNotAtMain,
+    );
+    assert.equal(
+      d,
+      undefined,
+      "TagNotAtMain must not fire when tag is on main first-parent ancestry — #233 prevention F",
+    );
+  } finally {
+    cleanup(repoRoot);
+  }
+});
+
+test("tag readiness: unresolvable first-parent chain fails TagNotAtMain", () => {
+  const repoRoot = createFixture();
+  try {
+    const report = checkReleaseReadiness({
+      version: VERSION,
+      repoRoot,
+      git: {
+        resolveRef(ref) {
+          if (ref === `v${VERSION}`) return TAG_SHA;
+          if (ref === "refs/heads/main" || ref === "main") return TAG_SHA;
+          return null;
+        },
+        firstParentChain: () => null,
+      },
+      qualitySignals: GREEN_QUALITY,
+    });
+    const d = report.diagnostics.find(
+      (x) => x.code === RELEASE_READINESS_DIAGNOSTIC_CODES.TagNotAtMain,
+    );
+    assert.ok(d, "expected TagNotAtMain when first-parent chain is unresolvable");
   } finally {
     cleanup(repoRoot);
   }


### PR DESCRIPTION
## Summary

Prevention **F** from the #233 punch list. Brings the release-readiness Layer 1 tag check into line with ADR-0020 §Compliance ("the tag commit is reachable from `main`") instead of the stricter `tag SHA == main HEAD SHA` reading the original implementation used.

The strict reading tripped twice during the v0.5.1 recovery alone — once when an unrelated PR merged into `main` between the tag cut and the dispatch, and once when a follow-up direct commit landed on `main` between the draft and stable dispatches.

## Why first-parent ancestry, not full reachability

A tag on a feature-branch tip merged into `main` via a PR is reachable from `main` HEAD, but lives on the **second-parent** edge of the merge commit. We still want to reject that — the rule "tags originate on `main` proper" is what `release/vX.Y.Z`-then-tag is supposed to enforce.

`git rev-list --first-parent <ref>` walks merge commits via their **left** parent only, which gives exactly the chain a release tag may legitimately sit on:

- merge commit on main → tag here ✓ (first-parent)
- direct commit on main → tag here ✓ (first-parent)
- feature-branch tip merged in → tag here ✗ (reached via second parent)

## Changes

- `scripts/lib/release-readiness.ts`
  - `GitInterface` gains `firstParentChain(ref): readonly string[] | null`.
  - `checkTagAtMain` renamed to `checkTagOnMainHistory`; body walks the chain and asserts membership instead of strict equality.
  - Diagnostic-code key `RELEASE_READINESS_TAG_NOT_AT_MAIN` and its string value stay stable so operator alerts, dashboards, and grep patterns are unaffected. Only the message is reworded ("first-parent history" instead of "main HEAD").
- `scripts/check-release-readiness.ts`
  - `realGit().firstParentChain` wires `git rev-list --first-parent <ref>`, mirroring the pattern of the existing `resolveRef`.
- `tests/scripts/release-readiness.test.ts`
  - Stub `STUB_GIT` gains a default-passing `firstParentChain`.
  - Existing `tag SHA differs from main HEAD` failure test reframed to cover the off-history case.
  - New test: tag on first-parent ancestry but not at HEAD passes — this is the v0.5.1 case the strict check rejected.
  - New test: unresolvable chain fails closed.
- `docs/adr/0020-v05-release-branch-strategy.md` §Errata records the correction. ADR body remains immutable; the decision is unchanged.
- Regenerated `docs/scripts/lib/release-readiness/{functions,interfaces}/...` typedoc.

## Test plan

- [x] `npm run test:scripts` — 4 tag-readiness tests pass.
- [x] `npm run verify` — green locally (18.0s).
- [ ] After merge: when v0.5.2 / v0.6 dispatch, the readiness check must accept a tag at any first-parent ancestor of `main` HEAD without an interstitial tag advance.

Refs #233 prevention F · ADR-0020 §Compliance · SPEC-V05-005.

🤖 Generated with [Claude Code](https://claude.com/claude-code)