### PR TITLE
docs(branch): add Shape B adoption spec + ADR-0027

### DIFF
--- a/docs/adr/0020-v05-release-branch-strategy.md
+++ b/docs/adr/0020-v05-release-branch-strategy.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-0020
 title: Adopt Shape A with release/vX.Y.Z branches for v0.5 releases
-status: accepted
+status: Superseded
 date: 2026-05-02
 deciders:
   - architect
@@ -13,7 +13,7 @@ informed:
   - qa
   - sre
 supersedes: []
-superseded-by: []
+superseded-by: [ADR-0027]
 tags: [release, branching, governance]
 ---
 

--- a/docs/adr/0027-adopt-shape-b-branching-model.md
+++ b/docs/adr/0027-adopt-shape-b-branching-model.md
@@ -1,0 +1,147 @@
+---
+id: ADR-0027
+title: Adopt Shape B branching model (develop / main / demo) for the template
+status: proposed
+date: 2026-05-03
+deciders:
+  - architect
+consulted:
+  - pm
+  - analyst
+  - release-manager
+informed:
+  - dev
+  - qa
+  - sre
+supersedes: [ADR-0020]
+superseded-by: []
+tags: [branching, governance, release, pages]
+---
+
+# ADR-0027 — Adopt Shape B branching model (develop / main / demo) for the template
+
+## Status
+
+Proposed
+
+## Context
+
+ADR-0020 (2026-05-02) committed the template repository to Shape A — single `main` integration branch plus short-lived `release/vX.Y.Z` branches for release prep. The v0.5 release cycle proved that decision insufficient for two concrete reasons:
+
+- **Integration window on `main`.** Release-prep commits land on `main` *before* the tag is cut. Between merge and tag, CI is green against partially-released content. ADR-0020's own errata (2026-05-02) records that the strict `tag SHA == main HEAD SHA` readiness check tripped twice during the v0.5.1 recovery dispatch because unrelated PRs and direct commits landed on `main` between draft and stable dispatches. The first-parent-history fix in `scripts/lib/release-readiness.ts` recovered the readiness check without removing the underlying integration window.
+- **GitHub Pages reflects in-progress work.** `pages.yml` triggers on `main`, so the public preview shows whatever is on `main` HEAD — including release-prep commits and post-release fixes — rather than a validated, tagged state.
+
+Forces in play in May 2026:
+
+- v0.5 has shipped; the template is past the "v0 → v1" cadence threshold ADR-0020 named for Shape A.
+- The reference Specorator repository (`Luis85/specorator`) already operates `develop` + `demo` with Pages from `demo`, providing prior-art proof the pattern works on the same toolchain.
+- The bot audit (RESEARCH-BRANCH-001 §Q1) confirms minimal blast radius: only `docs-review-bot` requires a one-line PROMPT.md edit; the other four bots are branch-agnostic at the prompt level and need only scheduler reconfiguration.
+- `develop` does not exist on the remote; `release/v0.5.0` is most likely already deleted; the seed step is non-destructive (`git push origin <main-SHA>:refs/heads/develop`).
+- The deferred items from PRD-BRANCH-001 (NG1 `feat/` rename, NG2 squash-merge, NG3 tag-scheme change) remain out of scope; this ADR limits itself to the Shape B branching model and the `release/*` drop.
+
+CLAR-003 and CLAR-004 from PRD-BRANCH-001 are resolved by this ADR (see §Compliance).
+
+## Decision
+
+We adopt **Shape B** as the active branching model for this template repository, with `develop` as the integration branch, `main` as the release-only branch, and `demo` as the GitHub Pages source. Specifically:
+
+1. **`develop`** is the integration branch. Every topic-branch PR (`feat/*`, `fix/*`, `refactor/*`, `chore/*`, `docs/*`, `claude/*`) targets `develop`. `develop` is push-denied at both the Claude Code permission layer (`.claude/settings.json`) and the GitHub remote layer (a ruleset).
+2. **`main`** is the release-only branch. It receives one merge commit at a time via a **promotion PR** from `develop`. Tags (`vX.Y.Z`) are cut on `main` HEAD after a promotion PR merges. `main` carries no release-prep commits ahead of the tag — release-prep lives on `develop`. `main` is push-denied at both layers.
+3. **`demo`** is the GitHub Pages source. After each `main` tag is cut, the maintainer opens a `chore/promote-demo` PR that fast-forwards `demo` to the tagged commit on `main`. `pages.yml` triggers on push to `demo` and deploys via OIDC. `demo` is push-denied at both layers; the maintainer is in the ruleset bypass list so the manual fast-forward is permitted via the GitHub PR merge UI.
+4. **The `release/vX.Y.Z` branch convention is dropped.** The `develop → main` promotion PR replaces the dedicated release-prep branch. Release-prep work (version bump, CHANGELOG entry, lifecycle release-notes finalization) lands on `develop` like any other docs/chore PR before the promotion.
+5. **Branches are seeded non-destructively.** At adoption time, `develop` and `demo` are created as new branch pointers at the current `main` HEAD SHA. No history is rewritten, squashed, or rebased.
+6. **The change set is one coherent piece.** Documentation (`docs/branching.md`, `docs/worktrees.md`, `AGENTS.md`, `CLAUDE.md`), settings (`.claude/settings.json`), workflow (`pages.yml`), bot prompt (`docs-review-bot/PROMPT.md`), bot scheduler configs, Dependabot config, and this ADR all move to Shape B together — there is no "Shape A in some files, Shape B in others" intermediate state on the merged result.
+
+This decision supersedes ADR-0020 in full. ADR-0020's `status` is updated to `Superseded` and its `superseded-by` field is set to `[ADR-0027]`. ADR-0020's body remains immutable per the rule restated at the bottom of every ADR.
+
+## Considered options
+
+### Option A — Adopt Shape B (chosen)
+
+- Pros:
+  - Eliminates the integration window on `main` — `main` carries only promoted, tagged commits.
+  - GitHub Pages serves a validated state (`demo` = last tagged `main`), not in-progress work.
+  - Provides downstream adopters with a live Shape B reference implementation to inspect.
+  - Bot blast radius is small (one PROMPT.md line edit; four scheduler config updates).
+  - Seeding is non-destructive (`develop` and `demo` are new pointers at existing `main` HEAD).
+  - The reference Specorator repo proves the pattern works on the same toolchain.
+- Cons:
+  - One-time coordination cost across `.claude/settings.json`, `pages.yml`, `docs/branching.md`, four scheduler configs, Dependabot config, two ADRs.
+  - Manual `chore/promote-demo` PR per release adds a step to the release checklist.
+  - GitHub Pages environment allow-list update is a manual UI action that cannot be expressed in tracked files.
+
+### Option B — Keep Shape A and add `demo` as a Pages-only branch
+
+- Pros:
+  - Smallest possible diff. Solves the Pages staleness problem in isolation.
+  - No bot reconfiguration; no `release/*` drop.
+- Cons:
+  - Leaves the integration-window defect on `main` unaddressed — the original v0.5.1 readiness-check failure mode is still possible.
+  - Template continues operating Shape A despite the docs noting Shape A is "recommended for v0 → v1" — the repo is past v0.5.
+  - Adopters still cannot inspect a live Shape B reference.
+
+### Option C — Trunk-Based Development (collapse to a single trunk, deploy on every push)
+
+- Pros: Maximum CI velocity for small teams; no promotion discipline needed.
+- Cons: Fundamentally incompatible with the goal of `main` carrying only promoted, tagged commits. Eliminates the protection that motivates this whole feature. Would require a much larger ADR and rewrite of `docs/branching.md`. Does not address Pages staleness; the same content lives on the same branch.
+
+### Option D — Auto-promote `demo` via a CI workflow on `main` tag creation
+
+- Pros: Removes the manual `chore/promote-demo` step.
+- Cons: Requires write credentials against a protected branch (`demo`) — either a PAT or a GitHub App token, both of which expand the threat surface. Single-maintainer cadence is too low to justify the new credential management. Reversible later by adding a workflow if cadence rises; recorded under §Revisit triggers.
+
+## Consequences
+
+### Positive
+
+- Release-prep commits no longer ride on `main` ahead of the tag. The integration-window class of bug — including the readiness-check tag-chase recorded in ADR-0020 errata — is structurally removed.
+- The `github-pages` environment serves the last validated tagged state. Public preview is stable.
+- `release/vX.Y.Z` branch overhead is gone. The promotion PR is the release path; one fewer branch type to remember and clean up.
+- Downstream adopters who inspect this template see the same Shape B model the docs recommend at versioned-release cadence.
+- The `.claude/settings.json` deny-coverage expands: `demo` joins `main` and `develop` under explicit push-deny, with symmetric `reset` / `checkout` / `branch -D/-d` deny entries.
+
+### Negative
+
+- The maintainer must remember the `chore/promote-demo` PR after every release. Forgotten promotion = stale public Pages.
+- The `github-pages` environment "Deployment branches" allow-list update must be done in the GitHub UI before `pages.yml` flips to trigger on `demo`. If this ordering is reversed, Pages deploys fail until the allow-list is fixed.
+- Four bot scheduler configurations require updates outside `agents/operational/`; some of these may live in workflow files not currently tracked under that path.
+- Contributors with muscle memory may continue opening PRs against `main` for the first days. The default-branch flip in repo settings (so `gh pr create` defaults to `develop`) reduces this risk but does not eliminate it.
+
+### Neutral
+
+- The `release/*` allow entries in `.claude/settings.json` are removed, narrowing the agent push surface from five long-lived prefixes to four. Nothing in the template currently uses `release/*` after this ADR is accepted.
+- ADR-0020 stays in `docs/adr/` with `status: Superseded`. Its rationale and errata remain readable as historical context.
+- The reference Specorator repo's `.claude/settings.json` does not currently carry `demo` push-deny; this template chooses to be stricter, since adding a deny entry costs nothing and matches NFR-BRANCH-005's monotonic-coverage rule.
+
+## Compliance
+
+How we know this decision is honoured:
+
+- **`docs/branching.md`** designates Shape B as the active model, names `develop` as the PR target for topic branches, names `main` as the release-only branch, names `demo` as the Pages source, and does not prescribe `release/vX.Y.Z` as a required release step. Reviewers check release PRs against that doc.
+- **`.claude/settings.json`** denies `git push origin {main,develop,demo}:*` and the `-u` variants, denies hard-resets and force-checkouts of all three, and does not include `release/*` in the allow list. The deny count for the three protected branches is monotonically non-decreasing across edits (NFR-BRANCH-005).
+- **GitHub rulesets (CLAR-004 resolution).** A repository ruleset targets `main`, `develop`, `demo` and enforces: require PR before merge; restrict creations and deletions; bypass list = the maintainer (so the manual `demo` promotion via PR merge works without a PAT). Rulesets are chosen over legacy branch-protection rules because rulesets are available on free-tier personal accounts for public repos and provide a single allow-list spanning all three branches; legacy rules are being phased out by GitHub. The exact ruleset configuration is documented in the implementation log; the ADR records the choice.
+- **`demo` promotion (CLAR-003 resolution).** Promotion is a manual `chore/promote-demo` PR cut by the maintainer after each `main` tag, listed in the release checklist. Auto-promotion via CI is rejected in this iteration (Option D); revisit if release cadence rises above one per month or if the maintainer pool grows.
+- **`.github/workflows/pages.yml`** lists `demo` (and only `demo`) under `on.push.branches`. The `github-pages` environment "Deployment branches" allow-list includes `demo`.
+- **`agents/operational/docs-review-bot/PROMPT.md`** does not contain the literal string `clean clone of \`main\`` and instead references `develop` (or "the integration branch") in the tutorial-drift rule.
+- **Bot scheduler configs** for `review-bot`, `plan-recon-bot`, `dep-triage-bot`, `actions-bump-bot` pass `develop` as the integration-branch argument.
+- **`.github/dependabot.yml`** (or Renovate config) sets `target-branch: develop` so automated dependency PRs land on `develop`, not `main`.
+- **`docs/worktrees.md`, `AGENTS.md`, `CLAUDE.md`** name `develop` as the integration / cut-from / PR-target branch wherever they describe the workflow.
+- **ADR-0020 frontmatter** carries `status: Superseded` and `superseded-by: [ADR-0027]`. The body of ADR-0020 is unchanged.
+- **Counter-metric.** Zero PRs targeting `main` as a topic-branch base in the 30 days following adoption. Zero `develop → main` promotions skipped (no direct commits landing on `main`). Zero `main → demo` promotions skipped after a `main` tag. A non-zero count on any of these is the signal Shape B discipline is not holding.
+- **Revisit triggers.** Auto-promotion of `demo` (Option D) is reconsidered if (a) release cadence exceeds one promotion per month for two consecutive months, or (b) the maintainer pool grows beyond one. Tag-scheme change, topic-prefix rename, and squash-merge default each remain out of scope; revisit only via their own ADRs when cause appears.
+
+## References
+
+- PRD-BRANCH-001 — `specs/shape-b-branching-adoption/requirements.md` — 15 EARS requirements + 6 NFRs.
+- DESIGN-BRANCH-001 — `specs/shape-b-branching-adoption/design.md` — Part C architecture, key decisions, rollout sequence.
+- RESEARCH-BRANCH-001 — `specs/shape-b-branching-adoption/research.md` — Q1 bot audit, Q2 demo protection options, Q3 supersession strategy, Q4 historical state, Q5 Pages source.
+- ADR-0020 — `docs/adr/0020-v05-release-branch-strategy.md` — superseded by this ADR.
+- `docs/branching.md` — branching model documentation, updated by this feature.
+- `.claude/settings.json` — agent permission boundary, updated by this feature.
+- `.github/workflows/pages.yml` — Pages deploy workflow, retargeted to `demo` by this feature.
+- Reference Specorator repo — `github.com/Luis85/specorator` — confirmed prior art for `develop` + `demo` pattern.
+- GitHub Docs — [About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches), [Available rules for rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets).
+
+---
+
+> **ADR bodies are immutable.** To change a decision, supersede it with a new ADR; only the predecessor's `status` and `superseded-by` pointer fields may be updated.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,13 +32,14 @@ Records of architecturally significant decisions. Format follows Michael Nygard'
 | [0017](0017-adopt-inputs-folder-as-canonical-ingestion-zone.md) | Adopt `inputs/` as the canonical ingestion folder for new work packages | Accepted |
 | [0018](0018-sites-consumes-tokens.md) | Flip sites/styles.css to consume design-system tokens | Accepted |
 | [0019](0019-add-design-track.md) | Add a Design Track as an opt-in first-party workflow | Accepted |
