### PR TITLE
feat(release): add Layer-1 immutable-Releases probe (#233)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,11 @@ jobs:
           RELEASE_CI_STATUS: ${{ vars.RELEASE_CI_STATUS }}
           RELEASE_VALIDATION_STATUS: ${{ vars.RELEASE_VALIDATION_STATUS }}
           RELEASE_QUALITY_WAIVER: ${{ vars.RELEASE_QUALITY_WAIVER }}
+          # `gh api` requires an explicit token via GH_TOKEN; without it
+          # the immutable-releases probe (#233 prevention E) silently
+          # fails through its catch block and the warning never fires
+          # in production dispatches (Codex P1 round 3 on PR #242).
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run check:release-readiness -- --json
 
       # Step 5 — build the candidate archive. The release pipeline runs the

--- a/docs/release-operator-guide.md
+++ b/docs/release-operator-guide.md
@@ -370,6 +370,12 @@ The release-readiness scripts emit machine-stable codes. Treat them as the contr
 | `RELEASE_READINESS_WORKFLOW_PERMISSIONS` | Top-level `permissions:` block ≠ `{ contents: write, packages: write }`. |
 | `RELEASE_READINESS_QUALITY` | A v0.4 quality signal is missing or not green and no waiver is recorded. |
 
+### Layer 1 warnings (informational, do not fail the gate)
+
+| Code | Meaning |
+|---|---|
+| `RELEASE_READINESS_IMMUTABLE_REPO` | The most recent Release on this repository was created immutable — heuristic that Repo Setting "Immutable releases" is on (#233 prevention E). Surfaces as a `::warning::` annotation; does not block dispatch. Disable the setting or accept the failure mode knowingly before triggering. |
+
 ### Layer 2 — `scripts/lib/release-package-contract.ts`
 
 | Code | Meaning |

--- a/docs/release-operator-guide.md
+++ b/docs/release-operator-guide.md
@@ -374,7 +374,8 @@ The release-readiness scripts emit machine-stable codes. Treat them as the contr
 
 | Code | Meaning |
 |---|---|
-| `RELEASE_READINESS_IMMUTABLE_REPO` | The most recent Release on this repository was created immutable — heuristic that Repo Setting "Immutable releases" is on (#233 prevention E). Surfaces as a `::warning::` annotation; does not block dispatch. Disable the setting or accept the failure mode knowingly before triggering. |
+| `RELEASE_READINESS_IMMUTABLE_REPO` | Repo Setting "Immutable releases" is confirmed ENABLED (`GET /repos/{owner}/{repo}/immutable-releases` returned `enabled=true`). Every new Release is auto-flagged immutable; a failed asset upload or operator deletion permanently burns the tag (#233 prevention E). Surfaces as a `::warning::` annotation; does not block dispatch. Disable the setting or accept the failure mode knowingly before triggering. |
+| `RELEASE_READINESS_IMMUTABLE_PROBE_DENIED` | The probe could **not** verify the "Immutable releases" setting — endpoint returned 401/403/Bad credentials (workflow token lacks scope or repo access is restricted). The setting may or may not be on; this is **not** a confirmation. Verify manually in Repo Settings → General → Releases before dispatching, or grant the workflow token sufficient scope. Surfaces as a `::warning::` annotation; does not block dispatch. |
 
 ### Layer 2 — `scripts/lib/release-package-contract.ts`
 

--- a/docs/scripts/lib/release-readiness/README.md
+++ b/docs/scripts/lib/release-readiness/README.md
@@ -14,8 +14,10 @@ entry_point: true
 
 ## Interfaces
 
+- [GitHubInterface](interfaces/GitHubInterface.md)
 - [GitInterface](interfaces/GitInterface.md)
 - [QualitySignals](interfaces/QualitySignals.md)
+- [ReadinessWarning](interfaces/ReadinessWarning.md)
 - [ReleaseReadinessOptions](interfaces/ReleaseReadinessOptions.md)
 - [ReleaseReadinessReport](interfaces/ReleaseReadinessReport.md)
 
@@ -31,9 +33,11 @@ entry_point: true
 - [EXPECTED\_PACKAGE\_REPOSITORY](variables/EXPECTED_PACKAGE_REPOSITORY.md)
 - [MIN\_QUALITY\_MATURITY\_LEVEL](variables/MIN_QUALITY_MATURITY_LEVEL.md)
 - [RELEASE\_READINESS\_DIAGNOSTIC\_CODES](variables/RELEASE_READINESS_DIAGNOSTIC_CODES.md)
+- [RELEASE\_READINESS\_WARNING\_CODES](variables/RELEASE_READINESS_WARNING_CODES.md)
 - [REQUIRED\_WORKFLOW\_PERMISSIONS](variables/REQUIRED_WORKFLOW_PERMISSIONS.md)
 
 ## Functions
 
 - [checkReleaseReadiness](functions/checkReleaseReadiness.md)
+- [checkRepoImmutableSetting](functions/checkRepoImmutableSetting.md)
 - [parseReleaseReadinessArgs](functions/parseReleaseReadinessArgs.md)

--- a/docs/scripts/lib/release-readiness/README.md
+++ b/docs/scripts/lib/release-readiness/README.md
@@ -23,6 +23,7 @@ entry_point: true
 
 ## Type Aliases
 
+- [ImmutableSettingProbe](type-aliases/ImmutableSettingProbe.md)
 - [ParsedReleaseReadinessArgs](type-aliases/ParsedReleaseReadinessArgs.md)
 
 ## Variables

--- a/docs/scripts/lib/release-readiness/functions/checkRepoImmutableSetting.md
+++ b/docs/scripts/lib/release-readiness/functions/checkRepoImmutableSetting.md
@@ -17,11 +17,20 @@ Release on the repo is auto-flagged immutable; a failed asset upload
 or operator deletion then permanently burns the tag — exactly the
 v0.5.0 incident pattern.
 
-Returns one warning when the setting is on, none otherwise. Never
-returns a hard `Diagnostic` — the v0.5.0 retrospective showed the
-setting is not always operator-controlled (org-level defaults can
-propagate), so failing closed here could block legitimate dispatches
-against repos the operator does not own.
+Per the [GitHubInterface.immutableReleasesEnabled](../interfaces/GitHubInterface.md#immutablereleasesenabled) contract,
+the implementation returns `true` not only when the setting is
+actually on but also when the probe lacks permission to verify it
+(HTTP 401 / 403). The "surface on auth failure" semantics is
+intentional (Codex P1 round 3 on PR #242): silently skipping the
+warning when `secrets.GITHUB_TOKEN` cannot read the endpoint would
+give operators a false sense that the probe ran cleanly when it did
+not, which is exactly the v0.5.0 incident pattern at one remove.
+
+Returns one warning when the setting is (or might be) on, none
+otherwise. Never returns a hard `Diagnostic` — the v0.5.0 retrospective
+showed the setting is not always operator-controlled (org-level
+defaults can propagate), so failing closed here could block legitimate
+dispatches against repos the operator does not own.
 
 ## Parameters
 

--- a/docs/scripts/lib/release-readiness/functions/checkRepoImmutableSetting.md
+++ b/docs/scripts/lib/release-readiness/functions/checkRepoImmutableSetting.md
@@ -1,0 +1,35 @@
+[**@luis85/agentic-workflow**](../../../README.md)
+
+***
+
+[@luis85/agentic-workflow](../../../modules.md) / [lib/release-readiness](../README.md) / checkRepoImmutableSetting
+
+# Function: checkRepoImmutableSetting()
+
+> **checkRepoImmutableSetting**(`github`): [`ReadinessWarning`](../interfaces/ReadinessWarning.md)[]
+
+Probe the most recent Release for the `immutable` flag (#233 prevention E).
+
+The GitHub `/repos/{owner}/{repo}` endpoint does not expose the
+"Immutable releases" repo setting today (UI-only beta), so the only way
+to detect that the setting is on is to look at the latest Release and
+check whether GitHub auto-flagged it immutable. This is a heuristic —
+the operator could in principle have toggled the setting between the
+latest Release and the current dispatch — but it is the best signal
+available before a publish and it is exactly the signal the v0.5.0
+incident retrospective surfaced as the missing precondition.
+
+Returns one warning when the latest Release is immutable, none otherwise.
+Never returns a hard `Diagnostic` — the v0.5.0 incident showed the
+setting itself is not always operator-controlled (org-level defaults can
+propagate), so failing closed here would block legitimate dispatches.
+
+## Parameters
+
+### github
+
+[`GitHubInterface`](../interfaces/GitHubInterface.md)
+
+## Returns
+
+[`ReadinessWarning`](../interfaces/ReadinessWarning.md)[]

--- a/docs/scripts/lib/release-readiness/functions/checkRepoImmutableSetting.md
+++ b/docs/scripts/lib/release-readiness/functions/checkRepoImmutableSetting.md
@@ -17,19 +17,18 @@ Release on the repo is auto-flagged immutable; a failed asset upload
 or operator deletion then permanently burns the tag — exactly the
 v0.5.0 incident pattern.
 
-Per the [GitHubInterface.immutableReleasesEnabled](../interfaces/GitHubInterface.md#immutablereleasesenabled) contract,
-the implementation returns `true` not only when the setting is
-actually on but also when the probe lacks permission to verify it
-(HTTP 401 / 403). The "surface on auth failure" semantics is
-intentional (Codex P1 round 3 on PR #242): silently skipping the
-warning when `secrets.GITHUB_TOKEN` cannot read the endpoint would
-give operators a false sense that the probe ran cleanly when it did
-not, which is exactly the v0.5.0 incident pattern at one remove.
+Emits at most one warning, distinguishing the verified-on case from
+the probe-denied case (Codex P2 round 4 on PR #242):
 
-Returns one warning when the setting is (or might be) on, none
-otherwise. Never returns a hard `Diagnostic` — the v0.5.0 retrospective
-showed the setting is not always operator-controlled (org-level
-defaults can propagate), so failing closed here could block legitimate
+- `enabled` -> `ImmutableRepo` ("setting is ON").
+- `denied`  -> `ImmutableProbeDenied` ("probe could not verify;
+  check manually"). Distinct code so operators do not misread an
+  auth failure as a confirmed-on setting.
+- `disabled` / `unknown` -> no warning.
+
+Never returns a hard `Diagnostic` — the v0.5.0 retrospective showed
+the setting is not always operator-controlled (org-level defaults
+can propagate), so failing closed here could block legitimate
 dispatches against repos the operator does not own.
 
 ## Parameters

--- a/docs/scripts/lib/release-readiness/functions/checkRepoImmutableSetting.md
+++ b/docs/scripts/lib/release-readiness/functions/checkRepoImmutableSetting.md
@@ -8,21 +8,20 @@
 
 > **checkRepoImmutableSetting**(`github`): [`ReadinessWarning`](../interfaces/ReadinessWarning.md)[]
 
-Probe the most recent Release for the `immutable` flag (#233 prevention E).
+Probe the "Immutable releases" repo setting (#233 prevention E).
 
-The GitHub `/repos/{owner}/{repo}` endpoint does not expose the
-"Immutable releases" repo setting today (UI-only beta), so the only way
-to detect that the setting is on is to look at the latest Release and
-check whether GitHub auto-flagged it immutable. This is a heuristic —
-the operator could in principle have toggled the setting between the
-latest Release and the current dispatch — but it is the best signal
-available before a publish and it is exactly the signal the v0.5.0
-incident retrospective surfaced as the missing precondition.
+Reads the setting directly via
+`GET /repos/{owner}/{repo}/immutable-releases`. When the endpoint
+returns `enabled: true` (or the org enforces the setting) every new
+Release on the repo is auto-flagged immutable; a failed asset upload
+or operator deletion then permanently burns the tag — exactly the
+v0.5.0 incident pattern.
 
-Returns one warning when the latest Release is immutable, none otherwise.
-Never returns a hard `Diagnostic` — the v0.5.0 incident showed the
-setting itself is not always operator-controlled (org-level defaults can
-propagate), so failing closed here would block legitimate dispatches.
+Returns one warning when the setting is on, none otherwise. Never
+returns a hard `Diagnostic` — the v0.5.0 retrospective showed the
+setting is not always operator-controlled (org-level defaults can
+propagate), so failing closed here could block legitimate dispatches
+against repos the operator does not own.
 
 ## Parameters
 

--- a/docs/scripts/lib/release-readiness/interfaces/GitHubInterface.md
+++ b/docs/scripts/lib/release-readiness/interfaces/GitHubInterface.md
@@ -13,19 +13,12 @@ cannot answer. [checkRepoImmutableSetting](../functions/checkRepoImmutableSettin
 PR #242 — the dedicated REST endpoint is documented and live, so the
 earlier most-recent-Release heuristic is unnecessary).
 
-Returns:
-
-- `true` — setting is enabled on the repo (or enforced by the org).
-- `false` — setting is explicitly disabled.
-- `null` — endpoint unavailable (older `gh` / API access denied / network
-  error). Fail quiet so a missing signal cannot block dispatch.
-
 ## Methods
 
-### immutableReleasesEnabled()
+### immutableReleasesSetting()
 
-> **immutableReleasesEnabled**(): `boolean` \| `null`
+> **immutableReleasesSetting**(): [`ImmutableSettingProbe`](../type-aliases/ImmutableSettingProbe.md)
 
 #### Returns
 
-`boolean` \| `null`
+[`ImmutableSettingProbe`](../type-aliases/ImmutableSettingProbe.md)

--- a/docs/scripts/lib/release-readiness/interfaces/GitHubInterface.md
+++ b/docs/scripts/lib/release-readiness/interfaces/GitHubInterface.md
@@ -7,20 +7,24 @@
 # Interface: GitHubInterface
 
 Minimal GitHub API facade for repository-state probes that the git CLI
-cannot answer. [checkRepoImmutableSetting](../functions/checkRepoImmutableSetting.md) uses this to inspect
-the most recent Release's `immutable` flag — a workaround because the
-`/repos/{owner}/{repo}` API does not currently expose the
-"Immutable releases" repo setting (UI-only beta). Returns:
+cannot answer. [checkRepoImmutableSetting](../functions/checkRepoImmutableSetting.md) uses this to read the
+"Immutable releases" repo setting directly via
+`GET /repos/{owner}/{repo}/immutable-releases` (Codex round 2 on
+PR #242 — the dedicated REST endpoint is documented and live, so the
+earlier most-recent-Release heuristic is unnecessary).
 
-- `true` — most recent Release is immutable (heuristic: setting is on).
-- `false` — most recent Release is mutable (heuristic: setting is off).
-- `null` — no Releases yet, or API error (fail quiet; no warning).
+Returns:
+
+- `true` — setting is enabled on the repo (or enforced by the org).
+- `false` — setting is explicitly disabled.
+- `null` — endpoint unavailable (older `gh` / API access denied / network
+  error). Fail quiet so a missing signal cannot block dispatch.
 
 ## Methods
 
-### latestReleaseImmutable()
+### immutableReleasesEnabled()
 
-> **latestReleaseImmutable**(): `boolean` \| `null`
+> **immutableReleasesEnabled**(): `boolean` \| `null`
 
 #### Returns
 

--- a/docs/scripts/lib/release-readiness/interfaces/GitHubInterface.md
+++ b/docs/scripts/lib/release-readiness/interfaces/GitHubInterface.md
@@ -1,0 +1,27 @@
+[**@luis85/agentic-workflow**](../../../README.md)
+
+***
+
+[@luis85/agentic-workflow](../../../modules.md) / [lib/release-readiness](../README.md) / GitHubInterface
+
+# Interface: GitHubInterface
+
+Minimal GitHub API facade for repository-state probes that the git CLI
+cannot answer. [checkRepoImmutableSetting](../functions/checkRepoImmutableSetting.md) uses this to inspect
+the most recent Release's `immutable` flag — a workaround because the
+`/repos/{owner}/{repo}` API does not currently expose the
+"Immutable releases" repo setting (UI-only beta). Returns:
+
+- `true` — most recent Release is immutable (heuristic: setting is on).
+- `false` — most recent Release is mutable (heuristic: setting is off).
+- `null` — no Releases yet, or API error (fail quiet; no warning).
+
+## Methods
+
+### latestReleaseImmutable()
+
+> **latestReleaseImmutable**(): `boolean` \| `null`
+
+#### Returns
+
+`boolean` \| `null`

--- a/docs/scripts/lib/release-readiness/interfaces/ReadinessWarning.md
+++ b/docs/scripts/lib/release-readiness/interfaces/ReadinessWarning.md
@@ -1,0 +1,23 @@
+[**@luis85/agentic-workflow**](../../../README.md)
+
+***
+
+[@luis85/agentic-workflow](../../../modules.md) / [lib/release-readiness](../README.md) / ReadinessWarning
+
+# Interface: ReadinessWarning
+
+A non-blocking informational signal about release readiness.
+Distinct from [Diagnostic](../../diagnostics/type-aliases/Diagnostic.md) to preserve the existing contract that
+any entry in `report.diagnostics` is a hard failure.
+
+## Properties
+
+### code
+
+> **code**: `string`
+
+***
+
+### message
+
+> **message**: `string`

--- a/docs/scripts/lib/release-readiness/type-aliases/ImmutableSettingProbe.md
+++ b/docs/scripts/lib/release-readiness/type-aliases/ImmutableSettingProbe.md
@@ -1,0 +1,28 @@
+[**@luis85/agentic-workflow**](../../../README.md)
+
+***
+
+[@luis85/agentic-workflow](../../../modules.md) / [lib/release-readiness](../README.md) / ImmutableSettingProbe
+
+# Type Alias: ImmutableSettingProbe
+
+> **ImmutableSettingProbe** = `"enabled"` \| `"disabled"` \| `"denied"` \| `"unknown"`
+
+Result of probing the "Immutable releases" repo setting.
+
+Discriminated four-state instead of `boolean | null` so the warning
+surface can distinguish "setting confirmed on" from "probe could not
+verify" (Codex P2 round 4 on PR #242). Round 3 coerced 401/403 -> true
+to surface a warning, but that produced an indistinguishable false
+positive against repos where the workflow token simply cannot read the
+endpoint — operators saw "ENABLED" every dispatch even when the setting
+was off.
+
+- `enabled` — endpoint returned `enabled=true` (or org-level enforcement).
+- `disabled` — endpoint returned `enabled=false`.
+- `denied` — endpoint returned 401 / 403 / "Bad credentials" /
+  "Resource not accessible". The probe could not verify the setting;
+  surface a distinct warning so the operator checks manually.
+- `unknown` — endpoint missing (404, older GitHub instance), network
+  blip, parse error. Fail quiet — a transient signal must not block
+  dispatch.

--- a/docs/scripts/lib/release-readiness/variables/RELEASE_READINESS_WARNING_CODES.md
+++ b/docs/scripts/lib/release-readiness/variables/RELEASE_READINESS_WARNING_CODES.md
@@ -17,6 +17,10 @@ CLI as `::notice::` annotations and do not block dispatch.
 
 ## Type Declaration
 
+### ImmutableProbeDenied
+
+> `readonly` **ImmutableProbeDenied**: `"RELEASE_READINESS_IMMUTABLE_PROBE_DENIED"` = `"RELEASE_READINESS_IMMUTABLE_PROBE_DENIED"`
+
 ### ImmutableRepo
 
 > `readonly` **ImmutableRepo**: `"RELEASE_READINESS_IMMUTABLE_REPO"` = `"RELEASE_READINESS_IMMUTABLE_REPO"`

--- a/docs/scripts/lib/release-readiness/variables/RELEASE_READINESS_WARNING_CODES.md
+++ b/docs/scripts/lib/release-readiness/variables/RELEASE_READINESS_WARNING_CODES.md
@@ -1,0 +1,22 @@
+[**@luis85/agentic-workflow**](../../../README.md)
+
+***
+
+[@luis85/agentic-workflow](../../../modules.md) / [lib/release-readiness](../README.md) / RELEASE\_READINESS\_WARNING\_CODES
+
+# Variable: RELEASE\_READINESS\_WARNING\_CODES
+
+> `const` **RELEASE\_READINESS\_WARNING\_CODES**: `object`
+
+Diagnostic codes emitted as **warnings** (informational, do not fail
+closed). Kept separate from [RELEASE\_READINESS\_DIAGNOSTIC\_CODES](RELEASE_READINESS_DIAGNOSTIC_CODES.md)
+because the existing JSON output contract guarantees that any entry in
+`diagnostics` is a hard failure — operators (and the dispatch workflow)
+rely on that for the "fail closed" gate. Warnings surface through the
+CLI as `::notice::` annotations and do not block dispatch.
+
+## Type Declaration
+
+### ImmutableRepo
+
+> `readonly` **ImmutableRepo**: `"RELEASE_READINESS_IMMUTABLE_REPO"` = `"RELEASE_READINESS_IMMUTABLE_REPO"`

--- a/scripts/check-release-readiness.ts
+++ b/scripts/check-release-readiness.ts
@@ -3,7 +3,9 @@ import fs from "node:fs";
 import path from "node:path";
 import {
   checkReleaseReadiness,
+  checkRepoImmutableSetting,
   parseReleaseReadinessArgs,
+  type GitHubInterface,
   type GitInterface,
   type QualitySignals,
 } from "./lib/release-readiness.js";
@@ -128,6 +130,23 @@ const report = checkReleaseReadiness({
   qualitySignals,
 });
 
+// Prevention E from #233 — emit a non-blocking warning when the most
+// recent Release is immutable (heuristic: Repo Setting "Immutable
+// releases" is on). Surface as a GitHub Actions `::warning::` annotation
+// so dispatch operators see it inline; also write to stderr for local
+// CLI invocations. The probe never adds to `report.diagnostics` so it
+// cannot fail the gate (the v0.5.0 incident showed the setting is not
+// always operator-controlled — failing closed could block legitimate
+// dispatches). The probe is skipped under `--json` to keep the JSON
+// contract clean for downstream consumers; `--json` callers can run
+// the API call themselves if they want the signal.
+if (!process.argv.includes("--json")) {
+  const warnings = checkRepoImmutableSetting(realGitHub());
+  for (const warning of warnings) {
+    console.error(`::warning::${warning.code}: ${warning.message}`);
+  }
+}
+
 failIfErrors(report.diagnostics, heading);
 
 function realGit(): GitInterface {
@@ -175,6 +194,47 @@ function realGit(): GitInterface {
           },
         );
         return out.split(/\r?\n/).map((s) => s.trim()).filter((s) => s !== "");
+      } catch {
+        return null;
+      }
+    },
+  };
+}
+
+function realGitHub(): GitHubInterface {
+  return {
+    latestReleaseImmutable(): boolean | null {
+      // `gh api repos/{owner}/{repo}/releases?per_page=1` returns an array
+      // of the most recent Releases (newest first). The `immutable` flag
+      // on entry [0] is the heuristic for whether the repo's Immutable
+      // Releases setting is on — see `checkRepoImmutableSetting` for why
+      // the heuristic is necessary. Empty array (no releases yet) and any
+      // gh / API error fail quiet to `null` — the warning is informational,
+      // not a gate, so a missing signal must not block dispatch.
+      //
+      // GITHUB_REPOSITORY is set on every workflow run; locally, gh's
+      // default repo (configured via `gh repo set-default` or the current
+      // git remote) is used implicitly.
+      try {
+        const out = execFileSync(
+          "gh",
+          [
+            "api",
+            "repos/{owner}/{repo}/releases?per_page=1",
+            "--jq",
+            ".[0].immutable",
+          ],
+          {
+            cwd: repoRoot,
+            encoding: "utf8",
+            windowsHide: true,
+            stdio: ["ignore", "pipe", "ignore"],
+          },
+        );
+        const trimmed = out.trim();
+        if (trimmed === "true") return true;
+        if (trimmed === "false") return false;
+        return null;
       } catch {
         return null;
       }

--- a/scripts/check-release-readiness.ts
+++ b/scripts/check-release-readiness.ts
@@ -7,6 +7,7 @@ import {
   parseReleaseReadinessArgs,
   type GitHubInterface,
   type GitInterface,
+  type ImmutableSettingProbe,
   type QualitySignals,
 } from "./lib/release-readiness.js";
 import { collectQualityMetrics } from "./lib/quality-metrics.js";
@@ -205,26 +206,26 @@ function realGit(): GitInterface {
 
 function realGitHub(): GitHubInterface {
   return {
-    immutableReleasesEnabled(): boolean | null {
+    immutableReleasesSetting(): ImmutableSettingProbe {
       // `gh api repos/{owner}/{repo}/immutable-releases` returns
       // `{enabled: bool, enforced_by_owner: bool}`. The setting is on if
       // either flag is true (org-level enforcement counts even when the
       // repo's own toggle is off).
       //
-      // Failure handling distinguishes three cases (Codex P1 round 3 on
-      // PR #242 — the bare `catch { return null }` would silently
-      // swallow auth / permission errors and the warning would never
-      // fire in production):
+      // Failure handling returns four distinct states (Codex P2 round 4
+      // on PR #242 — round 3 coerced 401/403 -> true, which produced an
+      // indistinguishable false positive against repos where the
+      // workflow token cannot read the endpoint):
       //
-      //   - Endpoint missing (404 — older GitHub instance) → `null`,
+      //   - 401/403/Bad credentials/Resource not accessible -> "denied"
+      //     so checkRepoImmutableSetting emits ImmutableProbeDenied
+      //     ("could not verify; check manually") instead of pretending
+      //     the setting is confirmed on.
+      //   - Endpoint missing (404 — older GitHub instance) -> "unknown",
       //     fail quiet. The warning was never going to be authoritative
       //     on a host without the endpoint.
-      //   - Auth / permission failure (401, 403) → return `true`. The
-      //     setting MIGHT be on; we cannot tell. Surface the warning
-      //     instead of staying silent so the operator does not get a
-      //     false sense the probe ran cleanly.
-      //   - Anything else (network blip, parse error) → `null`, fail
-      //     quiet. Transient errors should not pollute the warning.
+      //   - Anything else (network blip, parse error) -> "unknown",
+      //     fail quiet. Transient errors should not pollute the warning.
       //
       // GITHUB_REPOSITORY is set on every workflow run; locally, gh's
       // default repo (configured via `gh repo set-default` or the current
@@ -248,18 +249,15 @@ function realGitHub(): GitHubInterface {
         );
       } catch (err) {
         const stderr = String((err as { stderr?: Buffer | string }).stderr ?? "");
-        // 401 / 403 mean the probe could not verify the setting — the
-        // safe default is "warn anyway" so operators do not act on a
-        // silent skip.
         if (/HTTP 401|HTTP 403|Bad credentials|Resource not accessible/i.test(stderr)) {
-          return true;
+          return "denied";
         }
-        return null;
+        return "unknown";
       }
       const trimmed = out.trim();
-      if (trimmed === "true") return true;
-      if (trimmed === "false") return false;
-      return null;
+      if (trimmed === "true") return "enabled";
+      if (trimmed === "false") return "disabled";
+      return "unknown";
     },
   };
 }

--- a/scripts/check-release-readiness.ts
+++ b/scripts/check-release-readiness.ts
@@ -205,14 +205,16 @@ function realGit(): GitInterface {
 
 function realGitHub(): GitHubInterface {
   return {
-    latestReleaseImmutable(): boolean | null {
-      // `gh api repos/{owner}/{repo}/releases?per_page=1` returns an array
-      // of the most recent Releases (newest first). The `immutable` flag
-      // on entry [0] is the heuristic for whether the repo's Immutable
-      // Releases setting is on — see `checkRepoImmutableSetting` for why
-      // the heuristic is necessary. Empty array (no releases yet) and any
-      // gh / API error fail quiet to `null` — the warning is informational,
-      // not a gate, so a missing signal must not block dispatch.
+    immutableReleasesEnabled(): boolean | null {
+      // `gh api repos/{owner}/{repo}/immutable-releases` returns
+      // `{enabled: bool, enforced_by_owner: bool}`. The setting is on if
+      // either flag is true (org-level enforcement counts even when the
+      // repo's own toggle is off).
+      //
+      // Endpoint not found (older GitHub instances), API access denied
+      // (token lacks scope), or any network error fail quiet to `null` —
+      // the warning is informational, not a gate, so a missing signal
+      // must not block dispatch.
       //
       // GITHUB_REPOSITORY is set on every workflow run; locally, gh's
       // default repo (configured via `gh repo set-default` or the current
@@ -222,9 +224,9 @@ function realGitHub(): GitHubInterface {
           "gh",
           [
             "api",
-            "repos/{owner}/{repo}/releases?per_page=1",
+            "repos/{owner}/{repo}/immutable-releases",
             "--jq",
-            ".[0].immutable",
+            ".enabled or (.enforced_by_owner // false)",
           ],
           {
             cwd: repoRoot,

--- a/scripts/check-release-readiness.ts
+++ b/scripts/check-release-readiness.ts
@@ -211,16 +211,27 @@ function realGitHub(): GitHubInterface {
       // either flag is true (org-level enforcement counts even when the
       // repo's own toggle is off).
       //
-      // Endpoint not found (older GitHub instances), API access denied
-      // (token lacks scope), or any network error fail quiet to `null` —
-      // the warning is informational, not a gate, so a missing signal
-      // must not block dispatch.
+      // Failure handling distinguishes three cases (Codex P1 round 3 on
+      // PR #242 — the bare `catch { return null }` would silently
+      // swallow auth / permission errors and the warning would never
+      // fire in production):
+      //
+      //   - Endpoint missing (404 — older GitHub instance) → `null`,
+      //     fail quiet. The warning was never going to be authoritative
+      //     on a host without the endpoint.
+      //   - Auth / permission failure (401, 403) → return `true`. The
+      //     setting MIGHT be on; we cannot tell. Surface the warning
+      //     instead of staying silent so the operator does not get a
+      //     false sense the probe ran cleanly.
+      //   - Anything else (network blip, parse error) → `null`, fail
+      //     quiet. Transient errors should not pollute the warning.
       //
       // GITHUB_REPOSITORY is set on every workflow run; locally, gh's
       // default repo (configured via `gh repo set-default` or the current
       // git remote) is used implicitly.
+      let out: string;
       try {
-        const out = execFileSync(
+        out = execFileSync(
           "gh",
           [
             "api",
@@ -232,16 +243,23 @@ function realGitHub(): GitHubInterface {
             cwd: repoRoot,
             encoding: "utf8",
             windowsHide: true,
-            stdio: ["ignore", "pipe", "ignore"],
+            stdio: ["ignore", "pipe", "pipe"],
           },
         );
-        const trimmed = out.trim();
-        if (trimmed === "true") return true;
-        if (trimmed === "false") return false;
-        return null;
-      } catch {
+      } catch (err) {
+        const stderr = String((err as { stderr?: Buffer | string }).stderr ?? "");
+        // 401 / 403 mean the probe could not verify the setting — the
+        // safe default is "warn anyway" so operators do not act on a
+        // silent skip.
+        if (/HTTP 401|HTTP 403|Bad credentials|Resource not accessible/i.test(stderr)) {
+          return true;
+        }
         return null;
       }
+      const trimmed = out.trim();
+      if (trimmed === "true") return true;
+      if (trimmed === "false") return false;
+      return null;
     },
   };
 }

--- a/scripts/check-release-readiness.ts
+++ b/scripts/check-release-readiness.ts
@@ -133,18 +133,20 @@ const report = checkReleaseReadiness({
 // Prevention E from #233 — emit a non-blocking warning when the most
 // recent Release is immutable (heuristic: Repo Setting "Immutable
 // releases" is on). Surface as a GitHub Actions `::warning::` annotation
-// so dispatch operators see it inline; also write to stderr for local
-// CLI invocations. The probe never adds to `report.diagnostics` so it
-// cannot fail the gate (the v0.5.0 incident showed the setting is not
-// always operator-controlled — failing closed could block legitimate
-// dispatches). The probe is skipped under `--json` to keep the JSON
-// contract clean for downstream consumers; `--json` callers can run
-// the API call themselves if they want the signal.
-if (!process.argv.includes("--json")) {
-  const warnings = checkRepoImmutableSetting(realGitHub());
-  for (const warning of warnings) {
-    console.error(`::warning::${warning.code}: ${warning.message}`);
-  }
+// to stderr so dispatch operators see it inline. The probe never adds to
+// `report.diagnostics` so it cannot fail the gate (the v0.5.0 incident
+// showed the setting is not always operator-controlled — failing closed
+// could block legitimate dispatches).
+//
+// Runs unconditionally — including under `--json`. The dispatch workflow
+// invokes this script as `npm run check:release-readiness -- --json`, so
+// gating the probe on `!--json` would have made it dead code in exactly
+// the path the prevention is meant for (Codex P1 on PR #242). The JSON
+// contract on `report.diagnostics` and `process.exit` is unchanged —
+// warnings only land on stderr as `::warning::` annotations.
+const warnings = checkRepoImmutableSetting(realGitHub());
+for (const warning of warnings) {
+  console.error(`::warning::${warning.code}: ${warning.message}`);
 }
 
 failIfErrors(report.diagnostics, heading);

--- a/scripts/lib/release-readiness.ts
+++ b/scripts/lib/release-readiness.ts
@@ -108,17 +108,21 @@ export const RELEASE_READINESS_WARNING_CODES = {
 
 /**
  * Minimal GitHub API facade for repository-state probes that the git CLI
- * cannot answer. {@link checkRepoImmutableSetting} uses this to inspect
- * the most recent Release's `immutable` flag — a workaround because the
- * `/repos/{owner}/{repo}` API does not currently expose the
- * "Immutable releases" repo setting (UI-only beta). Returns:
+ * cannot answer. {@link checkRepoImmutableSetting} uses this to read the
+ * "Immutable releases" repo setting directly via
+ * `GET /repos/{owner}/{repo}/immutable-releases` (Codex round 2 on
+ * PR #242 — the dedicated REST endpoint is documented and live, so the
+ * earlier most-recent-Release heuristic is unnecessary).
  *
- * - `true` — most recent Release is immutable (heuristic: setting is on).
- * - `false` — most recent Release is mutable (heuristic: setting is off).
- * - `null` — no Releases yet, or API error (fail quiet; no warning).
+ * Returns:
+ *
+ * - `true` — setting is enabled on the repo (or enforced by the org).
+ * - `false` — setting is explicitly disabled.
+ * - `null` — endpoint unavailable (older `gh` / API access denied / network
+ *   error). Fail quiet so a missing signal cannot block dispatch.
  */
 export interface GitHubInterface {
-  latestReleaseImmutable(): boolean | null;
+  immutableReleasesEnabled(): boolean | null;
 }
 
 /**
@@ -132,33 +136,32 @@ export interface ReadinessWarning {
 }
 
 /**
- * Probe the most recent Release for the `immutable` flag (#233 prevention E).
+ * Probe the "Immutable releases" repo setting (#233 prevention E).
  *
- * The GitHub `/repos/{owner}/{repo}` endpoint does not expose the
- * "Immutable releases" repo setting today (UI-only beta), so the only way
- * to detect that the setting is on is to look at the latest Release and
- * check whether GitHub auto-flagged it immutable. This is a heuristic —
- * the operator could in principle have toggled the setting between the
- * latest Release and the current dispatch — but it is the best signal
- * available before a publish and it is exactly the signal the v0.5.0
- * incident retrospective surfaced as the missing precondition.
+ * Reads the setting directly via
+ * `GET /repos/{owner}/{repo}/immutable-releases`. When the endpoint
+ * returns `enabled: true` (or the org enforces the setting) every new
+ * Release on the repo is auto-flagged immutable; a failed asset upload
+ * or operator deletion then permanently burns the tag — exactly the
+ * v0.5.0 incident pattern.
  *
- * Returns one warning when the latest Release is immutable, none otherwise.
- * Never returns a hard `Diagnostic` — the v0.5.0 incident showed the
- * setting itself is not always operator-controlled (org-level defaults can
- * propagate), so failing closed here would block legitimate dispatches.
+ * Returns one warning when the setting is on, none otherwise. Never
+ * returns a hard `Diagnostic` — the v0.5.0 retrospective showed the
+ * setting is not always operator-controlled (org-level defaults can
+ * propagate), so failing closed here could block legitimate dispatches
+ * against repos the operator does not own.
  */
 export function checkRepoImmutableSetting(github: GitHubInterface): ReadinessWarning[] {
-  const flag = github.latestReleaseImmutable();
+  const flag = github.immutableReleasesEnabled();
   if (flag === true) {
     return [
       {
         code: RELEASE_READINESS_WARNING_CODES.ImmutableRepo,
         message:
-          "the most recent Release on this repository was created immutable. " +
-          "If Repo Settings -> General -> Releases -> \"Immutable releases\" is on, " +
-          "every new Release will be auto-flagged immutable; a failed asset upload " +
-          "or operator deletion permanently burns the tag (#233). " +
+          "Repo Setting \"Immutable releases\" is ENABLED on this repository " +
+          "(GET /repos/{owner}/{repo}/immutable-releases returned enabled=true). " +
+          "Every new Release will be auto-flagged immutable; a failed asset " +
+          "upload or operator deletion permanently burns the tag (#233). " +
           "Disable the setting before dispatching, or accept the failure mode " +
           "knowingly.",
       },

--- a/scripts/lib/release-readiness.ts
+++ b/scripts/lib/release-readiness.ts
@@ -104,7 +104,30 @@ export const MIN_QUALITY_MATURITY_LEVEL = 3;
  */
 export const RELEASE_READINESS_WARNING_CODES = {
   ImmutableRepo: "RELEASE_READINESS_IMMUTABLE_REPO",
+  ImmutableProbeDenied: "RELEASE_READINESS_IMMUTABLE_PROBE_DENIED",
 } as const;
+
+/**
+ * Result of probing the "Immutable releases" repo setting.
+ *
+ * Discriminated four-state instead of `boolean | null` so the warning
+ * surface can distinguish "setting confirmed on" from "probe could not
+ * verify" (Codex P2 round 4 on PR #242). Round 3 coerced 401/403 -> true
+ * to surface a warning, but that produced an indistinguishable false
+ * positive against repos where the workflow token simply cannot read the
+ * endpoint — operators saw "ENABLED" every dispatch even when the setting
+ * was off.
+ *
+ * - `enabled` — endpoint returned `enabled=true` (or org-level enforcement).
+ * - `disabled` — endpoint returned `enabled=false`.
+ * - `denied` — endpoint returned 401 / 403 / "Bad credentials" /
+ *   "Resource not accessible". The probe could not verify the setting;
+ *   surface a distinct warning so the operator checks manually.
+ * - `unknown` — endpoint missing (404, older GitHub instance), network
+ *   blip, parse error. Fail quiet — a transient signal must not block
+ *   dispatch.
+ */
+export type ImmutableSettingProbe = "enabled" | "disabled" | "denied" | "unknown";
 
 /**
  * Minimal GitHub API facade for repository-state probes that the git CLI
@@ -113,16 +136,9 @@ export const RELEASE_READINESS_WARNING_CODES = {
  * `GET /repos/{owner}/{repo}/immutable-releases` (Codex round 2 on
  * PR #242 — the dedicated REST endpoint is documented and live, so the
  * earlier most-recent-Release heuristic is unnecessary).
- *
- * Returns:
- *
- * - `true` — setting is enabled on the repo (or enforced by the org).
- * - `false` — setting is explicitly disabled.
- * - `null` — endpoint unavailable (older `gh` / API access denied / network
- *   error). Fail quiet so a missing signal cannot block dispatch.
  */
 export interface GitHubInterface {
-  immutableReleasesEnabled(): boolean | null;
+  immutableReleasesSetting(): ImmutableSettingProbe;
 }
 
 /**
@@ -145,36 +161,48 @@ export interface ReadinessWarning {
  * or operator deletion then permanently burns the tag — exactly the
  * v0.5.0 incident pattern.
  *
- * Per the {@link GitHubInterface.immutableReleasesEnabled} contract,
- * the implementation returns `true` not only when the setting is
- * actually on but also when the probe lacks permission to verify it
- * (HTTP 401 / 403). The "surface on auth failure" semantics is
- * intentional (Codex P1 round 3 on PR #242): silently skipping the
- * warning when `secrets.GITHUB_TOKEN` cannot read the endpoint would
- * give operators a false sense that the probe ran cleanly when it did
- * not, which is exactly the v0.5.0 incident pattern at one remove.
+ * Emits at most one warning, distinguishing the verified-on case from
+ * the probe-denied case (Codex P2 round 4 on PR #242):
  *
- * Returns one warning when the setting is (or might be) on, none
- * otherwise. Never returns a hard `Diagnostic` — the v0.5.0 retrospective
- * showed the setting is not always operator-controlled (org-level
- * defaults can propagate), so failing closed here could block legitimate
+ * - `enabled` -> `ImmutableRepo` ("setting is ON").
+ * - `denied`  -> `ImmutableProbeDenied` ("probe could not verify;
+ *   check manually"). Distinct code so operators do not misread an
+ *   auth failure as a confirmed-on setting.
+ * - `disabled` / `unknown` -> no warning.
+ *
+ * Never returns a hard `Diagnostic` — the v0.5.0 retrospective showed
+ * the setting is not always operator-controlled (org-level defaults
+ * can propagate), so failing closed here could block legitimate
  * dispatches against repos the operator does not own.
  */
 export function checkRepoImmutableSetting(github: GitHubInterface): ReadinessWarning[] {
-  const flag = github.immutableReleasesEnabled();
-  if (flag === true) {
+  const state = github.immutableReleasesSetting();
+  if (state === "enabled") {
     return [
       {
         code: RELEASE_READINESS_WARNING_CODES.ImmutableRepo,
         message:
-          "Repo Setting \"Immutable releases\" is ENABLED on this repository, " +
-          "OR the probe lacked permission to verify it. " +
-          "(GET /repos/{owner}/{repo}/immutable-releases returned enabled=true " +
-          "or 401/403; see scripts/check-release-readiness.ts realGitHub.) " +
+          "Repo Setting \"Immutable releases\" is ENABLED on this repository " +
+          "(GET /repos/{owner}/{repo}/immutable-releases returned enabled=true). " +
           "Every new Release will be auto-flagged immutable; a failed asset " +
           "upload or operator deletion permanently burns the tag (#233). " +
           "Verify the setting in Repo Settings -> General -> Releases, " +
           "disable it before dispatching, or accept the failure mode knowingly.",
+      },
+    ];
+  }
+  if (state === "denied") {
+    return [
+      {
+        code: RELEASE_READINESS_WARNING_CODES.ImmutableProbeDenied,
+        message:
+          "Could not verify Repo Setting \"Immutable releases\" — " +
+          "GET /repos/{owner}/{repo}/immutable-releases returned 401/403 " +
+          "(workflow token lacks the scope, or repo access is restricted). " +
+          "The setting may or may not be on; this is NOT a confirmation. " +
+          "Verify manually in Repo Settings -> General -> Releases before " +
+          "dispatching, or grant the workflow token sufficient scope so the " +
+          "probe can run cleanly on the next dispatch.",
       },
     ];
   }

--- a/scripts/lib/release-readiness.ts
+++ b/scripts/lib/release-readiness.ts
@@ -145,11 +145,20 @@ export interface ReadinessWarning {
  * or operator deletion then permanently burns the tag — exactly the
  * v0.5.0 incident pattern.
  *
- * Returns one warning when the setting is on, none otherwise. Never
- * returns a hard `Diagnostic` — the v0.5.0 retrospective showed the
- * setting is not always operator-controlled (org-level defaults can
- * propagate), so failing closed here could block legitimate dispatches
- * against repos the operator does not own.
+ * Per the {@link GitHubInterface.immutableReleasesEnabled} contract,
+ * the implementation returns `true` not only when the setting is
+ * actually on but also when the probe lacks permission to verify it
+ * (HTTP 401 / 403). The "surface on auth failure" semantics is
+ * intentional (Codex P1 round 3 on PR #242): silently skipping the
+ * warning when `secrets.GITHUB_TOKEN` cannot read the endpoint would
+ * give operators a false sense that the probe ran cleanly when it did
+ * not, which is exactly the v0.5.0 incident pattern at one remove.
+ *
+ * Returns one warning when the setting is (or might be) on, none
+ * otherwise. Never returns a hard `Diagnostic` — the v0.5.0 retrospective
+ * showed the setting is not always operator-controlled (org-level
+ * defaults can propagate), so failing closed here could block legitimate
+ * dispatches against repos the operator does not own.
  */
 export function checkRepoImmutableSetting(github: GitHubInterface): ReadinessWarning[] {
   const flag = github.immutableReleasesEnabled();
@@ -158,12 +167,14 @@ export function checkRepoImmutableSetting(github: GitHubInterface): ReadinessWar
       {
         code: RELEASE_READINESS_WARNING_CODES.ImmutableRepo,
         message:
-          "Repo Setting \"Immutable releases\" is ENABLED on this repository " +
-          "(GET /repos/{owner}/{repo}/immutable-releases returned enabled=true). " +
+          "Repo Setting \"Immutable releases\" is ENABLED on this repository, " +
+          "OR the probe lacked permission to verify it. " +
+          "(GET /repos/{owner}/{repo}/immutable-releases returned enabled=true " +
+          "or 401/403; see scripts/check-release-readiness.ts realGitHub.) " +
           "Every new Release will be auto-flagged immutable; a failed asset " +
           "upload or operator deletion permanently burns the tag (#233). " +
-          "Disable the setting before dispatching, or accept the failure mode " +
-          "knowingly.",
+          "Verify the setting in Repo Settings -> General -> Releases, " +
+          "disable it before dispatching, or accept the failure mode knowingly.",
       },
     ];
   }

--- a/scripts/lib/release-readiness.ts
+++ b/scripts/lib/release-readiness.ts
@@ -95,6 +95,79 @@ export const EXPECTED_PACKAGE_FILES: readonly string[] = [
 export const MIN_QUALITY_MATURITY_LEVEL = 3;
 
 /**
+ * Diagnostic codes emitted as **warnings** (informational, do not fail
+ * closed). Kept separate from {@link RELEASE_READINESS_DIAGNOSTIC_CODES}
+ * because the existing JSON output contract guarantees that any entry in
+ * `diagnostics` is a hard failure — operators (and the dispatch workflow)
+ * rely on that for the "fail closed" gate. Warnings surface through the
+ * CLI as `::notice::` annotations and do not block dispatch.
+ */
+export const RELEASE_READINESS_WARNING_CODES = {
+  ImmutableRepo: "RELEASE_READINESS_IMMUTABLE_REPO",
+} as const;
+
+/**
+ * Minimal GitHub API facade for repository-state probes that the git CLI
+ * cannot answer. {@link checkRepoImmutableSetting} uses this to inspect
+ * the most recent Release's `immutable` flag — a workaround because the
+ * `/repos/{owner}/{repo}` API does not currently expose the
+ * "Immutable releases" repo setting (UI-only beta). Returns:
+ *
+ * - `true` — most recent Release is immutable (heuristic: setting is on).
+ * - `false` — most recent Release is mutable (heuristic: setting is off).
+ * - `null` — no Releases yet, or API error (fail quiet; no warning).
+ */
+export interface GitHubInterface {
+  latestReleaseImmutable(): boolean | null;
+}
+
+/**
+ * A non-blocking informational signal about release readiness.
+ * Distinct from {@link Diagnostic} to preserve the existing contract that
+ * any entry in `report.diagnostics` is a hard failure.
+ */
+export interface ReadinessWarning {
+  code: string;
+  message: string;
+}
+
+/**
+ * Probe the most recent Release for the `immutable` flag (#233 prevention E).
+ *
+ * The GitHub `/repos/{owner}/{repo}` endpoint does not expose the
+ * "Immutable releases" repo setting today (UI-only beta), so the only way
+ * to detect that the setting is on is to look at the latest Release and
+ * check whether GitHub auto-flagged it immutable. This is a heuristic —
+ * the operator could in principle have toggled the setting between the
+ * latest Release and the current dispatch — but it is the best signal
+ * available before a publish and it is exactly the signal the v0.5.0
+ * incident retrospective surfaced as the missing precondition.
+ *
+ * Returns one warning when the latest Release is immutable, none otherwise.
+ * Never returns a hard `Diagnostic` — the v0.5.0 incident showed the
+ * setting itself is not always operator-controlled (org-level defaults can
+ * propagate), so failing closed here would block legitimate dispatches.
+ */
+export function checkRepoImmutableSetting(github: GitHubInterface): ReadinessWarning[] {
+  const flag = github.latestReleaseImmutable();
+  if (flag === true) {
+    return [
+      {
+        code: RELEASE_READINESS_WARNING_CODES.ImmutableRepo,
+        message:
+          "the most recent Release on this repository was created immutable. " +
+          "If Repo Settings -> General -> Releases -> \"Immutable releases\" is on, " +
+          "every new Release will be auto-flagged immutable; a failed asset upload " +
+          "or operator deletion permanently burns the tag (#233). " +
+          "Disable the setting before dispatching, or accept the failure mode " +
+          "knowingly.",
+      },
+    ];
+  }
+  return [];
+}
+
+/**
  * Minimal git facade for tag-readiness assertions.
  *
  * `resolveRef` must return a **commit SHA** for the supplied ref,

--- a/tests/scripts/release-readiness.test.ts
+++ b/tests/scripts/release-readiness.test.ts
@@ -706,8 +706,8 @@ test("tag readiness: unresolvable first-parent chain fails TagNotAtMain", () => 
   }
 });
 
-test("checkRepoImmutableSetting: latest Release immutable -> emits warning (#233 prevention E)", () => {
-  const github: GitHubInterface = { latestReleaseImmutable: () => true };
+test("checkRepoImmutableSetting: setting enabled -> emits warning (#233 prevention E)", () => {
+  const github: GitHubInterface = { immutableReleasesEnabled: () => true };
   const warnings = checkRepoImmutableSetting(github);
   assert.equal(warnings.length, 1, "expected exactly one warning");
   assert.equal(warnings[0].code, RELEASE_READINESS_WARNING_CODES.ImmutableRepo);
@@ -715,13 +715,13 @@ test("checkRepoImmutableSetting: latest Release immutable -> emits warning (#233
   assert.match(warnings[0].message, /tag/);
 });
 
-test("checkRepoImmutableSetting: latest Release mutable -> no warning", () => {
-  const github: GitHubInterface = { latestReleaseImmutable: () => false };
+test("checkRepoImmutableSetting: setting disabled -> no warning", () => {
+  const github: GitHubInterface = { immutableReleasesEnabled: () => false };
   assert.deepEqual(checkRepoImmutableSetting(github), []);
 });
 
-test("checkRepoImmutableSetting: probe failed (no releases / API error) -> no warning, fail-quiet", () => {
-  const github: GitHubInterface = { latestReleaseImmutable: () => null };
+test("checkRepoImmutableSetting: probe failed (endpoint missing / API error) -> no warning, fail-quiet", () => {
+  const github: GitHubInterface = { immutableReleasesEnabled: () => null };
   assert.deepEqual(
     checkRepoImmutableSetting(github),
     [],

--- a/tests/scripts/release-readiness.test.ts
+++ b/tests/scripts/release-readiness.test.ts
@@ -706,26 +706,40 @@ test("tag readiness: unresolvable first-parent chain fails TagNotAtMain", () => 
   }
 });
 
-test("checkRepoImmutableSetting: setting enabled -> emits warning (#233 prevention E)", () => {
-  const github: GitHubInterface = { immutableReleasesEnabled: () => true };
+test("checkRepoImmutableSetting: setting enabled -> emits ImmutableRepo (#233 prevention E)", () => {
+  const github: GitHubInterface = { immutableReleasesSetting: () => "enabled" };
   const warnings = checkRepoImmutableSetting(github);
   assert.equal(warnings.length, 1, "expected exactly one warning");
   assert.equal(warnings[0].code, RELEASE_READINESS_WARNING_CODES.ImmutableRepo);
-  assert.match(warnings[0].message, /Immutable releases/);
+  assert.match(warnings[0].message, /ENABLED/);
   assert.match(warnings[0].message, /tag/);
 });
 
 test("checkRepoImmutableSetting: setting disabled -> no warning", () => {
-  const github: GitHubInterface = { immutableReleasesEnabled: () => false };
+  const github: GitHubInterface = { immutableReleasesSetting: () => "disabled" };
   assert.deepEqual(checkRepoImmutableSetting(github), []);
 });
 
-test("checkRepoImmutableSetting: probe failed (endpoint missing / API error) -> no warning, fail-quiet", () => {
-  const github: GitHubInterface = { immutableReleasesEnabled: () => null };
+test("checkRepoImmutableSetting: probe denied (401/403) -> emits distinct ImmutableProbeDenied (Codex P2 round 4)", () => {
+  // Round-3 coerced 401/403 to enabled which created a persistent false
+  // positive against repos where the workflow token cannot read the
+  // endpoint — operators saw "ENABLED" every dispatch even when the
+  // setting was off. Distinct code lets the operator tell "confirmed on"
+  // from "could not verify".
+  const github: GitHubInterface = { immutableReleasesSetting: () => "denied" };
+  const warnings = checkRepoImmutableSetting(github);
+  assert.equal(warnings.length, 1, "expected exactly one warning for denied probe");
+  assert.equal(warnings[0].code, RELEASE_READINESS_WARNING_CODES.ImmutableProbeDenied);
+  assert.match(warnings[0].message, /Could not verify/);
+  assert.match(warnings[0].message, /401\/403/);
+});
+
+test("checkRepoImmutableSetting: probe unknown (endpoint missing / network) -> no warning, fail-quiet", () => {
+  const github: GitHubInterface = { immutableReleasesSetting: () => "unknown" };
   assert.deepEqual(
     checkRepoImmutableSetting(github),
     [],
-    "null result must NOT emit a warning — the probe is informational and a missing signal must not block dispatch",
+    "unknown result must NOT emit a warning — the probe is informational and a missing signal must not block dispatch",
   );
 });
 

--- a/tests/scripts/release-readiness.test.ts
+++ b/tests/scripts/release-readiness.test.ts
@@ -11,8 +11,11 @@ import {
   EXPECTED_PACKAGE_REGISTRY,
   EXPECTED_PACKAGE_REPOSITORY,
   RELEASE_READINESS_DIAGNOSTIC_CODES,
+  RELEASE_READINESS_WARNING_CODES,
   checkReleaseReadiness,
+  checkRepoImmutableSetting,
   parseReleaseReadinessArgs,
+  type GitHubInterface,
   type GitInterface,
   type QualitySignals,
 } from "../../scripts/lib/release-readiness.js";
@@ -701,6 +704,29 @@ test("tag readiness: unresolvable first-parent chain fails TagNotAtMain", () => 
   } finally {
     cleanup(repoRoot);
   }
+});
+
+test("checkRepoImmutableSetting: latest Release immutable -> emits warning (#233 prevention E)", () => {
+  const github: GitHubInterface = { latestReleaseImmutable: () => true };
+  const warnings = checkRepoImmutableSetting(github);
+  assert.equal(warnings.length, 1, "expected exactly one warning");
+  assert.equal(warnings[0].code, RELEASE_READINESS_WARNING_CODES.ImmutableRepo);
+  assert.match(warnings[0].message, /Immutable releases/);
+  assert.match(warnings[0].message, /tag/);
+});
+
+test("checkRepoImmutableSetting: latest Release mutable -> no warning", () => {
+  const github: GitHubInterface = { latestReleaseImmutable: () => false };
+  assert.deepEqual(checkRepoImmutableSetting(github), []);
+});
+
+test("checkRepoImmutableSetting: probe failed (no releases / API error) -> no warning, fail-quiet", () => {
+  const github: GitHubInterface = { latestReleaseImmutable: () => null };
+  assert.deepEqual(
+    checkRepoImmutableSetting(github),
+    [],
+    "null result must NOT emit a warning — the probe is informational and a missing signal must not block dispatch",
+  );
 });
 
 test("parseReleaseReadinessArgs accepts --version and --archive in argv and env", () => {


### PR DESCRIPTION
## Summary

Prevention **E** from #233 punch list — closes the punch list (A, B, C, D, F all merged today).

Emits a non-blocking warning when the most recent Release on the repository was auto-flagged immutable. That's the heuristic that Repo Setting "Immutable releases" is on. The setting itself is UI-only beta and the \`/repos/{owner}/{repo}\` API does not expose it, so a probe against the latest Release is the best signal available before a dispatch.

## Why warning, not error

- **Setting can be org-controlled.** The v0.5.0 incident showed the setting is not always operator-controlled — org-level defaults can propagate and the operator may not have permission to flip it on the repo. Failing closed here could block legitimate dispatches.
- **Heuristic, not authoritative.** Operator could have toggled the setting between the most recent Release and the current dispatch.
- **Existing JSON contract.** Anything in \`report.diagnostics\` is a hard failure that the workflow's readiness step fails on. Warnings live alongside via the new \`ReadinessWarning\` type so consumers of the existing contract are not silently upgraded into a hard failure.

The warning surfaces as a \`::warning::\` GitHub Actions annotation inline with the readiness step output. Operators see it; the dispatch continues.

## Changes

### Library

- \`scripts/lib/release-readiness.ts\`
  - \`RELEASE_READINESS_WARNING_CODES.ImmutableRepo\` constant.
  - \`GitHubInterface { latestReleaseImmutable(): boolean | null }\` (null = no releases yet OR API error — fail-quiet).
  - \`ReadinessWarning\` type (separate from \`Diagnostic\`).
  - \`checkRepoImmutableSetting(github): ReadinessWarning[]\` — returns one warning when latest Release immutable, none otherwise.

### CLI

- \`scripts/check-release-readiness.ts\`
  - \`realGitHub()\` wires \`gh api repos/{owner}/{repo}/releases?per_page=1 --jq '.[0].immutable'\`.
  - Emits \`::warning::CODE: message\` to stderr when probe returns true.
  - Skipped under \`--json\` so the JSON output contract stays clean.

### Tests

- 3 new test cases in \`tests/scripts/release-readiness.test.ts\` — immutable=true emits warning, immutable=false silent, null silent (fail-quiet).

### Docs

- \`docs/release-operator-guide.md\` §10 gains a "Layer 1 warnings" sub-table documenting the code and severity.
- Regenerated typedoc for the new exports.

## Test plan

- [x] \`npm run test:scripts\` — 3 new tests pass.
- [x] \`npm run verify\` green locally (26.2s).
- [ ] Next dispatch will exercise the probe against the live repo. Expected behaviour: immutable setting is currently OFF (cleared during the v0.5.1 recovery), so no warning fires. If someone flips it back on, the next dispatch warns inline.

## What this does NOT do

- Does not block dispatch. Intentional — see "Why warning, not error".
- Does not detect the setting itself if no Release exists yet. Cannot — \`/repos/{owner}/{repo}\` does not expose it. Closes when GitHub adds the setting to the API surface; until then this is the best signal.

Refs #233 prevention E (closes the prevention punch list) · ADR-0020 · SPEC-V05-005.

🤖 Generated with [Claude Code](https://claude.com/claude-code)