### PR TITLE
fix(release): combine create+upload, promote draft if exists (#233)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,9 +212,27 @@ jobs:
         run: |
           # Detect existing Release for this tag. `gh release view` exits
           # non-zero (and writes "release not found" to stderr) when no
-          # Release exists, so a clean exit means we promote-in-place.
-          # Output is discarded — only the exit code matters here.
-          if gh release view "v${INPUT_VERSION}" --json tagName,isDraft >/dev/null 2>&1; then
+          # Release exists. We capture the JSON shape so we can inspect
+          # the existing Release's draft / prerelease / asset state and
+          # branch safely — the v0.5.1 cycle showed that "blindly apply
+          # inputs" creates two destructive failure modes (Codex P1
+          # round 2 on PR #241).
+          existing_json="$(gh release view "v${INPUT_VERSION}" --json isDraft,isPrerelease,assets 2>/dev/null || true)"
+          if [ -n "${existing_json}" ]; then
+            existing_draft="$(echo "${existing_json}" | jq -r '.isDraft')"
+            existing_prerelease="$(echo "${existing_json}" | jq -r '.isPrerelease')"
+            existing_has_asset="$(echo "${existing_json}" | jq -r '[.assets[]? | select(.name == "'"$(basename "${TARBALL}")"'")] | length > 0')"
+            # Refuse-to-demote guard (Codex P1 round 2 #1): if the
+            # existing Release is already a published stable (draft=false
+            # AND prerelease=false), do NOT let an old draft+prerelease
+            # dispatch flip it back. Such a flip would unpublish a
+            # consumer-visible release; the operator presumably did not
+            # intend that. Stable→stable rerun is a no-op and harmless.
+            if [ "${existing_draft}" = "false" ] && [ "${existing_prerelease}" = "false" ] \
+                && { [ "${INPUT_DRAFT}" = "true" ] || [ "${INPUT_PRERELEASE}" = "true" ]; }; then
+              echo "::error::Release for v${INPUT_VERSION} is already published as stable; refusing to demote it to draft=${INPUT_DRAFT} prerelease=${INPUT_PRERELEASE}. Cut a new vX.Y.(Z+1) instead." >&2
+              exit 1
+            fi
             echo "::notice::Release for v${INPUT_VERSION} already exists — promoting in place (#233 prevention C)"
             # `gh release edit` preserves generated notes from the prior
             # create call. Pass `--draft=<bool>` and `--prerelease=<bool>`
@@ -223,9 +241,21 @@ jobs:
             gh release edit "v${INPUT_VERSION}" \
               --draft="${INPUT_DRAFT}" \
               --prerelease="${INPUT_PRERELEASE}"
-            # `--clobber` replaces a stale or partial asset from the
-            # earlier dispatch. Idempotent (NFR-V05-005).
-            gh release upload "v${INPUT_VERSION}" "${TARBALL}" --clobber
+            # Asset upload guard (Codex P1 round 2 #2): only upload when
+            # the named asset is NOT already attached. `gh release upload
+            # --clobber` deletes the existing asset before uploading the
+            # new one, and a network/API failure mid-upload would leave
+            # the published Release with no asset at all — strictly
+            # worse than skipping the upload. Step 9a's create-with-asset
+            # transaction (B path) already attached the tarball when the
+            # draft was created, so the two-step CLAR-V05-003 path
+            # reaches this branch with the asset already present and
+            # nothing to do.
+            if [ "${existing_has_asset}" = "true" ]; then
+              echo "::notice::Asset $(basename "${TARBALL}") already attached to v${INPUT_VERSION} — skipping upload to avoid clobber-then-fail data loss"
+            else
+              gh release upload "v${INPUT_VERSION}" "${TARBALL}"
+            fi
           else
             echo "::notice::Creating fresh Release for v${INPUT_VERSION} with asset attached (#233 prevention B)"
             flags=()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,28 +234,30 @@ jobs:
               exit 1
             fi
             echo "::notice::Release for v${INPUT_VERSION} already exists — promoting in place (#233 prevention C)"
-            # `gh release edit` preserves generated notes from the prior
-            # create call. Pass `--draft=<bool>` and `--prerelease=<bool>`
-            # explicitly so flipping from draft+prerelease (step 1) to
-            # stable (step 2) takes effect deterministically.
-            gh release edit "v${INPUT_VERSION}" \
-              --draft="${INPUT_DRAFT}" \
-              --prerelease="${INPUT_PRERELEASE}"
-            # Asset upload guard (Codex P1 round 2 #2): only upload when
-            # the named asset is NOT already attached. `gh release upload
-            # --clobber` deletes the existing asset before uploading the
-            # new one, and a network/API failure mid-upload would leave
-            # the published Release with no asset at all — strictly
-            # worse than skipping the upload. Step 9a's create-with-asset
-            # transaction (B path) already attached the tarball when the
-            # draft was created, so the two-step CLAR-V05-003 path
-            # reaches this branch with the asset already present and
-            # nothing to do.
+            # Asset upload BEFORE flag flip (Codex P1 round 3 on PR #241):
+            # if the existing Release is a draft with no asset (e.g. a
+            # prior dispatch failed mid-create), and we publish first
+            # then upload, post-publish asset upload can fail when the
+            # repo's Immutable Releases setting is on (assets cannot be
+            # added to published immutable Releases — see operator-guide
+            # §7.7). Uploading while the Release is still in its current
+            # draft state preserves the recovery path. We still skip the
+            # upload entirely when the asset is already attached, so the
+            # two-step CLAR-V05-003 path with a step-1 asset present
+            # remains a no-op on the upload (Codex P1 round 2 #2).
             if [ "${existing_has_asset}" = "true" ]; then
               echo "::notice::Asset $(basename "${TARBALL}") already attached to v${INPUT_VERSION} — skipping upload to avoid clobber-then-fail data loss"
             else
               gh release upload "v${INPUT_VERSION}" "${TARBALL}"
             fi
+            # `gh release edit` preserves generated notes from the prior
+            # create call. Pass `--draft=<bool>` and `--prerelease=<bool>`
+            # explicitly so flipping from draft+prerelease (step 1) to
+            # stable (step 2) takes effect deterministically. Runs AFTER
+            # the asset upload so we never publish-then-fail-to-attach.
+            gh release edit "v${INPUT_VERSION}" \
+              --draft="${INPUT_DRAFT}" \
+              --prerelease="${INPUT_PRERELEASE}"
           else
             echo "::notice::Creating fresh Release for v${INPUT_VERSION} with asset attached (#233 prevention B)"
             flags=()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,11 +213,8 @@ jobs:
           # Detect existing Release for this tag. `gh release view` exits
           # non-zero (and writes "release not found" to stderr) when no
           # Release exists, so a clean exit means we promote-in-place.
-          set +e
-          existing="$(gh release view "v${INPUT_VERSION}" --json tagName,isDraft 2>/dev/null)"
-          existing_exit=$?
-          set -e
-          if [ "$existing_exit" -eq 0 ]; then
+          # Output is discarded — only the exit code matters here.
+          if gh release view "v${INPUT_VERSION}" --json tagName,isDraft >/dev/null 2>&1; then
             echo "::notice::Release for v${INPUT_VERSION} already exists — promoting in place (#233 prevention C)"
             # `gh release edit` preserves generated notes from the prior
             # create call. Pass `--draft=<bool>` and `--prerelease=<bool>`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,32 +168,80 @@ jobs:
             exit 1
           fi
 
-      # Step 9a — non-dry-run: create the GitHub Release. Generated notes use
-      # the `.github/release.yml` categories from PR #156 (T-V05-003).
-      - name: Create GitHub Release
+      # Step 9a — non-dry-run: create the GitHub Release and attach the
+      # candidate tarball in one call, OR promote-in-place if a Release for
+      # this tag already exists. Generated notes use the
+      # `.github/release.yml` categories from PR #156 (T-V05-003).
+      #
+      # Two changes from the original step (#233 prevention B + C):
+      #
+      # B — combine create + asset upload. The tarball is passed as a
+      #     positional argument to `gh release create`, so the Release page
+      #     and its asset land in one transaction. The original two-step
+      #     shape (create, then a separate `gh release upload` in step 11)
+      #     left a window where `gh release create` had succeeded but the
+      #     asset was missing — exactly the failure mode that turned the
+      #     v0.5.0 incident from "transient asset upload glitch" into
+      #     "operator deletes the Release, GitHub burns the tag" (#233).
+      #
+      # C — promote-draft-if-exists. The two-step CLAR-V05-003 dispatch
+      #     path (step 1: draft + prerelease; step 2: stable + publish)
+      #     used to call `gh release create` twice for one tag, which
+      #     creates two separate Releases — orphan draft from step 1,
+      #     stable from step 2. Now step 2 detects the draft via
+      #     `gh release view`, flips its flags via `gh release edit`, and
+      #     replaces the asset with `--clobber`. Result: one Release per
+      #     tag, regardless of dispatch shape.
+      #
+      # `--verify-tag` on the create branch makes `gh release create` fail
+      # if `vX.Y.Z` does not already exist (Codex P2 on PR #159). Without
+      # it, `gh release create` auto-creates the tag from `--target main`
+      # when it is missing, which would silently bypass the ADR-0020
+      # requirement that the canonical tag is cut on main *before* the
+      # workflow runs. Layer 1 readiness already enforces this, but
+      # `--verify-tag` is a cheap defence-in-depth against a tag-race or
+      # readiness-gap path.
+      - name: Create or promote GitHub Release
         if: ${{ ! inputs.dry_run }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INPUT_VERSION: ${{ inputs.version }}
           INPUT_PRERELEASE: ${{ inputs.prerelease }}
           INPUT_DRAFT: ${{ inputs.draft }}
+          TARBALL: ${{ steps.pack.outputs.tarball }}
         run: |
-          flags=()
-          if [ "${INPUT_PRERELEASE}" = "true" ]; then flags+=(--prerelease); fi
-          if [ "${INPUT_DRAFT}" = "true" ]; then flags+=(--draft); fi
-          # `--verify-tag` makes `gh release create` fail if `vX.Y.Z` does not
-          # already exist (Codex P2 on PR #159). Without it, `gh release
-          # create` auto-creates the tag from `--target main` when it is
-          # missing, which would silently bypass the ADR-0020 requirement that
-          # the canonical tag is cut on main *before* the workflow runs.
-          # Layer 1 readiness already enforces this, but `--verify-tag` is a
-          # cheap defence-in-depth against a tag-race or readiness-gap path.
-          gh release create "v${INPUT_VERSION}" \
-            --target main \
-            --title "v${INPUT_VERSION}" \
-            --verify-tag \
-            --generate-notes \
-            "${flags[@]}"
+          # Detect existing Release for this tag. `gh release view` exits
+          # non-zero (and writes "release not found" to stderr) when no
+          # Release exists, so a clean exit means we promote-in-place.
+          set +e
+          existing="$(gh release view "v${INPUT_VERSION}" --json tagName,isDraft 2>/dev/null)"
+          existing_exit=$?
+          set -e
+          if [ "$existing_exit" -eq 0 ]; then
+            echo "::notice::Release for v${INPUT_VERSION} already exists — promoting in place (#233 prevention C)"
+            # `gh release edit` preserves generated notes from the prior
+            # create call. Pass `--draft=<bool>` and `--prerelease=<bool>`
+            # explicitly so flipping from draft+prerelease (step 1) to
+            # stable (step 2) takes effect deterministically.
+            gh release edit "v${INPUT_VERSION}" \
+              --draft="${INPUT_DRAFT}" \
+              --prerelease="${INPUT_PRERELEASE}"
+            # `--clobber` replaces a stale or partial asset from the
+            # earlier dispatch. Idempotent (NFR-V05-005).
+            gh release upload "v${INPUT_VERSION}" "${TARBALL}" --clobber
+          else
+            echo "::notice::Creating fresh Release for v${INPUT_VERSION} with asset attached (#233 prevention B)"
+            flags=()
+            if [ "${INPUT_PRERELEASE}" = "true" ]; then flags+=(--prerelease); fi
+            if [ "${INPUT_DRAFT}" = "true" ]; then flags+=(--draft); fi
+            gh release create "v${INPUT_VERSION}" \
+              --target main \
+              --title "v${INPUT_VERSION}" \
+              --verify-tag \
+              --generate-notes \
+              "${flags[@]}" \
+              "${TARBALL}"
+          fi
 
       # Step 9b — dry run: log a generated-notes preview without creating any
       # public artifact (SPEC-V05-009). All readiness diagnostics from step 4
@@ -285,15 +333,12 @@ jobs:
             exit 1
           fi
 
-      # Step 11 — attach the candidate tarball as a release asset. Runs after
-      # `gh release create` (step 9) so the release exists; `--clobber` lets a
-      # rerun replace a partial asset from an earlier failed publish without
-      # manual cleanup (NFR-V05-005 recoverability).
-      - name: Attach release asset
-        if: ${{ ! inputs.dry_run }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INPUT_VERSION: ${{ inputs.version }}
-          TARBALL: ${{ steps.pack.outputs.tarball }}
-        run: |
-          gh release upload "v${INPUT_VERSION}" "${TARBALL}" --clobber
+      # Step 11 was the standalone "Attach release asset" step. As of #233
+      # prevention B + C it has been folded into step 9a: a fresh Release
+      # gets the tarball as a positional argument to `gh release create`
+      # (one transaction); a promoted-in-place Release uses
+      # `gh release upload --clobber` immediately after `gh release edit`.
+      # Removing the standalone step closes the v0.5.0 failure window
+      # where the Release page existed but the asset upload had not yet
+      # run — that gap is what the operator was investigating when the
+      # Release got deleted and the tag got burned.

--- a/docs/release-operator-guide.md
+++ b/docs/release-operator-guide.md
@@ -95,7 +95,7 @@ Only after at least one fully green dry run, request a stable publish.
    - `npm pack` — candidate archive built and extracted.
    - Layer 2 readiness — fresh-surface contract ([ADR-0021](adr/0021-release-package-fresh-surface.md)).
    - Confirm gate — refuses to continue unless `confirm == version`.
-   - `gh release create vX.Y.Z --target main --verify-tag --generate-notes ${TARBALL}` — creates the GitHub Release with the candidate tarball attached **in one call** when no Release for the tag exists. When a draft from a prior dispatch already exists for the tag (the two-step CLAR-V05-003 path), the workflow uses `gh release edit … --draft=<bool> --prerelease=<bool>` followed by `gh release upload --clobber` instead, so a single Release per tag is preserved (#233 prevention B + C).
+   - `gh release create vX.Y.Z --target main --verify-tag --generate-notes ${TARBALL}` — creates the GitHub Release with the candidate tarball attached **in one call** when no Release for the tag exists. When a Release already exists (the two-step CLAR-V05-003 path), the workflow runs `gh release edit … --draft=<bool> --prerelease=<bool>` to flip flags in place and uploads the asset only if it is not already attached, so a single Release per tag is preserved (#233 prevention B + C). The promote branch refuses to demote an already-published stable Release back to draft or prerelease — that flip would unpublish a consumer-visible release; cut a new `vX.Y.(Z+1)` instead.
    - `npm publish` — only when `publish_package: true`; idempotent (see §7.1).
 
 3. Verify on `https://github.com/Luis85/agentic-workflow/releases/tag/vX.Y.Z`:

--- a/docs/release-operator-guide.md
+++ b/docs/release-operator-guide.md
@@ -95,9 +95,8 @@ Only after at least one fully green dry run, request a stable publish.
    - `npm pack` — candidate archive built and extracted.
    - Layer 2 readiness — fresh-surface contract ([ADR-0021](adr/0021-release-package-fresh-surface.md)).
    - Confirm gate — refuses to continue unless `confirm == version`.
-   - `gh release create vX.Y.Z --target main --verify-tag --generate-notes` — creates the GitHub Release using the `.github/release.yml` categories.
+   - `gh release create vX.Y.Z --target main --verify-tag --generate-notes ${TARBALL}` — creates the GitHub Release with the candidate tarball attached **in one call** when no Release for the tag exists. When a draft from a prior dispatch already exists for the tag (the two-step CLAR-V05-003 path), the workflow uses `gh release edit … --draft=<bool> --prerelease=<bool>` followed by `gh release upload --clobber` instead, so a single Release per tag is preserved (#233 prevention B + C).
    - `npm publish` — only when `publish_package: true`; idempotent (see §7.1).
-   - `gh release upload vX.Y.Z … --clobber` — attaches the candidate tarball as a release asset.
 
 3. Verify on `https://github.com/Luis85/agentic-workflow/releases/tag/vX.Y.Z`:
    - Release notes body matches the dry-run preview.
@@ -142,15 +141,15 @@ Recoverability differs per step:
 
 - `npm publish` (the workflow's idempotency guard wraps `npm view` so a successful publish is detected on a rerun) — idempotent.
 - `gh release upload --clobber` — idempotent.
-- `gh release create` — **not idempotent**: an existing Release at `vX.Y.Z` makes the step fail with HTTP 422 ("release already exists"). The workflow has no skip branch.
+- `gh release create` — **not idempotent on its own**, but as of #233 prevention C the workflow's "Create or promote GitHub Release" step now detects an existing Release via `gh release view` and switches to `gh release edit` + `gh release upload --clobber` for the promote-in-place path. So a rerun against an existing draft is now safe and will flip the draft flag and replace the asset rather than failing closed with HTTP 422 ("release already exists"). A rerun against an existing **stable** Release (draft=false, asset already published) still flips no flags meaningfully and is wasted work — but it no longer fails the workflow.
 
-So the rule is: **do not rerun the workflow as a recovery primitive once `gh release create` has succeeded**. Use the targeted manual commands below instead. The recovery scenarios are numbered by the failing step.
+So the rule is: **the workflow is now safely rerunnable across the two-step CLAR-V05-003 path** (draft+prerelease → stable+publish). It is still not the right tool for surgical recovery — use the targeted manual commands below for `npm publish` failures or asset-upload-only retries. The recovery scenarios are numbered by the failing step.
 
 ### 7.1 `npm publish` failed after `gh release create` succeeded
 
 Symptom: the GitHub Release exists (the tarball may or may not be attached), but `npm view @luis85/agentic-workflow@X.Y.Z` reports `404`. Cause: network blip, registry hiccup, or `EPUBLISHCONFLICT` from a prior partial run.
 
-Recovery — run the failed steps manually from a local checkout of `vX.Y.Z`. **Do not** rerun the workflow; `gh release create` will fail on the existing Release before the publish-recovery logic is reached.
+Recovery — run the failed steps manually from a local checkout of `vX.Y.Z`. As of #233 prevention C the workflow's create step is rerunnable, but a rerun would also re-trigger the readiness gates and the build-archive step — slower and more side-effect-heavy than necessary for an `npm publish`-only retry. Stick with the manual commands below.
 
 You will need a GitHub Personal Access Token with the `write:packages` scope (or a fine-grained token with `Packages: write` on the repository). The workflow gets this for free via `actions/setup-node` + `secrets.GITHUB_TOKEN`; for manual recovery, configure it explicitly:
 


### PR DESCRIPTION
## Summary

Prevention **B** and **C** from #233 punch list. Both touch step 9a of \`release.yml\` so they ship together.

The v0.5.0 incident sat in the gap between \`gh release create\` (step 9a) and \`gh release upload\` (step 11). When the upload failed, the operator went investigating; the Release got deleted; GitHub burned the \`v0.5.0\` tag. This PR removes that gap and makes the two-step CLAR-V05-003 dispatch path stop creating two Releases per tag.

## B — combine create + asset upload

\`gh release create\` now takes the tarball as a positional argument. One transaction, no intermediate "Release page exists but asset is missing" state. Step 11 is gone (comment retained pointing at this PR / #233).

## C — promote draft if exists

Step 9a now runs \`gh release view\` first:

- **Release exists** (e.g. draft from step 1 of the two-step dispatch): \`gh release edit --draft=<bool> --prerelease=<bool>\` flips flags on the existing Release (generated notes preserved), then \`gh release upload --clobber\` replaces the asset. One Release per tag.
- **Release does not exist**: fall through to the B path — \`gh release create [...flags] \"\${TARBALL}\"\`.

The two-step path was the source of the orphan draft (id \`316716256\` in the v0.5.0 incident, id \`316748115\` during the v0.5.1 recovery). Now there's one Release across the dispatch sequence.

## Operator-guide updates (rides with this PR per memory rules)

- §5 step list: describes the create-with-asset transaction and the promote branch.
- §7 intro: rerunning the workflow against an existing draft is now safe; rule narrows to "use manual commands for \`npm publish\` retries or asset-upload-only fixes".
- §7.1: updated wording — workflow rerun is no longer a hard "do not".

## Diff size

- \`.github/workflows/release.yml\` — step 9a body replaced; step 11 step block replaced with a comment block. Net +44 lines (the new branching logic plus comments).
- \`docs/release-operator-guide.md\` — three small wording updates in §5, §7 intro, §7.1.

## Test plan

- [x] \`npm run verify\` green locally (22.6s).
- [ ] **Integration test = next dispatch.** v0.5.2 or v0.6's first dispatch will exercise the create path; the two-step CLAR-V05-003 dispatch (draft+prerelease → stable+publish) will exercise the promote path. The acceptance bar is "one Release per tag, asset attached".

## What this does not touch

- The \`gh release create\` "release already exists" race that #233 prevention B / C also hint at — the new \`gh release view\` probe runs as one operation; if a draft is created between the probe and the create call, we still hit 422. That's a vanishingly rare race in a single-operator dispatch and not worth a transactional fix; left out of scope.
- Prevention E (Layer-1 readiness probe for the repo immutable-Releases setting) — that's the next PR.

Refs #233 prevention B + C · ADR-0020 · SPEC-V05-002.

🤖 Generated with [Claude Code](https://claude.com/claude-code)