-| [0020](0020-v05-release-branch-strategy.md) | Adopt Shape A with release/vX.Y.Z branches for v0.5 releases | Accepted |
+| [0020](0020-v05-release-branch-strategy.md) | Adopt Shape A with release/vX.Y.Z branches for v0.5 releases | Superseded by [ADR-0027](0027-adopt-shape-b-branching-model.md) |
 | [0021](0021-release-package-fresh-surface.md) | Ship the released template package as a fresh-surface starter | Accepted |
 | [0022](0022-add-issue-breakdown-track.md) | Adopt issue-breakdown track for parallelising post-tasks issue work | Proposed |
 | [0023](0023-adopt-zod-as-first-runtime-dependency.md) | Adopt zod as the first runtime dependency for script-layer validation | Accepted |
 | [0024](0024-lock-specorator-agentic-workflow-naming-contract.md) | Lock the Specorator and agentic-workflow naming contract | Accepted |
 | [0025](0025-adopt-doc-as-contract-review-protocol.md) | Adopt a doc-as-contract review protocol | Proposed |
 | [0026](0026-freeze-v1-workflow-track-taxonomy.md) | Freeze the v1.0 workflow track taxonomy | Accepted |
+| [0027](0027-adopt-shape-b-branching-model.md) | Adopt Shape B branching model (develop / main / demo) for the template | Proposed |
 <!-- END GENERATED: adr-index -->
 
 ## Conventions

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,7 +32,7 @@ Records of architecturally significant decisions. Format follows Michael Nygard'
 | [0017](0017-adopt-inputs-folder-as-canonical-ingestion-zone.md) | Adopt `inputs/` as the canonical ingestion folder for new work packages | Accepted |
 | [0018](0018-sites-consumes-tokens.md) | Flip sites/styles.css to consume design-system tokens | Accepted |
 | [0019](0019-add-design-track.md) | Add a Design Track as an opt-in first-party workflow | Accepted |
-| [0020](0020-v05-release-branch-strategy.md) | Adopt Shape A with release/vX.Y.Z branches for v0.5 releases | Superseded by [ADR-0027](0027-adopt-shape-b-branching-model.md) |
+| [0020](0020-v05-release-branch-strategy.md) | Adopt Shape A with release/vX.Y.Z branches for v0.5 releases | Superseded |
 | [0021](0021-release-package-fresh-surface.md) | Ship the released template package as a fresh-surface starter | Accepted |
 | [0022](0022-add-issue-breakdown-track.md) | Adopt issue-breakdown track for parallelising post-tasks issue work | Proposed |
 | [0023](0023-adopt-zod-as-first-runtime-dependency.md) | Adopt zod as the first runtime dependency for script-layer validation | Accepted |

