### PR TITLE
ci(bot): narrow issue-breakdown placeholder permissions

### DIFF
--- a/.github/workflows/issue-breakdown-bot.yml
+++ b/.github/workflows/issue-breakdown-bot.yml
@@ -4,9 +4,10 @@ name: Issue breakdown bot
 # automation) applies the `breakdown-me` label to an issue. The trigger contract,
 # concurrency, and permissions are pinned by this workflow; the actual model
 # invocation that runs `agents/operational/issue-breakdown-bot/PROMPT.md`
-# against the issue payload is intentionally a placeholder — adopters wire
-# their preferred Claude Code action (e.g. `anthropics/claude-code-action`)
-# in a fork. See `agents/operational/issue-breakdown-bot/README.md`.
+# against the issue payload is intentionally disabled by default — adopters
+# wire their preferred Claude Code action (e.g. `anthropics/claude-code-action`)
+# and set `ISSUE_BREAKDOWN_BOT_ENABLED=true` in repository variables. See
+# `agents/operational/issue-breakdown-bot/README.md`.
 
 on:
   issues:
@@ -23,14 +24,55 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  placeholder:
+    name: Notify operator that runner is disabled
+    if: github.event.label.name == 'breakdown-me' && vars.ISSUE_BREAKDOWN_BOT_ENABLED != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Notify operator that the runner is disabled
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          body=$(cat <<'EOF'
+          The `breakdown-me` label was received and the issue-breakdown-bot workflow ran, but the branch/PR runner is disabled. The default path only has `issues: write` permission and cannot push branches or open pull requests.
+
+          To enable the bot end-to-end:
+
+          1. Replace the guarded `Refuse until a model runner is wired` step in `.github/workflows/issue-breakdown-bot.yml` with your team's preferred Claude Code action (e.g. `anthropics/claude-code-action`), pointing it at `agents/operational/issue-breakdown-bot/PROMPT.md` and the issue payload from `${GITHUB_EVENT_PATH}`.
+          2. Add the `ANTHROPIC_API_KEY` (or equivalent) secret to the repository.
+          3. Set repository variable `ISSUE_BREAKDOWN_BOT_ENABLED=true`.
+          4. Re-apply the `breakdown-me` label to re-trigger.
+
+          In the meantime, the interactive conductor still works locally:
+
+          ```
+          /issue:breakdown <issue-number>
+          ```
+
+          See `agents/operational/issue-breakdown-bot/README.md` for the full setup checklist and `docs/issue-breakdown-track.md` for the track methodology.
+          EOF
+          )
+          gh issue comment "${ISSUE_NUMBER}" --repo "${REPO}" --body "${body}
+
+          ---
+          Workflow run: ${RUN_URL}"
+
   decompose:
     name: Decompose issue into draft PRs
-    if: github.event.label.name == 'breakdown-me'
+    if: github.event.label.name == 'breakdown-me' && vars.ISSUE_BREAKDOWN_BOT_ENABLED == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write          # branch push for feat/* + chore/* (never main / develop)
       issues: write             # comment + edit body + remove label
       pull-requests: write      # gh pr create
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -49,7 +91,9 @@ jobs:
           test -f templates/issue-breakdown-issue-section.md
 
       # ---------------------------------------------------------------------
-      # PLACEHOLDER — adopters replace this step with a Claude Code runner.
+      # GUARDED RUNNER SLOT — adopters replace this step with a Claude Code
+      # runner only after setting `ISSUE_BREAKDOWN_BOT_ENABLED=true` and
+      # provisioning the runner secret.
       #
       # The runner must:
       #   1. Load the prompt at `agents/operational/issue-breakdown-bot/PROMPT.md`.
@@ -59,38 +103,13 @@ jobs:
       #   4. Exit non-zero on refusal so the closing comment step below
       #      (which only runs on success) is skipped and the `breakdown-me`
       #      label stays on the issue.
-      #
-      # Until wired, the workflow falls back to posting a one-time comment
-      # explaining how to enable the bot, so issues labelled `breakdown-me`
-      # do not silently sit forever.
       # ---------------------------------------------------------------------
-      - name: Notify operator (placeholder — replace with Claude Code runner)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          REPO: ${{ github.repository }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      - name: Refuse until a model runner is wired
         run: |
           set -euo pipefail
-          body=$(cat <<'EOF'
-          The `breakdown-me` label was received and the issue-breakdown-bot workflow ran, but no Claude Code runner is wired into `.github/workflows/issue-breakdown-bot.yml` yet — the model-invocation step is a placeholder.
-
-          To enable the bot end-to-end:
-
-          1. Replace the `Notify operator (placeholder ...)` step in `.github/workflows/issue-breakdown-bot.yml` with your team's preferred Claude Code action (e.g. `anthropics/claude-code-action`), pointing it at `agents/operational/issue-breakdown-bot/PROMPT.md` and the issue payload from `${GITHUB_EVENT_PATH}`.
-          2. Add the `ANTHROPIC_API_KEY` (or equivalent) secret to the repository.
-          3. Re-apply the `breakdown-me` label to re-trigger.
-
-          In the meantime, the interactive conductor still works locally:
-
-          ```
-          /issue:breakdown <issue-number>
-          ```
-
-          See `agents/operational/issue-breakdown-bot/README.md` for the full setup checklist and `docs/issue-breakdown-track.md` for the track methodology.
-          EOF
-          )
-          gh issue comment "${ISSUE_NUMBER}" --repo "${REPO}" --body "${body}
-
-          ---
-          Workflow run: ${RUN_URL}"
+          if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+            echo "::error::ISSUE_BREAKDOWN_BOT_ENABLED=true but ANTHROPIC_API_KEY is not available."
+          else
+            echo "::error::ISSUE_BREAKDOWN_BOT_ENABLED=true but the model runner step is still the template refusal."
+          fi
+          exit 1

--- a/agents/operational/issue-breakdown-bot/README.md
+++ b/agents/operational/issue-breakdown-bot/README.md
@@ -29,10 +29,12 @@ The interactive `/issue:breakdown` conductor gates with `AskUserQuestion` and is
 Per‑project, before the first run:
 
 1. **Create the `breakdown-me` label** on the repo.
-2. **Wire a Claude Code runner.** This template ships the trigger contract at [`.github/workflows/issue-breakdown-bot.yml`](../../../.github/workflows/issue-breakdown-bot.yml) but does **not** invoke a model — that step is project‑specific. Replace the "Run the bot prompt" placeholder step with your team's preferred Claude Code action (e.g. `anthropics/claude-code-action`), pointing it at [`PROMPT.md`](./PROMPT.md) and the issue payload from `${GITHUB_EVENT_PATH}`. Keep the workflow's trigger / `if:` / `concurrency` / `permissions` blocks unchanged.
-3. **Provision secrets.** The Claude Code action you wire will need an `ANTHROPIC_API_KEY` (or equivalent) repo secret. The shipped workflow uses only `${{ secrets.GITHUB_TOKEN }}` for `gh` calls.
-4. **Run with `DRY_RUN=1` once** (set `env: DRY_RUN: "1"` on the runner step) before enabling for real. Read the stdout dump in the Actions log.
-5. **(Optional) Adopt the same trusted‑bot pattern as `dep-triage-bot`** if your repo restricts who may apply the `breakdown-me` label. The bot itself does not validate the labeller's identity — branch protection / label permissions are the trust boundary.
+2. **Keep the write-capable runner disabled by default.** The shipped workflow's default `placeholder` job only has `issues: write` permission and comments when the label is applied. It cannot push branches or open PRs.
+3. **Wire a Claude Code runner.** Replace the guarded `Refuse until a model runner is wired` step in [`.github/workflows/issue-breakdown-bot.yml`](../../../.github/workflows/issue-breakdown-bot.yml) with your team's preferred Claude Code action (e.g. `anthropics/claude-code-action`), pointing it at [`PROMPT.md`](./PROMPT.md) and the issue payload from `${GITHUB_EVENT_PATH}`. Keep the workflow's trigger / `if:` / `concurrency` blocks unchanged. Keep the broader `contents: write` / `pull-requests: write` job permissions only on the gated runner job.
+4. **Provision secrets.** The Claude Code action you wire will need an `ANTHROPIC_API_KEY` (or equivalent) repo secret. The runner uses `${{ secrets.GITHUB_TOKEN }}` for `gh` calls.
+5. **Enable the write-capable runner intentionally.** Set repository variable `ISSUE_BREAKDOWN_BOT_ENABLED=true` only after the model runner step and secret are in place. Until that variable is set, applying `breakdown-me` cannot mint a write-capable token.
+6. **Run with `DRY_RUN=1` once** (set `env: DRY_RUN: "1"` on the runner step) before enabling for real. Read the stdout dump in the Actions log.
+7. **(Optional) Adopt the same trusted‑bot pattern as `dep-triage-bot`** if your repo restricts who may apply the `breakdown-me` label. The bot itself does not validate the labeller's identity — branch protection / label permissions are the trust boundary.
 
 ## How findings get closed
 
@@ -49,6 +51,7 @@ GitHub's native task‑list‑link feature auto‑strikes the matching `- [ ] #<
 
 - **Trigger.** Default is `issues: types: [labeled]` filtered to `breakdown-me`. Some teams add `issue_comment` triggers for slash‑command‑on‑comment ergonomics — keep the `concurrency.group` keyed per issue if you do.
 - **Concurrency.** `cancel-in-progress: false`. Two runs against the same issue queue rather than race the parent‑issue body edit. Do **not** flip this to `true` — `gh issue edit --body` is last‑write‑wins and not safe to interrupt mid‑write.
+- **Permissions.** Default label-triggered runs stay on the low-permission placeholder path (`issues: write` only). The write-capable `decompose` job is gated by repository variable `ISSUE_BREAKDOWN_BOT_ENABLED=true` and should stay disabled until a real model runner and secret are configured.
 - **Branch prefix.** Slice branches are `feat/*`; the housekeeping branch is `chore/*`. Both must be permitted by branch protection. The integration branch (`main` or `develop`, auto‑detected) is push‑denied per `.claude/settings.json` for local Claude — the workflow runs under `${{ secrets.GITHUB_TOKEN }}` and inherits branch protection from the GitHub side.
 - **Fallback parser.** The bot uses the same liberal parser as the interactive conductor — accepts both the canonical `templates/tasks-template.md` shape *and* the legacy pre‑template shape (no emojis, hyphen separator, missing optional anchors). Drift in the template does not break the bot.
 

--- a/tools/automation-registry.yml
+++ b/tools/automation-registry.yml
@@ -459,7 +459,7 @@ entries:
   - id: workflow:issue-breakdown-bot
     kind: workflow
     path: .github/workflows/issue-breakdown-bot.yml
-    purpose: Trigger contract for the issue-breakdown-bot — fires on the `breakdown-me` label and queues one decomposition per issue. Model invocation step is a placeholder for adopters to wire their preferred Claude Code action.
+    purpose: Trigger contract for the issue-breakdown-bot — fires on the `breakdown-me` label, defaults to an issues-only placeholder comment, and gates the write-capable decomposition job behind `ISSUE_BREAKDOWN_BOT_ENABLED=true`.
     read_only: false
     safe_to_run_locally: false
     emits_json: false


### PR DESCRIPTION
## Summary

- Split the issue-breakdown bot workflow into a default issues-only placeholder job and a write-capable `decompose` job gated by `ISSUE_BREAKDOWN_BOT_ENABLED=true`.
- Added a guarded refusal step so the template runner path fails closed until a real model runner and secret are configured.
- Updated operator notes and the automation registry entry to document the permission gate.

Closes #247.

## Verification

- `npm run verify:changed` passed.
- `npm ci` completed successfully in the worktree.
- `npm run verify` passed.
- `git diff --check` passed.

## Skipped

- Local `actionlint .github/workflows/issue-breakdown-bot.yml` was not run because `actionlint` is not installed in this worktree; CI should cover the pinned workflow lint check.