--- a/specs/shape-b-branching-adoption/design.md
+++ b/specs/shape-b-branching-adoption/design.md
@@ -1,0 +1,371 @@
+---
+id: DESIGN-BRANCH-001
+title: Shape B branching adoption — Design
+stage: design
+feature: shape-b-branching-adoption
+status: draft
+owner: architect
+collaborators:
+  - architect
+inputs:
+  - PRD-BRANCH-001
+  - RESEARCH-BRANCH-001
+adrs:
+  - ADR-0027
+created: 2026-05-03
+updated: 2026-05-03
+---
+
+# Design — Shape B branching adoption
+
+## Context
+
+The agentic-workflow template currently runs Shape A (single `main` branch + ad-hoc `release/vX.Y.Z` branches per ADR-0020). The v0.5 release cycle exposed two concrete defects: release-prep commits land on `main` before a tag is cut (creating an integration window where CI is green against partially-released content), and GitHub Pages deploys from `main` (so the public preview reflects in-progress work rather than a validated state). PRD-BRANCH-001 specifies the transition to Shape B — `develop` for integration, `main` for tagged releases only, `demo` for Pages — including 15 functional requirements, 6 NFRs, and two architect-owned clarifications (CLAR-003 demo promotion automation; CLAR-004 protection mechanism).
+
+This design closes both clarifications, names the affected components, sequences the rollout, and routes the irreversible decisions through ADR-0027 (which supersedes ADR-0020).
+
+## Goals (design-level)
+
+- D1. Pick a `demo` promotion mechanism (CLAR-003) and document it so the spec stage can write the procedure.
+- D2. Pick a branch-protection mechanism for `develop` and `demo` (CLAR-004) consistent with this repo's GitHub plan tier.
+- D3. Specify the exact deny-rule strings to add to `.claude/settings.json` so REQ-BRANCH-002, REQ-BRANCH-003, REQ-BRANCH-011 are unambiguous.
+- D4. Specify the rollout order so NFR-BRANCH-006 (Pages continuity) and NFR-BRANCH-001 / NFR-BRANCH-002 (non-destructive seeding) hold.
+- D5. Record one new ADR superseding ADR-0020 (REQ-BRANCH-010) and update the predecessor frontmatter only (immutable-body rule).
+
+## Non-goals
+
+- ND1. No prescription for which contributor opens which PR — process detail belongs to the spec stage.
+- ND2. No new CI workflows beyond the demo-promotion entry; we are not redesigning the release workflow.
+- ND3. No data model — this feature has no runtime data.
+- ND4. No user-facing UI surface — Parts A and B are N/A.
+
+---
+
+## Part A — UX
+
+**N/A.** This feature has no user-facing UI surface. The "users" are the maintainer, contributors, operational bots, and Pages visitors; their interaction is through git operations and the public Pages site, both of which are existing surfaces. UX-relevant copy (the `docs/branching.md` rewrite) is a documentation-only artifact owned by the spec stage.
+
+## Part B — UI
+
+**N/A.** No screens, components, or design tokens introduced. The Pages site continues to render `sites/index.html` from the deploying branch; only the source branch changes.
+
+---
+
+## Part C — Architecture
+
+### System overview
+
+Three-branch topology. Topic branches feed `develop`; `develop` promotes to `main` via PR at release time; tags are cut on `main`; `demo` is fast-forwarded to the tagged commit on `main`. Bots and Pages key off the appropriate long-lived branch.
+
+```mermaid
+flowchart TB
+  subgraph topics[Topic branches in worktrees]
+    feat["feat/*"]
+    fix["fix/*"]
+    chore["chore/*"]
+    docs["docs/*"]
+    refactor["refactor/*"]
+  end
+
+  develop[("develop<br/>integration<br/>push-denied")]
+  main[("main<br/>release-only<br/>push-denied")]
+  demo[("demo<br/>Pages source<br/>push-denied")]
+  tag[/"vX.Y.Z tag<br/>on main HEAD"/]
+  pages[["GitHub Pages<br/>environment"]]
+
+  feat -- "PR (topic -> develop)" --> develop
+  fix -- "PR (topic -> develop)" --> develop
+  chore -- "PR (topic -> develop)" --> develop
+  docs -- "PR (topic -> develop)" --> develop
+  refactor -- "PR (topic -> develop)" --> develop
+
+  develop -- "promotion PR (develop -> main)<br/>at release time" --> main
+  main -- "tag from HEAD" --> tag
+  tag -- "manual fast-forward<br/>on chore/promote-demo PR" --> demo
+  demo -- "push event" --> pages
+
+  subgraph bots[Operational bots]
+    rb[review-bot]
+    drb[docs-review-bot]
+    prb[plan-recon-bot]
+    dtb[dep-triage-bot]
+    abb[actions-bump-bot]
+  end
+
+  bots -. "scheduled checkout / cut from develop" .-> develop
+```
+
+### Components and responsibilities
+
+Every component below is an existing artefact whose contents change, or a new branch pointer. No new code modules are introduced.
+
+| Component | Responsibility | Owns | Dependencies |
+|---|---|---|---|
+| `develop` branch (new pointer) | Integration target for all topic-branch PRs | Pointer at `main` HEAD on creation; thereafter the merge-commit history of merged topic PRs | `.claude/settings.json` deny entries; GitHub branch-protection rule |
+| `main` branch (role narrowed) | Release-only branch; carries promoted commits and tag commits | Tagged release commits | Promotion PR from `develop`; existing push-deny entries |
+| `demo` branch (new pointer) | GitHub Pages source; carries a fast-forward of `main` tagged HEADs | Pointer fast-forwarded to the tagged commit on `main` after each release | `.claude/settings.json` deny entries; GitHub branch-protection rule; Pages environment allow-list |
+| `docs/branching.md` | Authoritative human-readable description of Shape B as the active model | Branch table, rules, promotion section, settings section | ADR-0027; contributor reads |
+| `.claude/settings.json` | Local Claude Code permission boundary | Allow/deny lists for git push patterns | `docs/branching.md` rules; ADR-0027 compliance section |
+| `.github/workflows/pages.yml` | Trigger GitHub Pages deployment from the correct branch | `on.push.branches` array; OIDC deploy job | `demo` branch existence; `github-pages` environment allow-list |
+| `agents/operational/docs-review-bot/PROMPT.md` | Source-of-truth prompt for docs-review-bot | The "tutorial-drift" rule wording | Prompt is loaded by scheduled run |
+| Bot scheduler configs (review-bot, plan-recon-bot, dep-triage-bot, actions-bump-bot) | Pass `develop` as integration-branch argument at runtime | The scheduler/runner invocation strings (workflow YAML, Dependabot config) | The bot PROMPT.md files; runtime env |
+| `.github/dependabot.yml` (or Renovate config) | Specify PR target branch for automated dep updates | `target-branch` field | `develop` branch existence |
+| `docs/worktrees.md` | Tell contributors which branch to cut topic branches from | "cut from `develop`" instruction | `docs/branching.md`; ADR-0027 |
+| `AGENTS.md`, `CLAUDE.md` | Cross-tool root context naming the integration branch | "no direct commits on `main` / `develop`" rule wording, PR target references | `docs/branching.md`; ADR-0027 |
+| ADR-0027 (new) | Record the Shape B adoption decision and supersede ADR-0020 | Frontmatter (`supersedes: [ADR-0020]`); decision body; compliance rules | ADR-0020 (predecessor); `templates/adr-template.md` |
+| ADR-0020 (frontmatter only) | Predecessor pointer | `status: Superseded`; `superseded-by: [ADR-0027]` | ADR-0027 acceptance |
+| GitHub Pages environment (`github-pages`) | Gate deployments to allowed source branches | Environment "Deployment branches" allow-list | `pages.yml` trigger branch; manual UI step |
+| GitHub branch-protection (rule or ruleset, see Key decisions) | Block direct push to `develop` and `demo` at the remote | Push restriction; required PR | GitHub plan tier (free for personal account) |
+
+### Data model
+
+**N/A.** No runtime data; no entities; no migrations. The only "schema" change is JSON entries in `.claude/settings.json` and YAML entries in `pages.yml` — both covered under spec.md as exact-string contracts.
+
+### Data flow
+
+#### Flow 1 — A topic PR lands on `develop`
+
+```mermaid
+sequenceDiagram
+    actor Contributor
+    participant Worktree as .worktrees/<slug>/
+    participant GitHub
+    participant Bots as docs-review-bot
+
+    Contributor->>Worktree: git switch -c feat/foo origin/develop
+    Contributor->>Worktree: edit files; verify
+    Contributor->>GitHub: git push origin feat/foo
+    Note over Contributor,GitHub: .claude/settings.json allow: "Bash(git push origin feat/*)"
+    Contributor->>GitHub: gh pr create --base develop
+    GitHub-->>Contributor: PR opened against develop
+    GitHub->>GitHub: PR title CI, verify, review
+    GitHub->>GitHub: merge to develop
+    Bots->>GitHub: read develop HEAD on next run
+```
+
+#### Flow 2 — Release: `develop` → `main` → tag → `demo` → Pages
+
+```mermaid
+sequenceDiagram
+    actor Maintainer
+    participant develop
+    participant main
+    participant tag as vX.Y.Z tag
+    participant demo
+    participant Pages as GitHub Pages
+
+    Maintainer->>develop: ensure green; release-prep commits already on develop
+    Maintainer->>main: open promotion PR (develop -> main)
+    main->>main: PR review + verify
+    main->>main: merge promotion PR
+    Maintainer->>tag: create vX.Y.Z on main HEAD
+    tag-->>Maintainer: tag exists on main first-parent history
+    Maintainer->>demo: open chore/promote-demo PR (fast-forward demo to tagged main)
+    demo->>demo: review + merge (or maintainer pushes via GitHub UI bypass per ruleset)
+    demo->>Pages: push event triggers pages.yml
+    Pages-->>Maintainer: deployed page_url
+```
+
+#### Flow 3 — Bot runs against `develop`
+
+```mermaid
+sequenceDiagram
+    participant Scheduler as GitHub Actions cron
+    participant Bot as docs-review-bot run
+    participant Repo as develop branch checkout
+    participant Issue as routine GitHub issue
+
+    Scheduler->>Bot: cron tick (configured: integration-branch=develop)
+    Bot->>Repo: checkout origin/develop
+    Bot->>Repo: read PROMPT.md (references "develop" in tutorial-drift rule)
+    Bot->>Issue: idempotency check on develop HEAD SHA
+    alt SHA unchanged
+        Bot-->>Scheduler: no-op (idempotent)
+    else SHA advanced
+        Bot->>Issue: open or update routine issue
+    end
+```
+
+### Interaction / API contracts
+
+No HTTP/RPC API. The "contracts" in this feature are exact-text contracts on configuration files, captured here as sketches; full strings live in `spec.md`:
+
+- **`.claude/settings.json` deny entries (REQ-BRANCH-002, REQ-BRANCH-003).** Two new lines for `demo` push-deny; the existing `develop` deny entries stay (they are already present — see `.claude/settings.json` lines 41–42).
+- **`.claude/settings.json` allow entries (REQ-BRANCH-011).** Remove the two `release/*` entries (lines 36–37 in the current file).
+- **`.github/workflows/pages.yml` trigger (REQ-BRANCH-004).** Replace `branches: [main]` with `branches: [demo]`.
+- **`agents/operational/docs-review-bot/PROMPT.md` (REQ-BRANCH-008).** Replace the literal string `clean clone of main` (with backticks around `main`) with `clean clone of develop` (or "the integration branch").
+- **`.github/dependabot.yml` `target-branch` field.** Set to `develop` (technical-consideration 3 from research).
+
+No breaking change to any public surface — this is internal repo plumbing. Downstream adopters who copied an older `.claude/settings.json` are unaffected; their settings file is theirs to maintain.
+
+### Key decisions
+
+| Decision | Choice | Why | ADR |
+|---|---|---|---|
+| Single ADR vs. separate ADRs for the two coupled decisions (Shape B adoption + `release/*` drop) | Single ADR (ADR-0027) covering both | The two are inseparable per research Q3; partial supersession not required by any future scenario; reduces cross-reference overhead | ADR-0027 |
+| `demo` promotion trigger (CLAR-003) | Manual `chore/promote-demo` PR cut after each `main` tag, listed in the release checklist; **no** automated CI tag-trigger in this iteration | Single-maintainer cadence is low; an automated workflow would need to push to `demo` (a protected branch) which requires either a ruleset bypass list or a PAT — both expand the threat surface for negligible velocity gain. The manual step is reversible and discoverable; automation can be added later as a follow-up ADR if cadence rises | ADR-0027 §Compliance |
+| Branch-protection mechanism for `develop` and `demo` (CLAR-004) | GitHub **rulesets** (not legacy branch-protection rules) | Rulesets are available on free-tier personal accounts for public repos as of 2024; legacy rules are being phased out by GitHub; rulesets give a single allow-list for bypass actors (the maintainer) and a single source of truth for both branches; bypass for the manual `demo` promotion is configurable without a PAT | ADR-0027 §Compliance |
+| `.claude/settings.json` deny syntax for `demo` | Add exactly `"Bash(git push origin demo:*)"` and `"Bash(git push -u origin demo:*)"` matching the existing `main` / `develop` patterns; also add `"Bash(git checkout demo:*)"`, `"Bash(git branch -D demo:*)"`, `"Bash(git branch -d demo:*)"`, and `"Bash(git reset --hard origin/demo:*)"` / `"Bash(git reset --hard demo:*)"` for symmetry with `main` and `develop` deny coverage | NFR-BRANCH-005 forbids the deny list shrinking; symmetric coverage prevents accidental hard-resets and force-checkouts of `demo`, matching how `main`/`develop` are protected | ADR-0027 |
+| `release/*` push-allow removal timing | Remove in the same change set, not deferred | Research recommended deferral as low priority; PRD raised it to a `should` requirement (REQ-BRANCH-011); doing it together avoids a stale-config window and is one-line of risk | ADR-0027 |
+| Bots: PROMPT.md edits vs. scheduler-only edits | `docs-review-bot` PROMPT.md edited (1 line, REQ-BRANCH-008); other four bots unchanged at PROMPT.md level — scheduler config only (REQ-BRANCH-009) | Research Q1 audit confirmed only one literal `main` reference in any prompt; the remaining bots already use `<integration-branch>` placeholders or generic phrasing | — (operational, not architectural) |
+| `demo` initial seed source | `main` HEAD at adoption time (REQ-BRANCH-014) | Cleanest non-destructive starting state; matches Pages continuity NFR-BRANCH-006; identical bytes mean Pages sees no diff at the trigger flip | — (mechanical) |
+| `develop` initial seed source | `main` HEAD at adoption time (REQ-BRANCH-006) | Same rationale as above; pointer creation, no history rewrite | — (mechanical) |
+
+### Alternatives considered
+
+#### Alt-1 — Keep Shape A (status quo plus a `demo` Pages branch only)
+
+Reject. Addresses only the Pages staleness problem and leaves the integration-window defect intact. The v0.5.1 readiness-check failures recorded in ADR-0020's errata are evidence that the integration window causes real harm at this cadence. Adopters who inspect this template would still see Shape A, contradicting the desired-outcome of providing a live Shape B reference. Detailed in research §Alternatives Alt-B.
+
+#### Alt-2 — Full specorator parity (Shape B + topic-prefix rename + squash-merge default + tag-scheme change)
+
+Reject. Each of the three additional changes has its own blast radius and is excluded from this feature's scope per PRD-BRANCH-001 NG1–NG3. Bundling them would expand the change-set across `.claude/settings.json` allow-list, every agent prompt that mentions `feat/`, every CI regex, every existing in-flight branch, the tag-source script in `scripts/lib/release-readiness.ts`, and downstream adopter expectations. Shape B alone resolves the documented harm; the other three are independent improvements that can each be filed as their own feature when justification appears.
+
+#### Alt-3 — `demo` auto-promoted by CI on every `main` tag creation
+
+Reject for this iteration. Would require: (a) a new GitHub Actions workflow listening for tag events, (b) a write credential against `demo` (PAT or app-token because the default `GITHUB_TOKEN` cannot bypass branch protection without explicit ruleset bypass), (c) error-recovery logic when the auto-fast-forward fails (e.g., `demo` ahead of `main`). The complexity is unjustified at single-maintainer cadence. The manual `chore/promote-demo` PR keeps the protection model uniform and is one extra command per release. Revisit when cadence rises (recorded in ADR-0027 revisit trigger).
+
+### Risks
+
+| ID | Risk | Severity | Likelihood | Mitigation |
+|---|---|---|---|---|
+| RISK-BRANCH-001 | Pages serves a 404 or stale content during the trigger swap (Pages-environment allow-list not updated before `pages.yml` flips) — violates NFR-BRANCH-006 | high | med | Rollout step 4 (below) requires updating the `github-pages` environment allow-list to include `demo` *before* `pages.yml` is merged. Spec stage to record the manual UI step verbatim. The seeded `demo` branch points to the same commit as `main` so content is byte-identical; the only failure mode is permission denial, recoverable by reverting `pages.yml` |
+| RISK-BRANCH-002 | The `.claude/settings.json` deny list shortens (loses coverage) when the `release/*` allow entries are removed but `demo` deny entries are forgotten — violates NFR-BRANCH-005 | med | low | Rollout step 3 specifies adding `demo` deny entries and removing `release/*` allow entries in the same edit; spec.md to enumerate exact strings; reviewer checks the diff against the count rule (post-change deny count for `main`+`develop`+`demo` ≥ pre-change deny count for `main`+`develop`) |
+| RISK-BRANCH-003 | Bot scheduler reconfiguration missed for one or more of the four scheduler-config-only bots — produces false drift findings or missed coverage (REQ-BRANCH-009) | med | med | Spec.md to enumerate the exact scheduler/runner config file path per bot (or escalate as clarification if the path is in an external system not tracked in the repo); rollout step 6 lists each bot by name; review checklist includes "all four schedulers updated" |
+| RISK-BRANCH-004 | PRs continue to target `main` for the first days after `develop` exists (contributor habit, RISK-001 in research) | low | high | `docs/branching.md`, `AGENTS.md`, `CLAUDE.md`, `docs/worktrees.md` updated in the same PR as `develop` creation (NFR-BRANCH-003 consistency); single maintainer can also set `develop` as the GitHub default branch in repo settings to make `gh pr create` default to it without `--base develop` |
+| RISK-BRANCH-005 | `release/v0.5.0` branch exists on remote but is undisplayed; deletion skipped (RISK-008 in research, REQ-BRANCH-013) | low | low | Rollout step 1 specifies pre-condition check `git ls-remote --heads origin release/v0.5.0`; deletion sequenced before `develop` creation; idempotent — safe to re-run |
+| RISK-BRANCH-006 | ADR-0020 `superseded-by` left empty after ADR-0027 merges (RISK-007 in research, NFR-BRANCH-004) | low | med | ADR-0020 frontmatter update is part of this same design hand-off; the new ADR PR includes both files; review checklist in ADR-0027 §Compliance |
+| RISK-BRANCH-007 | Dependabot opens its first post-flip PR against `main` because `.github/dependabot.yml` `target-branch` was forgotten | med | med | Spec.md to list `.github/dependabot.yml` (or Renovate config) update as an explicit task with the exact field name; rollout step 6 covers it under bot scheduler reconfiguration |
+| RISK-BRANCH-008 | Demo promotion forgotten after a `main` tag → public Pages goes stale (RISK-006 in research) | low | med | Manual step is in the release checklist (ADR-0027 compliance); release-manager agent prompt to be updated as a follow-up if cadence rises; counter-metric defined in PRD ("zero `develop → main` promotions skipped" extends naturally to "zero `main → demo` promotions skipped" — record in retrospective) |
+
+### Performance, security, observability
+
+- **Performance.** No runtime change. Bot CI minutes do not increase (same number of bots, same checkout pattern, just a different ref). Pages deploy time unchanged. CI lead time per topic PR may decrease marginally because `develop` carries less drift than `main` did between releases.
+- **Security.** Push-deny coverage expands (adds `demo`); does not contract (NFR-BRANCH-005). The `release/*` allow-list removal narrows the remote-push surface for Claude Code agents from five long-lived prefixes to four. GitHub ruleset on `develop` and `demo` adds a server-side enforcement layer that survives clone-and-push from any client. No new credentials introduced; the manual `demo` promotion uses the maintainer's existing push permissions via a PR (no new PAT, no new app token).
+- **Observability.** No new SLI. Existing PR-title CI, verify gate, and Pages deployment status remain the operational signals. The "zero PRs targeting `main`" north-star metric (PRD §Success metrics) is observable from the GitHub PR list filtered by `base:main`.
+
+### ADR diff (for ADR-0020 supersession)
+
+Apply only to **frontmatter** of `docs/adr/0020-v05-release-branch-strategy.md`. The body remains immutable per the rule restated at the bottom of the ADR.
+
+```diff
+ ---
+ id: ADR-0020
+ title: Adopt Shape A with release/vX.Y.Z branches for v0.5 releases
+-status: accepted
++status: Superseded
+ date: 2026-05-02
+ deciders:
+   - architect
+ consulted:
+   - pm
+   - release-manager
+ informed:
+   - dev
+   - qa
+   - sre
+ supersedes: []
+-superseded-by: []
++superseded-by: [ADR-0027]
+ tags: [release, branching, governance]
+ ---
+```
+
+No other lines in ADR-0020 change. The existing 2026-05-02 errata stays untouched.
+
+### Rollout sequence
+
+The implementation order is non-destructive and ordered so each step is reversible until the next one runs. The spec stage will translate this into discrete tasks; the design fixes the order.
+
+1. **Pre-condition checks** (read-only, no remote write):
+   - `git ls-remote --heads origin develop` — must return empty.
+   - `git ls-remote --heads origin demo` — must return empty.
+   - `git ls-remote --heads origin release/v0.5.0` — if non-empty, queue a delete in step 2.
+   - Capture current `main` HEAD SHA — this is the seed commit for both new branches.
+2. **Historical cleanup** (REQ-BRANCH-013): if `release/v0.5.0` exists, delete with `git push origin --delete release/v0.5.0`. Safe — that branch is post-tag and superseded by the v0.5.0 tag itself. Skip if not present.
+3. **Settings update PR** (touches `.claude/settings.json` only) — independent, can land first or alongside step 5:
+   - Add `demo` deny entries (REQ-BRANCH-003).
+   - Remove `release/*` allow entries (REQ-BRANCH-011).
+   - Add `demo` symmetric deny entries (`reset`, `checkout`, `branch -D/-d`).
+   - Verify count rule (NFR-BRANCH-005).
+4. **GitHub Pages environment update** (manual UI step, no PR): Settings → Environments → `github-pages` → Deployment branches → add `demo` to allow-list. Do **not** remove `main` from the allow-list yet; remove only after step 7 confirms `demo` deploys cleanly. This satisfies the NFR-BRANCH-006 sequencing constraint.
+5. **Branch creation** (no content, no rewrites):
+   - `git push origin <captured-main-SHA>:refs/heads/develop` (REQ-BRANCH-006, NFR-BRANCH-001).
+   - `git push origin <captured-main-SHA>:refs/heads/demo` (REQ-BRANCH-014, NFR-BRANCH-002).
+   - In repo Settings, set `develop` as the default branch (so `gh pr create` defaults to `develop`).
+6. **Branch protection rulesets** (manual UI step or `gh api` calls):
+   - Create or update a ruleset that targets `main`, `develop`, `demo` and enforces: require PR before merge; restrict creations / deletions; bypass list = maintainer (for `demo` manual promotion).
+7. **Pages workflow flip PR** (touches `.github/workflows/pages.yml` only) — sequenced *after* step 4:
+   - Change `on.push.branches` from `[main]` to `[demo]` (REQ-BRANCH-004).
+   - Trigger one manual `workflow_dispatch` on `demo` to verify the deploy succeeds.
+   - After verified-green, optionally remove `main` from the `github-pages` environment allow-list (closes the legacy path).
+8. **Documentation + ADR PR** (touches `docs/branching.md`, `docs/worktrees.md`, `AGENTS.md`, `CLAUDE.md`, `agents/operational/docs-review-bot/PROMPT.md`, `docs/adr/0027-adopt-shape-b-branching-model.md`, and `docs/adr/0020-v05-release-branch-strategy.md` frontmatter, and `docs/adr/README.md` index):
+   - REQ-BRANCH-001, REQ-BRANCH-005, REQ-BRANCH-007, REQ-BRANCH-008, REQ-BRANCH-010, REQ-BRANCH-012, REQ-BRANCH-015, NFR-BRANCH-003, NFR-BRANCH-004 all close here.
+   - This is the largest PR; it locks the new model in writing.
+9. **Bot scheduler reconfiguration** (REQ-BRANCH-009): for `review-bot`, `plan-recon-bot`, `dep-triage-bot`, `actions-bump-bot`, update each scheduler's invocation to pass `develop`. For Dependabot, update `.github/dependabot.yml` `target-branch: develop`. Spec stage will identify the exact files; some live outside `agents/operational/` per research technical-consideration 6.
+10. **Verification**:
+    - `gh pr list --base main` — should show only the (none-yet) post-adoption promotion PRs going forward.
+    - Pages site loads; `chore/promote-demo` dry-run unnecessary because `demo` already points at `main` HEAD.
+    - `docs-review-bot` next scheduled run does not flag the tutorial-drift rule.
+    - Counter-metric: zero direct commits on `main` in the next 30 days.
+
+Steps 3, 5, 7, 8, 9 each land as their own PR per the branch-per-concern rule. Step 4 and Step 6 are GitHub UI actions logged in the implementation log per ADR-0027 compliance. Order matters between 4 → 7 (Pages allow-list before workflow flip) and between 5 → 6 (branches must exist before they can be ruleset-protected).
+
+---
+
+## Cross-cutting
+
+### Requirements coverage
+
+| REQ ID | Addressed in (Arch section) |
+|---|---|
+| REQ-BRANCH-001 | Components and responsibilities (`docs/branching.md`); Rollout step 8 |
+| REQ-BRANCH-002 | Interaction / API contracts (deny entries — already present, retained); Key decisions (deny syntax row); Rollout step 3 |
+| REQ-BRANCH-003 | Interaction / API contracts (new `demo` deny entries); Key decisions (deny syntax row); Rollout step 3 |
+| REQ-BRANCH-004 | Interaction / API contracts (pages.yml trigger); Rollout step 7; Risks RISK-BRANCH-001 |
+| REQ-BRANCH-005 | Components and responsibilities (`docs/branching.md`); Rollout step 8 |
+| REQ-BRANCH-006 | Rollout step 1, step 5; NFR-BRANCH-001 mitigation; Key decisions (`develop` initial seed source) |
+| REQ-BRANCH-007 | Components and responsibilities (`docs/branching.md`); Rollout step 8 |
+| REQ-BRANCH-008 | Interaction / API contracts (PROMPT.md text); Components and responsibilities; Rollout step 8 |
+| REQ-BRANCH-009 | Components and responsibilities (Bot scheduler configs); Rollout step 9; Risks RISK-BRANCH-003, RISK-BRANCH-007 |
+| REQ-BRANCH-010 | Components and responsibilities (ADR-0027); Key decisions (single ADR row); ADR diff section; Rollout step 8 |
+| REQ-BRANCH-011 | Interaction / API contracts (allow-list removal); Key decisions (`release/*` removal timing); Rollout step 3 |
+| REQ-BRANCH-012 | Components and responsibilities (`docs/worktrees.md`); Rollout step 8 |
+| REQ-BRANCH-013 | Rollout step 1, step 2; Risks RISK-BRANCH-005 |
+| REQ-BRANCH-014 | Rollout step 5; Key decisions (`demo` initial seed source); Data flow Flow 2 |
+| REQ-BRANCH-015 | Components and responsibilities (`AGENTS.md`, `CLAUDE.md`); Rollout step 8 |
+| NFR-BRANCH-001 | Rollout step 1, step 5; Key decisions (`develop` initial seed source) |
+| NFR-BRANCH-002 | Rollout step 1, step 5; Key decisions (`demo` initial seed source) |
+| NFR-BRANCH-003 | Components and responsibilities (each affected file); Rollout step 8 (single docs PR locks the model) |
+| NFR-BRANCH-004 | ADR diff section; Components and responsibilities (ADR-0020 row); Risks RISK-BRANCH-006 |
+| NFR-BRANCH-005 | Key decisions (deny syntax row); Risks RISK-BRANCH-002 |
+| NFR-BRANCH-006 | Rollout step 4 sequencing; Risks RISK-BRANCH-001; Key decisions (`demo` initial seed source) |
+
+### Open questions
+
+- OPEN-BRANCH-001 (for spec stage). Exact path and syntax for each of the four scheduler-only bot configs (review-bot, plan-recon-bot, dep-triage-bot, actions-bump-bot). Research technical-consideration 6 notes the scheduler config is not tracked in `agents/operational/`. The spec author should locate the GitHub Actions workflow files (likely `.github/workflows/<bot>.yml`) and record exact field paths; if any scheduler lives outside the repo, escalate as a clarification with the user.
+- OPEN-BRANCH-002 (for spec stage). Whether to remove `main` from the `github-pages` environment allow-list immediately at step 7 or leave it for a follow-up. Architecturally optional; mention in spec but do not block on it.
+- OPEN-BRANCH-003 (for spec stage). Whether to add a PR-title or PR-base CI check that fails when a topic PR targets `main` (RISK-BRANCH-004 mitigation). Out of scope for this feature per PRD NG, but worth flagging as a future improvement.
+
+CLAR-003 and CLAR-004 from the requirements stage are **resolved** in the Key decisions table above:
+
+- CLAR-003 → Manual `chore/promote-demo` PR per release (no auto-trigger this iteration).
+- CLAR-004 → GitHub rulesets (not legacy branch-protection rules), available on free-tier personal accounts for public repos.
+
+---
+
+## Quality gate
+
+- [x] UX: N/A — declared explicitly with reason.
+- [x] UI: N/A — declared explicitly with reason.
+- [x] Architecture: components, data flow, integration points named.
+- [x] Alternatives considered and rejected with rationale.
+- [x] Irreversible architectural decisions have ADRs (ADR-0027).
+- [x] Risks have mitigations.
+- [x] Every PRD requirement is addressed (15 REQ-BRANCH-NNN + 6 NFR-BRANCH-NNN mapped above).
+- [x] Branch topology diagram present (System overview).
+- [x] CLAR-003 resolved (Key decisions: manual promotion).
+- [x] CLAR-004 resolved (Key decisions: GitHub rulesets).
+- [x] Rollout sequence is ordered and non-destructive.
+- [x] New ADR (ADR-0027) written with `supersedes: [ADR-0020]`.
+- [x] ADR-0020 frontmatter update specified (status + superseded-by only; body untouched).

--- a/specs/shape-b-branching-adoption/idea.md
+++ b/specs/shape-b-branching-adoption/idea.md
@@ -1,0 +1,86 @@
+---
+id: IDEA-BRANCH-001
+title: Adopt Shape B branching model in agentic-workflow template
+stage: idea
+feature: shape-b-branching-adoption
+status: accepted
+owner: analyst
+created: 2026-05-03
+updated: 2026-05-03
+---
+
+# Idea — Adopt Shape B branching model in agentic-workflow template
+
+## Problem statement
+
+The agentic-workflow template repo currently runs Shape A (single `main` integration + release branch) under ADR-0020. The v0.5 release cycle exposed a concrete friction: release-prep commits land on `main` before a tag is cut, creating a window where CI is green against partially-released content and operational bots key off commits that do not yet represent a stable release. The GitHub Pages preview deploys from `main`, meaning it reflects in-progress work rather than a validated demo state. Template adopters who ship versioned software need a clear separation between "code being integrated" and "code that has been released," but the template they clone defaults to the simpler Shape A without a migration path that is modelled end-to-end. Transitioning the template itself to Shape B — `develop` as the integration branch, `main` as release-only, and `demo` as the Pages preview branch — resolves this for the template's own operations and provides adopters with a live reference implementation.
+
+## Target users
+
+- Primary: maintainers and contributors to the agentic-workflow template repo who currently merge topic branches to `main` and cut releases from it.
+- Secondary: downstream adopters of the template who evaluate whether to use Shape A or Shape B by inspecting how the template itself is operated.
+- Secondary: operational bots (`review-bot`, `plan-recon-bot`, `dep-triage-bot`, `docs-review-bot`, `actions-bump-bot`) whose branch regexes and integration-branch assumptions must remain correct after the flip.
+
+## Desired outcome
+
+After this work is merged and adopted:
+
+1. All topic-branch PRs target `develop` by default; `main` receives only promotion PRs cut from `develop`.
+2. GitHub Pages deploys from the `demo` branch, not `main`, so the public preview reflects a validated state rather than in-progress integration work.
+3. `release/vX.Y.Z` branches are no longer used; the develop-to-main PR is the promotion path, and tags are cut from `main` HEAD after that merge.
+4. `docs/branching.md`, `.claude/settings.json`, operational bot configs, and `pages.yml` are internally consistent with Shape B.
+5. ADR-0020 is superseded by a new ADR that records the Shape B decision with its rationale, consequences, and compliance rules.
+6. A contributor arriving at the repo can follow the documented branching model without encountering contradictions between the docs and the live branch structure.
+
+## Constraints
+
+- Time: lifecycle stops at Stage 4 (Design) + ADR + GitHub issue this round; Stages 5-11 are deferred pending parent issue triage and v0.5 immutable-release recovery (#233).
+- Budget: single-maintainer repo; no tooling cost budget.
+- Technical: `develop` push-deny is already in `.claude/settings.json`; enabling it as an active integration branch requires adding the `develop` merge allow and confirming the push-deny stays on both `main` and `develop` direct-push surface. The `demo` branch does not yet exist; its protection rules are unspecified (CLAR-001).
+- Technical: `.claude/settings.json` permission rules use prefix matching on literal command strings — any new branch names or promotion patterns must be reflected in the allowlist. The deny rules for `main` and `develop` direct push must remain intact.
+- Technical: operational bots in `agents/operational/` carry branch-regex assumptions keyed to the current Shape A integration branch; each bot must be audited before implementation.
+- Technical: the `pages.yml` workflow currently triggers on push to `main`; flipping it to `demo` requires the `demo` branch to exist and have a defined promotion source before the workflow change lands.
+- Policy: the merge-not-rebase rule (`feedback_parallel_pr_conflicts.md`) is kept; squash-merge default is not adopted.
+- Policy: topic prefix rename (`feat/` to `feature/`) and tag-scheme change (`vX.Y.Z` to `X.Y.Z`) are out of scope this round.
+- Policy: ADR bodies are immutable; ADR-0020 must be superseded by a new ADR, not amended.
+- Policy: the `develop` branch does not yet exist on the remote; creating it is an implementation step, not a design step.
+
+## Open questions
+
+> These become the research agenda in stage 2.
+
+- Q1 — What exact changes are needed in each operational bot's `PROMPT.md` to support `develop` as the integration branch? Which bots hard-code `main` in branch-name checks, PR-target assertions, or idempotency guards?
+- Q2 — What are the concrete protection-rule options for the `demo` branch? Should it be push-deny (promote-only from `main` or `develop`) or allow direct push for hotfix previews? What does the reference Specorator repo do? (CLAR-001)
+- Q3 — What is the recommended strategy for ADR-0020 supersession: a new ADR that supersedes and leaves ADR-0020's `superseded-by` field pointing at the new number, or a combined ADR that also captures the `release/vX.Y.Z` drop? Does the immutable-body rule require any errata on ADR-0020 before supersession?
+- Q4 — What historical state needs to be addressed before `develop` is created? Specifically, does the existing `release/v0.5.0` branch (if present on the remote) need to be deleted or retained as evidence, and does any history-split step need to happen to seed `develop` from the current `main` HEAD?
+- Q5 — What is the Pages deployment source for the initial `demo` cut — `main` HEAD or a separately assembled `demo` state — and does the `demo` branch need its own branch-protection rule in GitHub settings (outside `.claude/settings.json`) to prevent accidental direct push?
+
+## Out of scope (preliminary)
+
+- Topic prefix rename `feat/` to `feature/` — cosmetic, high blast radius, explicitly deferred.
+- Squash-merge as the default merge strategy — excluded per the merge-not-rebase rule.
+- Tag-scheme change `vX.Y.Z` to `X.Y.Z` — deferred until #233 v0.5 immutable-release recovery closes.
+- Stages 5-11 of the lifecycle (implementation, testing, review, release, retro) — gated on parent issue triage.
+- Changes to downstream adopter repos — this feature only modifies the template repo itself.
+- GitHub branch-protection UI settings (rulesets, required reviews count) — noted as a feasibility consideration for the architect; not a design or requirements deliverable from this track.
+
+## References
+
+- `docs/branching.md` — current branching doc; defines Shape A and Shape B side by side; records ADR-0020 as the lock.
+- `docs/adr/0020-v05-release-branch-strategy.md` — ADR being superseded; Shape A + `release/vX.Y.Z` decision and rationale.
+- `.claude/settings.json` — push-deny and allowlist rules; `develop` direct-push already denied.
+- `.github/workflows/pages.yml` — Pages source currently triggered on push to `main`; needs flip to `demo`.
+- `.claude/memory/feedback_parallel_pr_conflicts.md` — merge-not-rebase rule being kept.
+- `agents/operational/` — operational bots whose branch regexes need auditing.
+- Specorator contributing model: `develop`/`demo`/`main` with squash-merge (squash NOT adopted here).
+
+---
+
+## Quality gate
+
+- [x] Problem statement is one paragraph and understandable to a non-expert.
+- [x] Target users named.
+- [x] Desired outcome stated.
+- [x] Constraints listed.
+- [x] Open questions captured.
+- [x] Scope is bounded — no "boil the ocean" framing.

--- a/specs/shape-b-branching-adoption/requirements.md
+++ b/specs/shape-b-branching-adoption/requirements.md
@@ -1,0 +1,331 @@
+---
+id: PRD-BRANCH-001
+title: Adopt Shape B branching model in agentic-workflow template
+stage: requirements
+feature: shape-b-branching-adoption
+status: accepted
+owner: pm
+inputs:
+  - IDEA-BRANCH-001
+  - RESEARCH-BRANCH-001
+created: 2026-05-03
+updated: 2026-05-03
+---
+
+# PRD — Adopt Shape B branching model in agentic-workflow template
+
+## Summary
+
+The agentic-workflow template currently operates under Shape A (single `main` integration and release branch, ADR-0020). The v0.5 release cycle exposed a concrete integration-window problem: release-prep commits land on `main` before a tag is cut, causing CI to be green against partially-released content and the GitHub Pages site to reflect in-progress work rather than a validated state. This PRD specifies the changes needed to transition the template's own operations to Shape B — `develop` as the integration branch, `main` as the release-only branch, `demo` as the GitHub Pages source — eliminating the integration window, giving downstream adopters a live reference implementation, and keeping all tooling layers (settings, bots, Pages workflow, ADR registry, documentation) internally consistent.
+
+## Goals
+
+- G1. Establish `develop` as the integration branch so that topic PRs never land directly on `main` outside of a promotion.
+- G2. Restrict `main` to promoted, tagged commits only, eliminating the release-prep integration window.
+- G3. Serve GitHub Pages from the `demo` branch so the public preview always reflects a validated state.
+- G4. Prevent direct push to `demo` at the Claude Code agent layer, consistent with how `main` and `develop` are protected.
+- G5. Keep all affected tooling layers (`docs/branching.md`, `.claude/settings.json`, operational bot PROMPT.md files, bot scheduler configurations, `pages.yml`) consistent with Shape B after the change.
+- G6. Supersede ADR-0020 with a new ADR that records the Shape B decision, rationale, and compliance rules.
+- G7. Drop the `release/vX.Y.Z` branch convention; the develop-to-main promotion PR becomes the release path.
+
+## Non-goals
+
+- NG1. Topic prefix rename (`feat/` to `feature/`) — explicitly deferred, high blast radius.
+- NG2. Squash-merge as the default merge strategy — excluded per the merge-not-rebase rule.
+- NG3. Tag-scheme change (`vX.Y.Z` to `X.Y.Z`) — deferred until issue #233 (v0.5 immutable-release recovery) closes.
+- NG4. Stages 5–11 of the lifecycle (implementation, testing, review, release, retro) — gated on parent issue triage.
+- NG5. Changes to downstream adopter repositories — this feature modifies only the template repo itself.
+- NG6. GitHub branch-protection UI configuration details (rulesets vs. legacy rules, required-review counts) — feasibility determination belongs to the design stage.
+- NG7. Creation of the `develop` branch on the remote — an implementation-stage action, not a design or requirements deliverable.
+
+## Personas / stakeholders
+
+| Persona | Need | Why it matters |
+|---|---|---|
+| Template maintainer (Luis) | Merge topic PRs to an integration branch without polluting `main` with in-progress commits | Eliminates the release-prep window that caused v0.5.1 readiness check failures |
+| Template contributor | Know which branch to target when opening a PR | Prevents PRs from landing on the wrong base branch by accident |
+| Downstream adopter (evaluator) | See a live Shape B reference implementation in the template repo | Currently no live Shape B repo in the Specorator ecosystem to inspect |
+| Operational bots (`review-bot`, `docs-review-bot`, `plan-recon-bot`, `dep-triage-bot`, `actions-bump-bot`) | Execute against the correct integration branch with accurate PROMPT.md text | Incorrect branch targets or stale references produce false findings or missed coverage |
+| GitHub Pages visitor | See a stable, validated public preview rather than in-progress work | The current Pages source (`main`) reflects integration-phase content |
+
+## Jobs to be done
+
+- When I open a topic PR, I want it to target `develop` by default, so I can merge work into the integration branch without touching `main`.
+- When I cut a release, I want to promote `develop` to `main` and tag from `main` HEAD, so I can ensure `main` carries only validated, tagged commits.
+- When I visit the public GitHub Pages site, I want it to reflect the latest promoted state, so I can evaluate the template from a stable reference rather than in-progress content.
+- When I clone the template to evaluate Shape B, I want to see the template itself operating Shape B end-to-end, so I can understand the model by inspecting a live example rather than documentation alone.
+- When an operational bot runs, I want its PROMPT.md and scheduler config to reference `develop` as the integration branch, so I do not receive false drift findings or missed coverage caused by a stale `main` reference.
+
+## Functional requirements (EARS)
+
+### REQ-BRANCH-001 — Topic PRs target `develop`
+
+- **Pattern:** Ubiquitous
+- **Statement:** The `docs/branching.md` documentation shall state that all topic-branch PRs target `develop` under Shape B, and shall not reference `main` as a valid PR target for topic branches.
+- **Acceptance:**
+  - Given `docs/branching.md` has been updated for Shape B
+  - When a contributor reads the Shape B section
+  - Then the document names `develop` as the PR target for topic branches
+  - And the document does not name `main` as a PR target for topic branches
+- **Priority:** must
+- **Satisfies:** IDEA-BRANCH-001 (desired outcome 1), RESEARCH-BRANCH-001 (Alternative A)
+
+---
+
+### REQ-BRANCH-002 — `develop` push-deny remains in `.claude/settings.json`
+
+- **Pattern:** Ubiquitous
+- **Statement:** The `.claude/settings.json` deny list shall include entries that block Claude Code agents from pushing directly to `develop` (both `git push origin develop:*` and `git push -u origin develop:*`).
+- **Acceptance:**
+  - Given the updated `.claude/settings.json`
+  - When Claude Code attempts `git push origin develop` or `git push -u origin develop`
+  - Then the push is denied by the permission layer
+- **Priority:** must
+- **Satisfies:** IDEA-BRANCH-001 (constraint: push-deny stays on both main and develop), RESEARCH-BRANCH-001 (Q2 conclusion)
+
+---
+
+### REQ-BRANCH-003 — `demo` push-deny added to `.claude/settings.json`
+
+- **Pattern:** Ubiquitous
+- **Statement:** The `.claude/settings.json` deny list shall include entries that block Claude Code agents from pushing directly to `demo` (both `git push origin demo:*` and `git push -u origin demo:*`).
+- **Acceptance:**
+  - Given the updated `.claude/settings.json`
+  - When Claude Code attempts `git push origin demo` or `git push -u origin demo`
+  - Then the push is denied by the permission layer
+- **Priority:** must
+- **Satisfies:** IDEA-BRANCH-001 (desired outcome 2), RESEARCH-BRANCH-001 (Q2 conclusion, CLAR-001 resolved)
+
+---
+
+### REQ-BRANCH-004 — `pages.yml` triggers on `demo` not `main`
+
+- **Pattern:** Ubiquitous
+- **Statement:** The `.github/workflows/pages.yml` workflow shall declare `demo` as its trigger branch and shall not declare `main` as a trigger branch for the GitHub Pages deployment job.
+- **Acceptance:**
+  - Given the updated `pages.yml`
+  - When a reviewer inspects the `on: push: branches:` block
+  - Then `demo` appears in the list
+  - And `main` does not appear in the list as a Pages deployment trigger
+- **Priority:** must
+- **Satisfies:** IDEA-BRANCH-001 (desired outcome 2), RESEARCH-BRANCH-001 (Q5 conclusion)
+
+---
+
+### REQ-BRANCH-005 — `release/vX.Y.Z` pattern dropped from `docs/branching.md`
+
+- **Pattern:** Ubiquitous
+- **Statement:** The `docs/branching.md` document shall not describe `release/vX.Y.Z` branches as a required step in the release workflow, and shall describe the develop-to-main promotion PR as the release path.
+- **Acceptance:**
+  - Given `docs/branching.md` has been updated for Shape B
+  - When a contributor reads the release-path section
+  - Then the document describes the develop-to-main promotion PR as the release path
+  - And the document does not prescribe cutting a `release/vX.Y.Z` branch as a required release step under Shape B
+- **Priority:** must
+- **Satisfies:** IDEA-BRANCH-001 (desired outcome 3), RESEARCH-BRANCH-001 (Q3 recommendation)
+
+---
+
+### REQ-BRANCH-006 — `develop` seeded from `main` HEAD non-destructively
+
+- **Pattern:** Ubiquitous
+- **Statement:** The implementation plan shall specify seeding `develop` from `main` HEAD without history rewrite, squash, or rebase, so that the seed operation is reversible.
+- **Acceptance:**
+  - Given the implementation tasks artifact
+  - When a reviewer inspects the `develop` creation step
+  - Then the step is described as `git branch develop main` (or equivalent) creating a branch pointer at `main` HEAD
+  - And no history-rewrite, squash, or rebase operation is specified as part of the seed
+- **Priority:** must
+- **Satisfies:** IDEA-BRANCH-001 (constraint: non-destructive), RESEARCH-BRANCH-001 (Q4 conclusion)
+
+---
+
+### REQ-BRANCH-007 — `docs/branching.md` designates Shape B as the active model
+
+- **Pattern:** Ubiquitous
+- **Statement:** The `docs/branching.md` document shall designate Shape B as the active branching model for this repository and shall update or remove any text that describes Shape A as the current default for template-own operations.
+- **Acceptance:**
+  - Given `docs/branching.md` has been updated
+  - When a contributor reads the document
+  - Then Shape B (`develop`, `main`, `demo`) is described as the current model for this template repo
+  - And the document does not describe Shape A as the current default for template-own operations
+  - And the Shape A description is retained as a documented option for adopters, clearly marked as not the active template model
+- **Priority:** must
+- **Satisfies:** IDEA-BRANCH-001 (desired outcome 6), RESEARCH-BRANCH-001 (Alternative A)
+
+---
+
+### REQ-BRANCH-008 — `docs-review-bot` PROMPT.md updated to reference `develop`
+
+- **Pattern:** Ubiquitous
+- **Statement:** The `agents/operational/docs-review-bot/PROMPT.md` file shall reference `develop` (or "the integration branch") in the tutorial-drift rule that currently reads "a clean clone of `main`", and shall not contain the literal string "clean clone of `main`".
+- **Acceptance:**
+  - Given the updated `docs-review-bot/PROMPT.md`
+  - When a reviewer searches for the string "clean clone of `main`"
+  - Then zero occurrences are found
+  - And the tutorial-drift rule references `develop` or "the integration branch" in its place
+- **Priority:** must
+- **Satisfies:** RESEARCH-BRANCH-001 (Q1 bot audit — docs-review-bot, 1 line change required)
+
+---
+
+### REQ-BRANCH-009 — Operational bot scheduler configurations updated to pass `develop`
+
+- **Pattern:** Ubiquitous
+- **Statement:** The implementation tasks for `review-bot`, `plan-recon-bot`, `dep-triage-bot`, and `actions-bump-bot` shall each specify updating the bot's scheduler or runner configuration to pass `develop` as the integration-branch argument, so that those bots do not operate against `main` as the integration branch.
+- **Acceptance:**
+  - Given the implementation tasks artifact for each of the four named bots
+  - When a reviewer inspects the tasks
+  - Then each task names the specific scheduler or runner configuration file to update
+  - And each task specifies `develop` as the value to set for the integration-branch argument
+- **Priority:** must
+- **Satisfies:** RESEARCH-BRANCH-001 (Q1 bot audit summary — scheduler changes for 4 of 5 bots)
+
+---
+
+### REQ-BRANCH-010 — New ADR supersedes ADR-0020
+
+- **Pattern:** Ubiquitous
+- **Statement:** The repository shall contain a new ADR that records the Shape B adoption decision, the rationale for dropping `release/vX.Y.Z`, and the compliance rules, and that ADR shall supersede ADR-0020.
+- **Acceptance:**
+  - Given the new ADR has been written and merged
+  - When a reviewer reads the new ADR's frontmatter
+  - Then it lists ADR-0020 in its `supersedes` field
+  - And when a reviewer reads ADR-0020's frontmatter
+  - Then its `status` field reads `Superseded` and its `superseded-by` field names the new ADR number
+- **Priority:** must
+- **Satisfies:** IDEA-BRANCH-001 (desired outcome 5, constraint: ADR bodies immutable), RESEARCH-BRANCH-001 (Q3 recommendation)
+
+---
+
+### REQ-BRANCH-011 — `release/*` push-allow removed from `.claude/settings.json`
+
+- **Pattern:** Ubiquitous
+- **Statement:** The `.claude/settings.json` allow list shall not include push-allow entries for the `release/*` branch prefix, because `release/vX.Y.Z` branches are no longer used under Shape B.
+- **Acceptance:**
+  - Given the updated `.claude/settings.json`
+  - When a reviewer inspects the `allow` array
+  - Then no entry of the form `"Bash(git push origin release/*)"` or `"Bash(git push -u origin release/*)"` is present
+- **Priority:** should
+- **Satisfies:** IDEA-BRANCH-001 (desired outcome 3), RESEARCH-BRANCH-001 (technical consideration 4)
+
+---
+
+### REQ-BRANCH-012 — `docs/worktrees.md` names `develop` as the branch to cut from
+
+- **Pattern:** Ubiquitous
+- **Statement:** The `docs/worktrees.md` document shall name `develop` as the branch from which topic branches are cut, and shall not name `main` as the cut-from branch for new topic work.
+- **Acceptance:**
+  - Given `docs/worktrees.md` has been updated
+  - When a contributor reads the worktree setup instructions
+  - Then `develop` is named as the base branch for cutting new topic branches
+  - And `main` is not named as the base branch for new topic work
+- **Priority:** should
+- **Satisfies:** RESEARCH-BRANCH-001 (technical consideration 5), IDEA-BRANCH-001 (desired outcome 6)
+
+---
+
+### REQ-BRANCH-013 — `release/v0.5.0` branch removed from the remote if it exists
+
+- **Pattern:** IF `release/v0.5.0` exists on the remote repository, THEN the implementation plan shall include a step to delete it.
+- **Pattern label:** Unwanted behaviour
+- **Statement:** IF the branch `release/v0.5.0` is found on the remote repository at implementation time, THEN the implementation tasks shall include a step to delete that branch from the remote.
+- **Acceptance:**
+  - Given the implementation tasks artifact
+  - When a reviewer inspects the pre-condition check step
+  - Then it specifies verifying `release/v0.5.0` existence with `git ls-remote --heads origin release/v0.5.0`
+  - And if found, a deletion step is listed before `develop` and `demo` are created
+- **Priority:** should
+- **Satisfies:** RESEARCH-BRANCH-001 (Q4 — release/v0.5.0 most likely absent; check required), RESEARCH-BRANCH-001 (RISK-008)
+
+---
+
+### REQ-BRANCH-014 — `demo` seeded from `main` HEAD at Shape B adoption time
+
+- **Pattern:** Ubiquitous
+- **Statement:** The implementation plan shall specify seeding `demo` from `main` HEAD at the time of Shape B adoption, so that the GitHub Pages site is not disrupted during the transition.
+- **Acceptance:**
+  - Given the implementation tasks artifact
+  - When a reviewer inspects the `demo` branch creation step
+  - Then it specifies creating `demo` from `main` HEAD (same commit, no content change)
+  - And the step is sequenced after `develop` is created and before `pages.yml` is updated
+- **Priority:** must
+- **Satisfies:** IDEA-BRANCH-001 (desired outcome 2), RESEARCH-BRANCH-001 (Q5 conclusion)
+
+---
+
+### REQ-BRANCH-015 — `AGENTS.md` and `CLAUDE.md` updated to name `develop` as the integration branch
+
+- **Pattern:** Ubiquitous
+- **Statement:** The `AGENTS.md` and `CLAUDE.md` root files shall name `develop` as the integration branch wherever they describe the PR workflow or branching model, and shall not name `main` as the target for topic-branch PRs.
+- **Acceptance:**
+  - Given both files have been updated
+  - When a reviewer searches for "topic" or "PR target" references in both files
+  - Then `develop` is named as the target
+  - And `main` is not described as the PR target for new topic work
+- **Priority:** should
+- **Satisfies:** IDEA-BRANCH-001 (desired outcome 6), RESEARCH-BRANCH-001 (RISK-001)
+
+## Non-functional requirements
+
+| ID | Category | Requirement | Target |
+|---|---|---|---|
+| NFR-BRANCH-001 | reversibility | The `develop` branch creation step shall be non-destructive to existing history | Zero commits rewritten; `develop` is a new pointer at existing `main` HEAD |
+| NFR-BRANCH-002 | reversibility | The `demo` branch creation step shall be non-destructive to existing history | Zero commits rewritten; `demo` is a new pointer at existing `main` HEAD |
+| NFR-BRANCH-003 | consistency | All affected files modified in this feature (`docs/branching.md`, `.claude/settings.json`, `AGENTS.md`, `CLAUDE.md`, `docs/worktrees.md`, `docs-review-bot/PROMPT.md`, `pages.yml`, ADR) shall be internally consistent with Shape B on merge | No file describes `main` as the integration branch or PR target for topic work after the change lands |
+| NFR-BRANCH-004 | traceability | The new ADR shall carry a `supersedes: [ADR-0020]` field and ADR-0020 shall carry `status: Superseded` and `superseded-by: [ADR-NNNN]` in its frontmatter | Verified by reading both ADR frontmatter blocks post-merge |
+| NFR-BRANCH-005 | safety | The `.claude/settings.json` deny list shall not become shorter (in terms of protected branch surface) as a result of this change | Post-change deny count for `main`, `develop`, and `demo` push patterns is equal to or greater than the pre-change count for `main` and `develop` |
+| NFR-BRANCH-006 | continuity | GitHub Pages availability shall not be interrupted during the transition from `main`-triggered to `demo`-triggered deployments | The `demo` branch exists and the GitHub Pages environment is updated to allow `demo` before `pages.yml` triggers on `demo` |
+
+## Success metrics
+
+- **North star:** Zero PRs targeting `main` as a topic-branch base in the 30 days following Shape B adoption.
+- **Supporting — bot accuracy:** Zero false drift findings from `docs-review-bot` attributable to the stale "clean clone of `main`" reference in the 30 days following the PROMPT.md fix.
+- **Supporting — Pages stability:** GitHub Pages site remains continuously available (no 404 period) through the `main` → `demo` trigger swap.
+- **Supporting — ADR coverage:** ADR-0020 `status` field reads `Superseded` within the same PR that merges the new ADR; no gap period where the old ADR appears active.
+- **Counter-metric:** Number of `develop → main` promotions that are skipped (i.e., direct commits land on `main` bypassing the promotion path). Target: zero. A non-zero count indicates the Shape B discipline is not holding.
+
+## Release criteria
+
+What must be true to ship Stages 3–4 artifacts (requirements + design + ADR + GitHub issue):
+
+- [ ] All `must` requirements (`REQ-BRANCH-001` through `REQ-BRANCH-010`, `REQ-BRANCH-014`) pass acceptance review.
+- [ ] All `should` requirements (`REQ-BRANCH-011`, `REQ-BRANCH-012`, `REQ-BRANCH-013`, `REQ-BRANCH-015`) are either accepted or explicitly deferred with a rationale recorded in the ADR or design document.
+- [ ] All NFRs are met or explicitly waived with rationale recorded.
+- [ ] New ADR written, reviewed, and assigned the next available ADR number.
+- [ ] ADR-0020 frontmatter update (`status: Superseded`, `superseded-by`) is included in the same PR as the new ADR.
+- [ ] `docs/branching.md` update is included in the same PR as or a coordinated PR with the ADR, so no window exists where the ADR is accepted but the docs still describe Shape A as active.
+- [ ] GitHub issue created that captures the implementation tasks for Stages 5–11 (gated on issue triage and #233).
+- [ ] No open clarifications remain unresolved at the requirements level (see below).
+
+## Open questions / clarifications
+
+- CLAR-001 — RESOLVED 2026-05-03. `demo` branch: push-deny in `.claude/settings.json` + GitHub branch-protection rule; promote-only from `main`; no direct push for hotfixes. Promotion automation is TBD for architect.
+- CLAR-002 — RESOLVED 2026-05-03. `release/v0.5.0` historical branch: verify with `git ls-remote` at implementation time; delete if found. ADR-0020 supersession: single new ADR; update ADR-0020 frontmatter only (status + superseded-by); no errata required pre-supersession (immutable-body rule).
+- CLAR-003 — TBD (owner: architect). Whether `demo` promotion (after `main` tag cut) is a manual release-checklist step or an automated GitHub Actions trigger on `main` tag creation. Does not block requirements; gates design.
+- CLAR-004 — TBD (owner: architect). Confirm whether a legacy branch-protection rule or a GitHub ruleset is used for `demo` and `develop` given this repo's GitHub plan tier. Does not block requirements; gates design.
+
+## Out of scope
+
+What we explicitly will not do this cycle:
+
+- Topic prefix rename `feat/` → `feature/` — cosmetic, high blast radius, deferred.
+- Squash-merge as default merge strategy — excluded per `feedback_parallel_pr_conflicts.md` merge-not-rebase rule.
+- Tag-scheme change `vX.Y.Z` → `X.Y.Z` — deferred until #233 closes.
+- Implementation, testing, review, release, and retro (Stages 5–11) — gated on parent issue triage.
+- Changes to downstream adopter repositories.
+- GitHub branch-protection UI settings (rulesets, required-review counts, bypass lists) — architect deliverable, not PM.
+
+---
+
+## Quality gate
+
+- [x] Goals and non-goals explicit.
+- [x] Personas / stakeholders named.
+- [x] Jobs to be done captured.
+- [x] Every functional requirement uses EARS and has a stable ID.
+- [x] Acceptance criteria testable (concrete, no "handles errors" or "appropriate").
+- [x] NFRs listed with targets.
+- [x] Success metrics defined (including a counter-metric).
+- [x] Release criteria stated.
+- [x] Open clarifications resolved at the requirements level (CLAR-001, CLAR-002 resolved; CLAR-003, CLAR-004 deferred to design — no blocker).

--- a/specs/shape-b-branching-adoption/research.md
+++ b/specs/shape-b-branching-adoption/research.md
@@ -1,0 +1,355 @@
+---
+id: RESEARCH-BRANCH-001
+title: Shape B branching adoption — ecosystem and prior-art research
+stage: research
+feature: shape-b-branching-adoption
+status: complete
+owner: analyst
+inputs:
+  - IDEA-BRANCH-001
+created: 2026-05-03
+updated: 2026-05-03
+---
+
+# Research — Shape B branching adoption
+
+## Research questions
+
+| ID | Question | Status |
+|---|---|---|
+| Q1 | What exact changes are needed in each operational bot's `PROMPT.md` to support `develop` as integration branch? Which bots hard-code `main`? | answered |
+| Q2 | Concrete protection options for the `demo` branch — push-deny or allow direct push for hotfixes? What does the reference Specorator repo do? | answered |
+| Q3 | ADR-0020 supersession strategy — single new ADR or separate ADRs per decision? Does immutable-body rule require errata on ADR-0020 before supersession? | answered |
+| Q4 | What historical state needs addressing before `develop` is created? Does `release/v0.5.0` exist on remote? Does seeding `develop` from `main` HEAD require history steps? | answered |
+| Q5 | Pages deployment source for initial `demo` cut — `main` HEAD or separately assembled state? Does `demo` need its own GitHub branch-protection rule? | answered |
+
+---
+
+## Q1 — Operational bot audit
+
+Each bot's `PROMPT.md` was read in full. Findings are below.
+
+### review-bot
+
+File: `agents/operational/review-bot/PROMPT.md`
+
+The prompt refers to "the integration branch" descriptively throughout but never names a literal branch. The idempotency check reads the head SHA of the most recent `review-bot` issue; it does not assert the branch name. The command `git log --oneline <last-sha>..HEAD` is branch-agnostic.
+
+**Change needed:** None to the prompt text itself. However, the scheduled GitHub Actions workflow that runs `review-bot` likely passes a checkout ref. That workflow file must be updated to checkout `develop` instead of (or in addition to) `main`. The bot prompt itself is clean.
+
+### docs-review-bot
+
+File: `agents/operational/docs-review-bot/PROMPT.md`
+
+The prompt refers to "the integration branch" generically. The instruction "read from the working tree (`git show HEAD:<path>`)" is branch-agnostic. The idempotency check keys on head SHA in the issue title.
+
+The tutorial-drift rule in §What to flag item 8 references "a clean clone of `main`" explicitly:
+
+> "Flag the tutorial for re-run from a clean clone of `main`"
+
+**Change needed:** This one literal `main` reference must be updated to read "a clean clone of `develop`" (or "the integration branch") to remain accurate under Shape B. No other changes required.
+
+### plan-recon-bot
+
+File: `agents/operational/plan-recon-bot/PROMPT.md`
+
+Contains explicit hardcoded references to the integration branch in two places:
+
+1. §Process step 4 names the branch variable in the worktree cut command:
+
+   > `git worktree add .worktrees/plan-recon-${RUN_DATE} -b docs/plan-recon-${RUN_DATE} origin/<integration-branch>`
+
+   The placeholder `<integration-branch>` is already a variable form — not hardcoded to `main`. This is intentionally generic.
+
+2. §Decision criteria reads "the plan's last commit on the **integration branch** is ≥14 days old" — generic, not hardcoded.
+
+3. §Idempotency guard (step 1): the worktree path is dated, not branch-name-keyed. The PR search is on `docs/plan-recon-*` prefix from this routine's login — branch-agnostic.
+
+4. §Hard rules: "Never push directly to the integration branch." — generic.
+
+5. §Failure handling commands refer to `git worktree remove` and `git branch -D` operations on the worktree branch, not on `main`.
+
+**Change needed:** The process step that cuts the worktree must be confirmed to resolve `<integration-branch>` to `develop` (not `main`) at runtime. The prompt currently uses the angle-bracket placeholder, which is safe if the operator configures the env var correctly. No text edit is strictly required, but it is worth adding an explicit note: the env var or config value passed to the scheduler must be set to `develop`. The PM/architect should add this to compliance notes in the new ADR.
+
+### dep-triage-bot
+
+File: `agents/operational/dep-triage-bot/PROMPT.md`
+
+The prompt refers to the integration branch in one place:
+
+> §Process step 4: "If the PR is BEHIND the integration branch, trigger the upstream tool to rebase"
+
+No branch name is hardcoded. The idempotency marker keyed on `<head-sha7>:<action>` is PR-level. The classification matrix is package-type-based, not branch-based. The `ROUTINE_GH_LOGIN` env var is project-level.
+
+**Change needed:** None. The prompt is branch-agnostic throughout. The PR target branch assumption is implicit in what Dependabot/Renovate opens PRs against; those tools must be configured at the repository level to target `develop` rather than `main`. That is a repository settings change (in `.github/dependabot.yml` or Renovate config), not a bot prompt change.
+
+### actions-bump-bot
+
+File: `agents/operational/actions-bump-bot/PROMPT.md`
+
+Contains one explicit branch reference in §Process step 6:
+
+> "Cut the bump branch off the **integration branch** as `chore/actions-bump-YYYY-MM-DD` (UTC)."
+
+The phrase "integration branch" is generic — not hardcoded to `main`. The idempotency check keys on the presence of any open `chore/actions-bump-*` PR from the bot's login, not on a branch name.
+
+§Hard rules: "Never push directly to the integration branch." — generic.
+
+**Change needed:** None to the prompt text. Like `plan-recon-bot`, the scheduled runner must be configured with the correct integration branch value (`develop`). The `gh pr create` base-branch argument passed at runtime must target `develop`.
+
+### Summary of bot audit
+
+| Bot | Hard-codes `main`? | Change needed in PROMPT.md? | Change needed elsewhere? |
+|---|---|---|---|
+| `review-bot` | No | No | Scheduler/checkout ref: `develop` |
+| `docs-review-bot` | Yes — 1 occurrence ("clean clone of `main`") | Yes — 1 line edit | Scheduler checkout ref: `develop` |
+| `plan-recon-bot` | No (uses `<integration-branch>` placeholder) | No | Scheduler env var: set to `develop` |
+| `dep-triage-bot` | No | No | Dependabot/Renovate target-branch config |
+| `actions-bump-bot` | No (uses "integration branch" generically) | No | Scheduler base-branch arg: `develop` |
+
+Only `docs-review-bot` requires a text edit to its `PROMPT.md`. The remaining bots require changes in their scheduler configurations, CI workflow files, or external tool configs — not in the source-of-truth prompts.
+
+---
+
+## Q2 — `demo` branch protection options
+
+### What the reference Specorator repo does
+
+The reference repo `github.com/Luis85/specorator` has `develop` as its default branch and a `demo` branch exists. The `pages.yml` workflow triggers on `branches: [demo]` — confirming the Pages-from-`demo` pattern. The repo's `.claude/settings.json` does not appear to carry push-deny rules for `demo` in the version fetchable from develop; its settings file only has plugin enablement. This suggests the reference repo may rely on GitHub branch-protection UI rules (rulesets or legacy protection rules) rather than `.claude/settings.json` to gate `demo` direct push, or it permits direct push to `demo` as a privileged maintenance action.
+
+### GitHub branch-protection mechanics (2024–2025 state)
+
+Two mechanisms are available to block direct push to `demo`:
+
+**Mechanism 1 — GitHub branch protection rule (legacy or ruleset)**
+- Requires a PR and (optionally) a passing status check before any push lands on `demo`.
+- Can be bypassed by repo admins in the legacy model; rulesets allow fine-grained bypass.
+- Works at the GitHub API / push level — Claude Code's `.claude/settings.json` deny rules operate at the local CLI level only. Both layers are complementary, not redundant.
+- Pages deployment via OIDC (`id-token: write`) works regardless of branch protection on the source branch as long as the GitHub Pages environment allows deployment from that branch.
+
+**Mechanism 2 — `.claude/settings.json` push deny**
+- Adds a line: `"Bash(git push origin demo:*)"` and `"Bash(git push -u origin demo:*)"` to the deny array.
+- Blocks Claude Code agents from pushing directly to `demo`.
+- Does not block a human with git access; does not block GitHub Actions push (if the Actions workflow itself pushes to `demo`).
+
+**Promotion-only model (recommended)**
+Under Shape B as documented in `docs/branching.md`, `demo` is described as "promoted from `main` or `develop`" with direct push denied. The promotion path would be:
+- A dedicated `chore/promote-demo` topic branch (or a direct GitHub Action that fast-forwards `demo` to `main` HEAD post-merge).
+- Or: the `pages.yml` workflow itself can be changed to push to `demo` automatically after every merge to `main` — a "deploy-on-promote" model that keeps `demo` identical to the latest `main` tag.
+
+**Hotfix-direct-push model (not recommended)**
+Allowing direct push to `demo` for preview hotfixes breaks the invariant that `demo` reflects a validated state. It introduces a divergence between `demo` and `main` that is hard to track and reconcile. Given single-maintainer governance, the complexity cost exceeds the benefit.
+
+**Conclusion for Q2:** The `demo` branch should be push-denied in both `.claude/settings.json` and a GitHub branch-protection rule (or ruleset). The reference Specorator repo triggers Pages from `demo` — this pattern is confirmed. The promotion path is: merge to `main` → trigger (manual or automated) fast-forward of `demo` to `main` HEAD → Pages deploys. This is a design decision (TBD — owner: architect), but the research finding is that push-deny plus explicit promotion is the correct default.
+
+---
+
+## Q3 — ADR-0020 supersession strategy
+
+### What the immutable-body rule permits
+
+ADR-0020 ends with: "ADR bodies are immutable. To change a decision, supersede it with a new ADR; only the predecessor's `status` and `superseded-by` pointer fields may be updated."
+
+ADR-0020's own frontmatter already has `superseded-by: []`. The constitution (Article VIII) and the ADR template together confirm: the only permitted edits on an accepted ADR are updating `status` to `Superseded` and populating `superseded-by: [ADR-NNNN]`. No errata section is added as part of supersession; the existing errata section (the 2026-05-02 entry) was added to the same ADR before supersession and is already present — it does not need to be modified.
+
+There is no requirement for errata on ADR-0020 before supersession. The errata mechanism is for clarifying the *implementation* of an unchanged decision; supersession is for replacing the decision itself.
+
+### Single new ADR vs. separate ADRs
+
+Two sub-decisions are bundled in this feature:
+
+1. Adopt Shape B (`develop` as integration branch, `main` as release-only, `demo` as Pages source).
+2. Drop the `release/vX.Y.Z` branch convention in favor of the develop-to-main promotion PR.
+
+**Option: Single ADR covering both**
+- Pros: one document captures the coherent new branching model; reviewers see the full picture.
+- Cons: if the `release/vX.Y.Z` drop is later revisited independently, the ADR structure does not support partial supersession cleanly.
+
+**Option: Separate ADRs**
+- ADR-A: Adopt Shape B (supersedes ADR-0020).
+- ADR-B: Drop `release/vX.Y.Z` (references ADR-A; could supersede the `release/vX.Y.Z` subsection of ADR-0020 conceptually, though ADR-0020 is the only formal record).
+- Cons: two ADRs for closely coupled decisions creates cross-reference overhead; the decisions are not independently viable (Shape B without dropping `release/vX.Y.Z` is explicitly contradictory per the idea.md desired outcome #3).
+
+**Recommendation for Q3:** A single new ADR that supersedes ADR-0020 and covers both the Shape B adoption and the `release/vX.Y.Z` drop. The two decisions are inseparable in context. The supersession of ADR-0020 requires only updating its `status` to `Superseded` and its `superseded-by` field to the new ADR number. No errata addition to ADR-0020 is needed or permitted as part of supersession.
+
+---
+
+## Q4 — Historical state and `develop` branch seeding
+
+### Does `release/v0.5.0` exist on the remote?
+
+The public branch listing at `github.com/Luis85/agentic-workflow/branches` shows: `main`, `review/v05-stage-9`, `chore/v06-iso-9001-watch`, `feat/v06-adoption-profiles`, `feat/v06-agentic-security`, `feat/v06-hook-packs`, plus additional branches not displayed. **`release/v0.5.0` is not visible in the displayed set.** Given ADR-0020's cleanup rule ("delete the `release/vX.Y.Z` branch locally and on the remote once the tag is cut"), and the fact that the v0.5.0 release cycle has progressed past the tag-cut stage, it is most likely that `release/v0.5.0` has already been deleted. No history steps or retention decisions are required for a branch that does not exist on the remote. If it does exist in the undisplayed set, it should be deleted as part of the Shape B adoption implementation — it represents completed release prep under the old convention.
+
+### Seeding `develop` from current `main` HEAD
+
+`develop` does not exist on the remote (confirmed: absent from branch listing). Seeding it is a single operation: `git branch develop main && git push origin develop`. No history split is required — `develop` simply becomes a pointer to the same commit as `main` at the moment of creation. No rebase, no squash, no history rewrite. This is safe, reversible (a branch can be deleted), and fast.
+
+The one timing consideration: `develop` must be created before the first feature PR is retargeted to it. The `pages.yml` flip to `demo` must happen after `demo` also exists. The order of operations is: create `develop` → create `demo` (from `main` HEAD) → update `pages.yml` to trigger on `demo` → update bot scheduler configs → update `docs/branching.md` and `AGENTS.md`.
+
+---
+
+## Q5 — Pages deployment source for initial `demo` cut
+
+### Source for the initial `demo` branch
+
+The cleanest initial state for `demo` is `main` HEAD at the moment of Shape B adoption. This ensures:
+- The public Pages site is not disrupted during the transition.
+- `demo` starts from a validated, tagged state rather than in-progress `develop` content.
+- The Pages deployment workflow can be flipped in a single PR that also creates `demo`, because the content is identical.
+
+A "separately assembled `demo` state" (cherry-picking commits, hand-editing) adds complexity with no benefit given that `main` HEAD is already the stable, reviewed state.
+
+### GitHub branch-protection rule for `demo`
+
+`.claude/settings.json` deny rules are a local enforcement layer for Claude Code agents. They do not prevent:
+- A human developer with git access pushing directly to `demo`.
+- A GitHub Actions workflow that performs a `git push origin demo`.
+
+For a single-maintainer repo the risk of accidental direct push to `demo` by a human is low but nonzero. A GitHub branch-protection rule (or ruleset) requiring PRs for `demo` provides the backstop at the remote level — consistent with how `main` and `develop` are treated.
+
+The `pages.yml` workflow does not push to `demo`; it reads from `demo` and deploys to GitHub Pages via OIDC. The promotion step (updating `demo` to match `main`) would require a separate workflow or a manual operation. If promotion is implemented as a GitHub Actions workflow, that workflow must be granted bypass access to the branch protection rule for `demo` (via environment protection or a ruleset bypass list).
+
+**Conclusion for Q5:** Seed `demo` from `main` HEAD. Add `demo` to the `.claude/settings.json` deny list. A GitHub branch-protection rule on `demo` is recommended (TBD — owner: architect to determine whether a legacy rule or a ruleset is appropriate for this repo's tier). The Pages environment protection rule in GitHub Settings must also be updated to allow deployment from `demo` (currently it is likely set to `main`).
+
+---
+
+## Market / ecosystem
+
+What exists as prior art for the specific pattern being adopted:
+
+| Solution | Approach | Strengths | Weaknesses | Source |
+|---|---|---|---|---|
+| GitFlow (Nvie) | `develop` as integration, `main` as release-only, hotfix branches | Mature; well-understood by contributors; clear semantic separation | Complex for small teams; release branches are a third tier; no `demo` concept | [nvie.com](https://nvie.com/posts/a-successful-git-branching-model/) |
+| GitHub Flow | Single branch (`main`) + short-lived feature branches; deploy from PR or tag | Simpler; CI-friendly; lower maintenance | No explicit integration vs. release separation; all work lands on `main` | [Atlassian](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) |
+| reference Specorator repo (`Luis85/specorator`) | `develop` default + `demo` Pages branch; Pages workflow triggers on `demo` | Direct prior art; proves the pattern works with the same toolchain | `.claude/settings.json` does not carry demo push-deny; relies on GitHub branch-protection UI | [github.com/Luis85/specorator](https://github.com/Luis85/specorator) |
+| Trunk-Based Development | Single trunk + short-lived feature flags | Maximum CI velocity; no integration branch overhead | Requires feature flags for in-progress work; does not model a release-only branch | [Atlassian](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) |
+
+The reference Specorator repo is the most relevant prior art: same maintainer, same toolchain, confirmed `develop` + `demo` pattern in production.
+
+---
+
+## User needs
+
+Evidence is drawn from the idea.md problem statement and the ADR-0020 errata, both of which record observed friction:
+
+- The v0.5 release cycle exposed that release-prep commits landing on `main` before a tag is cut create a window where CI is green against partially-released content. *(idea.md problem statement)*
+- The release readiness check tripped twice during the v0.5.1 recovery dispatch because the strict `tag SHA == main HEAD SHA` comparison broke when unrelated PRs or direct commits landed on `main` between tag creation and publication. *(ADR-0020 errata, 2026-05-02)*
+- GitHub Pages deploys from `main`, meaning the public preview reflects in-progress work rather than a validated demo state. *(idea.md problem statement)*
+- Template adopters who evaluate Shape A vs. Shape B by inspecting the template have no live reference implementation of Shape B to inspect. *(idea.md target users)*
+
+No primary research (interviews, surveys) was conducted. The assumptions that must hold for the desired outcomes to be realized:
+
+1. Operational bots are executed via schedulers that can be reconfigured to pass `develop` as the integration-branch argument without code changes to PROMPT.md files (true for 4 of 5 bots; 1 requires a 1-line PROMPT.md edit).
+2. GitHub Pages can be triggered from `demo` with OIDC authentication without conflict from the existing `github-pages` environment protection rule — requires updating the environment protection rule in GitHub Settings to accept `demo`.
+3. Single-maintainer promotion discipline is sufficient for `develop → main → demo` without tooling enforcement beyond the deny rules and a branch-protection rule.
+
+---
+
+## Alternatives considered
+
+### Alternative A — Full Shape B adoption (recommended)
+
+Adopt `develop` as the integration branch, `main` as release-only, `demo` as the Pages source. Drop `release/vX.Y.Z` convention. Issue a single new ADR superseding ADR-0020. Update all touch-points in one coordinated set of PRs.
+
+- **Description:** `develop` is created from `main` HEAD. All topic PRs retarget `develop`. Promotion PRs (`develop → main`) are the release path; tags are cut from `main` after promotion. `demo` is created from `main` HEAD and receives a push-deny in `.claude/settings.json` plus a GitHub branch-protection rule. `pages.yml` flips to `demo`. Bots are reconfigured at the scheduler level; `docs-review-bot` gets a 1-line PROMPT.md edit.
+- **Pros:** Resolves the integration-window problem for all future releases. Gives adopters a live Shape B reference. Eliminates the `release/vX.Y.Z` overhead that proved fragile in v0.5. Aligns the template's own operations with what it recommends to adopters at versioned-release cadence.
+- **Cons:** Coordination cost across multiple files and settings layers. The initial `develop → main` promotion discipline requires trust until tooling enforces it. GitHub environment protection rule update requires manual UI action (not automatable via `.claude/settings.json`).
+
+### Alternative B — Shape A with `demo` branch only (Pages fix without integration-branch change)
+
+Keep `main` as the integration branch. Create a `demo` branch from `main` HEAD. Flip `pages.yml` to trigger on `demo`. Leave `develop` unused. No ADR-0020 supersession.
+
+- **Description:** This is a targeted fix for the Pages preview problem only. The integration-window issue (release-prep commits on `main` before tag) is not addressed. Bots require no changes. The `demo` branch is promoted after each tag cut.
+- **Pros:** Minimal blast radius. Addresses the Pages staleness problem. No bot reconfiguration.
+- **Cons:** Does not provide adopters with a Shape B reference implementation. Does not resolve the integration window that caused the v0.5.1 release readiness check failures. The template continues to operate Shape A, which is documented as appropriate only "for v0 → v1" — but the repo is now beyond v0.5. The Pages site would reflect tags rather than `develop` state, which is arguably even better, but only if promotion is disciplined.
+
+### Alternative C — Trunk-Based Development (abandon Shape A/B entirely)
+
+Drop the Shape A / Shape B distinction. Merge all work to a single `main` trunk. Deploy from `main` on every push. Use feature flags or short-lived branches for in-progress work.
+
+- **Description:** Collapse the model to a single integration+release branch. Remove `develop`, `demo`, and `release/*` concepts from `docs/branching.md`. Single branch, single deploy source.
+- **Pros:** Simplest possible model. No promotion discipline required. Maximally consistent with modern CI/CD practice for small teams.
+- **Cons:** Fundamentally incompatible with the existing desire to have `main` carry only promoted, tagged commits. Eliminates the integration-window protection that Shape B provides. Would require a new ADR and a significant rewrite of `docs/branching.md`. Operational bots keying off "the integration branch" would need to key off `main`, which is already the current state — so no bot improvement. Does not address the Pages staleness issue. Contradicts the idea.md desired outcomes.
+
+---
+
+## Technical considerations
+
+1. **`.claude/settings.json` coverage gap for `demo`:** The current deny list has no entry for `demo`. Adding `"Bash(git push origin demo:*)"` and `"Bash(git push -u origin demo:*)"` is a one-line addition that is consistent with how `main` and `develop` are denied. The allow list has no need for a `demo/*` prefix (because `demo` is not a topic branch; it is a long-lived branch).
+
+2. **Pages environment protection rule:** The `pages.yml` workflow uses OIDC (`id-token: write`). GitHub Pages environments have their own "deployment branch" allow-list in Settings → Environments → github-pages. After `pages.yml` is flipped to trigger on `demo`, the `github-pages` environment protection rule must be updated to add `demo` (and optionally remove `main`). This is a GitHub UI action; it cannot be committed to the repo. The architect must document this as a manual step in the new ADR's compliance section.
+
+3. **Dependabot / Renovate target-branch config:** If the repo uses Dependabot, the `.github/dependabot.yml` file specifies `target-branch`. After the flip to `develop`, this field must be updated. Without it, Dependabot will continue opening PRs against `main`, which will then fail the Shape B convention that `main` receives only promotion PRs.
+
+4. **No `release/*` push-allow removal needed immediately:** `.claude/settings.json` currently allows `git push origin release/*`. After Shape B adoption, `release/*` branches are no longer used. The allow entry is harmless to leave in place (allowing push to a branch prefix that is no longer used does not weaken security). However, it should be removed in a follow-up cleanup PR to avoid confusion. This is low priority.
+
+5. **Worktree base-branch convention:** `docs/worktrees.md` and the worktree skill documentation instruct users to "cut every topic branch fresh from the integration branch." After the flip to `develop`, this instruction is automatically correct if the documentation is updated to name `develop` explicitly. The worktree tooling itself is branch-agnostic.
+
+6. **Bot scheduler configuration is not in-repo:** None of the five bots have their scheduler configuration in the tracked `agents/operational/` directory — only `PROMPT.md` and `README.md` are there. The scheduler configuration (GitHub Actions workflow YAML, cron config) that actually runs the bots must be updated separately. This is a feasibility constraint for the implementation stage.
+
+---
+
+## Risks
+
+| ID | Risk | Severity | Likelihood | Mitigation |
+|---|---|---|---|---|
+| RISK-001 | PRs targeting `main` after `develop` is created (contributor habit mismatch) | med | high | Update `docs/branching.md` and CONTRIBUTING immediately; add a PR-title CI check that validates base branch; docs-review-bot will surface stale references |
+| RISK-002 | `pages.yml` flip to `demo` breaks Pages deployment if the GitHub Pages environment protection rule is not updated at the same time | high | med | Include environment protection rule update as a required step in the implementation plan; gate the `pages.yml` PR on confirmation that the UI step is done |
+| RISK-003 | `docs-review-bot` tutorial-drift rule continues to reference `main` instead of `develop`, producing false drift findings | low | high | 1-line PROMPT.md edit (identified in Q1); include in the same PR as other bot updates |
+| RISK-004 | Dependabot opens PRs targeting `main` after the flip, polluting `main` with dependency update PRs | med | med | Update `.github/dependabot.yml` `target-branch` to `develop` in the same implementation batch |
+| RISK-005 | Single-maintainer promotion discipline breaks down: `develop → main` promotion is skipped, `main` goes stale | low | low | The push-deny on `main` prevents accidental direct commits; stale `main` is recoverable via a promotion PR; risk is low for single-maintainer repo |
+| RISK-006 | `demo` branch diverges from `main` if promotion to `demo` is forgotten after a `main` tag | low | med | Document promotion to `demo` as a required step in the release checklist; consider a GitHub Actions trigger on `main` tag creation that automatically fast-forwards `demo` |
+| RISK-007 | ADR-0020 `superseded-by` field left as `[]` after the new ADR is merged (bookkeeping gap) | low | med | New ADR PR must include an update to ADR-0020 frontmatter (`status: Superseded`, `superseded-by: [ADR-NNNN]`) — include as an explicit checklist item in the PR template |
+| RISK-008 | `release/v0.5.0` branch exists on remote but is undisplayed on the branches page; deletion is skipped | low | low | Implementation step: verify with `git ls-remote --heads origin release/v0.5.0` before proceeding; delete if found |
+
+---
+
+## Recommendation
+
+**Adopt Alternative A — Full Shape B adoption.**
+
+The evidence is unambiguous:
+- The reference Specorator repo (`Luis85/specorator`) already operates the `develop` + `demo` pattern successfully with Pages triggering on `demo`.
+- The v0.5.1 release readiness failures (ADR-0020 errata) demonstrate concrete harm from the integration-window in Shape A.
+- The bot audit shows the PROMPT.md blast radius is minimal: one line in `docs-review-bot`, no changes in the other four bots.
+- The `develop` branch does not exist on the remote, making the seeding step clean and non-destructive.
+- `release/v0.5.0` most likely does not exist on the remote; if it does, deletion is trivial.
+
+The supersession of ADR-0020 should be accomplished by a **single new ADR** that covers both Shape B adoption and the `release/vX.Y.Z` drop, because the two decisions are inseparable. No errata are needed on ADR-0020 as a precondition — only the `status` and `superseded-by` fields are updated when the new ADR is accepted.
+
+What still needs validating before Requirements:
+
+- **CLAR-001 resolved:** `demo` branch protection = push-deny (`.claude/settings.json` + GitHub branch-protection rule). Promote-only from `main`. Direct push for preview hotfixes is rejected.
+- **TBD — owner: architect:** Whether the `demo` promotion step is a manual release-checklist item or a GitHub Actions trigger on `main` tag creation.
+- **TBD — owner: architect:** Confirm whether to use a legacy branch-protection rule or a GitHub ruleset for `demo` and `develop` at the repository tier this repo is on (free vs. team plan affects ruleset availability).
+- **TBD — owner: pm:** Confirm the PR for bot scheduler configs is in scope for Stages 7–11 (currently deferred), or whether a separate ops task covers it.
+
+---
+
+## Sources
+
+- [Gitflow Workflow — Atlassian](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow)
+- [A successful Git branching model — nvie.com](https://nvie.com/posts/a-successful-git-branching-model/)
+- [ADR process — AWS Prescriptive Guidance](https://docs.aws.amazon.com/prescriptive-guidance/latest/architectural-decision-records/adr-process.html)
+- [About protected branches — GitHub Docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)
+- [Available rules for rulesets — GitHub Docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets)
+- [Branch is not allowed to deploy to github-pages due to environment protection rules — GitHub Community](https://github.com/orgs/community/discussions/39054)
+- [Luis85/specorator — reference Specorator repo](https://github.com/Luis85/specorator)
+- ADR-0020 (local) — `docs/adr/0020-v05-release-branch-strategy.md`
+- idea.md (local) — `specs/shape-b-branching-adoption/idea.md`
+- `docs/branching.md` (local)
+- `.claude/settings.json` (local)
+- `.github/workflows/pages.yml` (local)
+- `agents/operational/*/PROMPT.md` (local, all five bots)
+
+---
+
+## Quality gate
+
+- [x] Each research question is answered or marked open.
+- [x] Sources cited.
+- [x] >= 2 alternatives explored (three alternatives: A, B, C).
+- [x] User needs supported by evidence (from idea.md problem statement and ADR-0020 errata; assumptions stated explicitly).
+- [x] Technical considerations noted.
+- [x] Risks listed with severity.
+- [x] Recommendation made.

--- a/specs/shape-b-branching-adoption/workflow-state.md
+++ b/specs/shape-b-branching-adoption/workflow-state.md
@@ -1,0 +1,156 @@
+---
+feature: shape-b-branching-adoption
+area: BRANCH
+current_stage: specification
+status: active
+last_updated: 2026-05-03
+last_agent: architect
+artifacts:
+  idea.md: complete
+  research.md: complete
+  requirements.md: complete
+  design.md: complete
+  spec.md: pending
+  tasks.md: pending
+  implementation-log.md: pending
+  test-plan.md: pending
+  test-report.md: pending
+  review.md: pending
+  traceability.md: pending
+  release-notes.md: pending
+  retrospective.md: pending
+---
+
+# Workflow state — shape-b-branching-adoption
+
+## Stage progress
+
+| Stage | Artifact | Status |
+|---|---|---|
+| 1. Idea | `idea.md` | complete |
+| 2. Research | `research.md` | complete |
+| 3. Requirements | `requirements.md` | complete |
+| 4. Design | `design.md` | complete |
+| 5. Specification | `spec.md` | pending |
+| 6. Tasks | `tasks.md` | pending |
+| 7. Implementation | `implementation-log.md` + code | pending |
+| 8. Testing | `test-plan.md`, `test-report.md` | pending |
+| 9. Review | `review.md`, `traceability.md` | pending |
+| 10. Release | `release-notes.md` | pending |
+| 11. Learning | `retrospective.md` | pending |
+
+> **Statuses:** `pending` | `in-progress` | `complete` | `skipped` | `blocked`. Section semantics + status enums: see [`_shared/state-file-sections.md`](./_shared/state-file-sections.md).
+
+## Notes on meta-features
+
+Plan-level meta-features may skip Stage 7-9 canonical artifacts when each sub-task ships as its own PR with implementation evidence, tests, review, and trace links. Record the rationale under `## Skips` and point to the per-PR evidence. See [`_shared/state-file-sections.md`](./_shared/state-file-sections.md) for the full rule.
+
+## Skips
+
+- Stages 5-11 deferred this round — scope ends at Stage 4 (Design) + ADR + GitHub issue per agreed plan. Tag-scheme cleanup (#233) gates downstream stages.
+
+## Blocks
+
+- Implementation gated on parent issue triage and v0.5 immutable-release recovery (#233).
+
+## Hand-off notes
+
+```
+2026-05-03 (orchestrator): Scaffolded after grill-resolved scope.
+                           Decisions: Shape B in; release/* drop;
+                           feat/ keep; squash out; tag-scheme deferred.
+                           Next: /spec:idea capturing decisions as brief.
+2026-05-03 (analyst): idea.md complete and quality gate passed (all 6 boxes checked).
+                      Five open questions surface the research agenda:
+                      bot audit (Q1), demo protection rules (Q2/CLAR-001),
+                      ADR-0020 supersession strategy (Q3), develop branch
+                      seeding and historical cleanup (Q4), Pages/demo initial
+                      cut source (Q5).
+                      Next: /spec:research.
+2026-05-03 (analyst): research.md complete. All 5 questions answered.
+                      Key findings: only docs-review-bot requires a 1-line
+                      PROMPT.md edit (literal "main" in tutorial-drift rule);
+                      other 4 bots are branch-agnostic in PROMPT.md. Reference
+                      Specorator repo confirms develop+demo pattern with Pages
+                      on demo branch. Single new ADR recommended to supersede
+                      ADR-0020 (no errata required pre-supersession). release/v0.5.0
+                      not visible on remote; develop does not exist on remote —
+                      clean seed from main HEAD. demo seeded from main HEAD;
+                      push-deny in settings.json + GitHub branch-protection rule
+                      recommended. CLAR-001 resolved: promote-only for demo.
+                      TBDs for architect: demo promotion automation and ruleset vs.
+                      legacy protection rule choice.
+                      Next: /spec:requirements.
+2026-05-03 (pm): requirements.md complete. 15 EARS requirements written
+                 (REQ-BRANCH-001 through REQ-BRANCH-015): 11 must, 4 should.
+                 Covers: develop as PR target, push-deny for develop and demo,
+                 pages.yml flip to demo, release/* drop from allow list,
+                 develop+demo seeding, branching.md Shape B designation,
+                 docs-review-bot PROMPT.md 1-line fix, bot scheduler updates,
+                 new ADR superseding ADR-0020, release/v0.5.0 cleanup,
+                 AGENTS.md/CLAUDE.md/worktrees.md updates.
+                 CLAR-002 resolved at requirements stage (ADR-0020 supersession
+                 strategy confirmed: single new ADR, frontmatter update only).
+                 CLAR-003 (demo promotion automation) and CLAR-004 (ruleset vs.
+                 legacy protection rule) are open — no blocker for design;
+                 owner: architect.
+                 Next: /spec:design.
+2026-05-03 (architect): design.md complete (Part C only — Parts A and B are
+                 N/A, no user-facing UI surface). All 15 REQ-BRANCH-NNN and
+                 6 NFR-BRANCH-NNN mapped in the requirements coverage table.
+                 CLAR-003 RESOLVED: manual chore/promote-demo PR per release;
+                 no auto-trigger this iteration (revisit if cadence rises or
+                 maintainer pool grows). CLAR-004 RESOLVED: GitHub rulesets
+                 (not legacy branch-protection rules) targeting main, develop,
+                 demo with maintainer in bypass list — rulesets are available
+                 on free-tier personal accounts for public repos and provide
+                 a single allow-list spanning all three branches.
+                 ADR-0027 written (next free number) supersedes ADR-0020.
+                 ADR-0020 frontmatter updated: status=Superseded,
+                 superseded-by=[ADR-0027]; body untouched per immutable-body
+                 rule. ADR README index updated.
+                 Rollout sequence: 10 ordered steps spanning 5 PRs + 2 manual
+                 GitHub UI actions; non-destructive; pre-condition checks for
+                 release/v0.5.0, develop, demo absence. Pages continuity
+                 (NFR-BRANCH-006) preserved by sequencing the github-pages
+                 environment allow-list update before the pages.yml trigger
+                 flip.
+                 Three open clarifications surfaced for spec stage
+                 (OPEN-BRANCH-001 through 003) — none block specification.
+                 Hand-off to: planner (Tasks) — but per workflow-state.md
+                 Skips section, scope ends at Stage 4 + ADR + GitHub issue
+                 (Stages 5-11 gated on parent issue triage and #233). Spec
+                 stage may proceed if user opts in.
+                 Next: /spec:specify (or stop here per agreed scope).
+```
+
+## Open clarifications
+
+- [x] CLAR-001 — confirm `demo` branch protection rules pre-design (push-deny? promote-only from main or develop?)
+                  RESOLVED 2026-05-03: push-deny in .claude/settings.json + GitHub branch-protection rule;
+                  promote-only from main; no direct push for hotfixes. Promotion automation is TBD for architect.
+- [x] CLAR-002 — fate of `release/v0.5.0` historical branch + ADR-0020 supersede strategy (mark superseded, or supersede + amend in place?)
+                  RESOLVED 2026-05-03: verify release/v0.5.0 with git ls-remote at implementation time; delete
+                  if found. ADR-0020 supersession: single new ADR; update ADR-0020 frontmatter only (status +
+                  superseded-by); no errata required pre-supersession per immutable-body rule.
+- [x] CLAR-003 — whether demo promotion (after main tag cut) is a manual release-checklist step or an automated
+                  GitHub Actions trigger on main tag creation. Owner: architect.
+                  RESOLVED 2026-05-03 (architect): manual chore/promote-demo PR per release; no CI auto-trigger
+                  this iteration. Rationale: single-maintainer cadence does not justify the credential
+                  surface a write-to-protected-branch workflow would require. Recorded in ADR-0027 §Compliance
+                  with explicit revisit triggers (cadence > 1/month for 2 months OR maintainer pool grows).
+- [x] CLAR-004 — confirm whether a legacy branch-protection rule or GitHub ruleset is used for demo and develop
+                  given this repo's GitHub plan tier. Owner: architect.
+                  RESOLVED 2026-05-03 (architect): GitHub rulesets (not legacy branch-protection rules).
+                  Rationale: rulesets available on free-tier personal accounts for public repos; legacy rules
+                  being phased out by GitHub; rulesets give one allow-list spanning main+develop+demo with a
+                  single bypass list (the maintainer) for the manual demo promotion. Recorded in ADR-0027
+                  §Compliance.
+- [ ] OPEN-BRANCH-001 — exact path/syntax for the four scheduler-only bot configs (review-bot, plan-recon-bot,
+                  dep-triage-bot, actions-bump-bot). Likely .github/workflows/<bot>.yml; some may live outside
+                  the repo. Owner: spec author. Does not block specification start.
+- [ ] OPEN-BRANCH-002 — whether to remove `main` from the github-pages environment allow-list immediately at
+                  rollout step 7 or leave it for a follow-up. Architecturally optional. Owner: spec author.
+- [ ] OPEN-BRANCH-003 — whether to add a PR-base CI check that fails when a topic PR targets `main`
+                  (RISK-BRANCH-004 mitigation). Out of scope for this feature per PRD NG; flagged for future.
+                  Owner: spec author / future feature.

--- a/specs/shape-b-branching-adoption/workflow-state.md
+++ b/specs/shape-b-branching-adoption/workflow-state.md
@@ -39,11 +39,11 @@ artifacts:
 | 10. Release | `release-notes.md` | pending |
 | 11. Learning | `retrospective.md` | pending |
 
-> **Statuses:** `pending` | `in-progress` | `complete` | `skipped` | `blocked`. Section semantics + status enums: see [`_shared/state-file-sections.md`](./_shared/state-file-sections.md).
+> **Statuses:** `pending` | `in-progress` | `complete` | `skipped` | `blocked`.
 
 ## Notes on meta-features
 
-Plan-level meta-features may skip Stage 7-9 canonical artifacts when each sub-task ships as its own PR with implementation evidence, tests, review, and trace links. Record the rationale under `## Skips` and point to the per-PR evidence. See [`_shared/state-file-sections.md`](./_shared/state-file-sections.md) for the full rule.
+Plan-level meta-features may skip Stage 7-9 canonical artifacts when each sub-task ships as its own PR with implementation evidence, tests, review, and trace links. Record the rationale under `## Skips` and point to the per-PR evidence.
 
 ## Skips
 


### PR DESCRIPTION
## Summary

Stages 1–4 planning artifacts for Shape B branching adoption (issue #255).

- `specs/shape-b-branching-adoption/` — idea, research, requirements, design (15 EARS reqs, 6 NFRs)
- `docs/adr/0027-adopt-shape-b-branching-model.md` — new ADR (supersedes ADR-0020)
- `docs/adr/0020-v05-release-branch-strategy.md` — frontmatter update: `status: Superseded`, `superseded-by: [ADR-0027]`
- `docs/adr/README.md` — index updated

No code changes. No workflow changes. Documentation and spec artifacts only.

## Closes / tracks

Tracks #255. Does not close — implementation gated on #233.

## Test plan

- [ ] Read `specs/shape-b-branching-adoption/requirements.md` — 15 REQ-BRANCH-NNN all have EARS notation and acceptance criteria
- [ ] Read `docs/adr/0027-adopt-shape-b-branching-model.md` — `supersedes: [ADR-0020]` in frontmatter
- [ ] Read `docs/adr/0020-v05-release-branch-strategy.md` — `status: Superseded`, `superseded-by: [ADR-0027]` in frontmatter, body untouched
- [ ] Verify gate green (`npm run verify`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)