### PR TITLE
ci(security): add dependency review workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,34 @@
+name: dependency-review
+
+on:
+  pull_request:
+    paths:
+      - 'package.json'
+      - 'npm-shrinkwrap.json'
+      - '.github/workflows/**'
+      - '.github/actions/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    name: dependency review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        with:
+          fail-on-severity: high
+          vulnerability-check: true
+          license-check: false
+          comment-summary-in-pr: never

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -14,12 +14,14 @@ Companion to [`verify-gate.md`](verify-gate.md) and [`security-ci.md`](security-
 | **pr-title** | [`.github/workflows/pr-title.yml`](../.github/workflows/pr-title.yml) | `pull_request` opened / edited / reopened / synchronize | Validates PR title against Conventional Commits (`feat`, `fix`, `chore`, `docs`, `refactor`, `perf`, `test`, `build`, `ci`, `revert`). Mirrors the [AGENTS.md](../AGENTS.md) commit convention. |
 | **typos** | [`.github/workflows/typos.yml`](../.github/workflows/typos.yml) | PR + push to `main` | Spell-check across the repo. Allowlist in [`_typos.toml`](../_typos.toml). |
 | **dependabot** | [`.github/dependabot.yml`](../.github/dependabot.yml) | Weekly (Monday 06:00 UTC) | Opens PRs for new versions of pinned GitHub Actions and npm dev-dependencies. Groups patches and minors to keep PR volume low. |
+| **dependency-review** | [`.github/workflows/dependency-review.yml`](../.github/workflows/dependency-review.yml) | PRs touching dependency or workflow files | Blocks PRs that introduce high/critical vulnerable npm packages or GitHub Actions dependencies. See [`security-ci.md`](security-ci.md#dependency-review-policy). |
 
-## Why these three
+## Why these automation gates
 
 - **pr-title** enforces the existing convention. Without it, the rule lives only in `AGENTS.md` and gets violated. The check is cheap and informs reviewers immediately.
 - **typos** targets a Markdown-heavy repo where prose drift accumulates faster than code drift. Fast (< 5s) and config-driven.
 - **dependabot** closes the loop on the [SHA-pin policy](security-ci.md#action-pinning) — without an automated bumper, pinning is a maintenance burden that ages out the codebase.
+- **dependency-review** adds PR-diff vulnerability feedback before a lockfile or workflow dependency change reaches `main`.
 
 ## Why **not** markdownlint (yet)
 
@@ -67,6 +69,8 @@ If a real typo is rejected because of an allowlist entry, **delete the entry** r
 
 Both ecosystems run weekly Monday 06:00 / 06:30 UTC. The hour offset spreads PR creation so reviewers don't see a wall of bumps simultaneously.
 
+Dependabot version updates are not the same as Dependabot alerts. Repository maintainers should enable Dependabot alerts in GitHub security settings so already-merged dependencies are checked when new advisories are published. Dependency review covers PR diffs; alerts cover the resting dependency graph.
+
 ### Release cooldown
 
 Both blocks set `cooldown` so Dependabot waits before proposing newly published versions:
@@ -95,4 +99,6 @@ typos --config _typos.toml
 
 1. Replace the README badge URLs with your own repo coordinates (or remove the row).
 2. Update `dependabot.yml` `directory:` if `package.json` is not at repo root.
-3. Decide whether to lock a `locale` in `_typos.toml`. The template stays unlocked because it mixes en-us and en-gb spellings; a real product probably picks one.
+3. Enable Dependabot alerts in the repository security settings.
+4. Decide whether to require the `dependency review` check in branch protection or rulesets.
+5. Decide whether to lock a `locale` in `_typos.toml`. The template stays unlocked because it mixes en-us and en-gb spellings; a real product probably picks one.

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -71,6 +71,8 @@ Both ecosystems run weekly Monday 06:00 / 06:30 UTC. The hour offset spreads PR 
 
 Dependabot version updates are not the same as Dependabot alerts. Repository maintainers should enable Dependabot alerts in GitHub security settings so already-merged dependencies are checked when new advisories are published. Dependency review covers PR diffs; alerts cover the resting dependency graph.
 
+Dependabot security updates stay disabled initially to avoid unplanned PR volume. Turn them on after the alert baseline is known and the team wants Dependabot to open remediation PRs automatically.
+
 ### Release cooldown
 
 Both blocks set `cooldown` so Dependabot waits before proposing newly published versions:

--- a/docs/security-ci.md
+++ b/docs/security-ci.md
@@ -16,18 +16,32 @@ Each gate is a separate workflow file under `.github/workflows/` so it can be en
 | **actionlint** | [`.github/workflows/actionlint.yml`](../.github/workflows/actionlint.yml) | PR + push to `main`, paths `.github/workflows/**`, `.github/actions/**` | Workflow YAML schema errors, deprecated action calls, shellcheck inside `run:` blocks. |
 | **zizmor** | [`.github/workflows/zizmor.yml`](../.github/workflows/zizmor.yml) | PR + push to `main` (workflow paths) + weekly schedule | Workflow security smells: template injection, unpinned actions, excessive permissions, dangerous triggers. SARIF results land in the GitHub Security tab. |
 | **gitleaks** | [`.github/workflows/gitleaks.yml`](../.github/workflows/gitleaks.yml) | PR + push to `main` + weekly schedule | Committed secrets — API keys, tokens, private keys — detected against the full git history. |
+| **dependency-review** | [`.github/workflows/dependency-review.yml`](../.github/workflows/dependency-review.yml) | PRs touching `package.json`, `npm-shrinkwrap.json`, or workflow/action files | New vulnerable npm or GitHub Actions dependencies introduced by the PR diff. Fails on `high` and `critical` severities; license policy is deferred. |
 
-## Why three separate workflows
+## Why separate workflows
 
 - **Independent failure surfaces.** A flaky workflow lint should not block a security scan and vice versa.
 - **Targeted triggers.** `actionlint` and `zizmor` only run on workflow file changes; `gitleaks` runs on every PR.
 - **Replaceable.** Adopters of this template can swap any of the three for an internal equivalent without rewiring the others.
 
-## Why these three first
+## Why these gates first
 
-`actionlint` and `zizmor` defend the CI pipeline itself — every other gate lives downstream of GitHub Actions, so that surface gets hardened first. `gitleaks` defends the repo against the most common single-event leak (a secret pasted into a commit). Together they close the highest-leverage gaps for a workflow-template repo.
+`actionlint` and `zizmor` defend the CI pipeline itself — every other gate lives downstream of GitHub Actions, so that surface gets hardened first. `gitleaks` defends the repo against the most common single-event leak (a secret pasted into a commit). `dependency-review` catches vulnerable packages and actions before dependency diffs merge. Together they close the highest-leverage gaps for a workflow-template repo.
 
-Higher-friction or domain-specific gates (CodeQL, dependency-review, OSSF Scorecard, typos, markdownlint, conventional-commits PR titles) are deferred until a concrete signal demands them. Adding them later is a one-file change.
+Higher-friction or domain-specific gates (CodeQL, OSSF Scorecard, markdownlint) are deferred until a concrete signal demands them. `typos`, conventional-commits PR titles, and dependency review are now implemented.
+
+## Dependency review policy
+
+The dependency-review workflow uses GitHub's dependency graph diff for pull requests. It runs only when a PR changes the npm manifest/lock or GitHub Actions workflow/action files.
+
+Policy:
+
+- Fail on vulnerabilities with severity `high` or `critical`.
+- Report lower-severity findings in the job output without blocking the PR.
+- Keep `license-check: false` for now; license allow/deny policy needs a separate decision.
+- Do not post PR comments from the action. Reviewers read the job summary and logs, and branch protection can require the `dependency review` check once the repo ruleset is updated.
+
+The workflow complements, but does not replace, repository-level Dependabot alerts. Dependabot alerts must be enabled in the GitHub repository security settings so newly disclosed vulnerabilities in already-merged dependencies surface outside PR review.
 
 ## Local equivalents
 
@@ -43,6 +57,11 @@ uvx zizmor .
 
 # gitleaks (requires the gitleaks binary: https://github.com/gitleaks/gitleaks)
 gitleaks detect --source . --redact
+
+# dependency-review has no direct local equivalent; it depends on GitHub's
+# pull-request dependency graph comparison API. Use npm audit locally for
+# a coarse npm-only check.
+npm audit --audit-level=high
 ```
 
 These are not bundled into `npm run verify` on purpose — see the verify gate doc for the rationale.

--- a/tools/automation-registry.yml
+++ b/tools/automation-registry.yml
@@ -456,6 +456,15 @@ entries:
     emits_json: false
     used_by: [ci]
     rerun_command: gh run list --workflow gitleaks.yml
+  - id: workflow:dependency-review
+    kind: workflow
+    path: .github/workflows/dependency-review.yml
+    purpose: Review dependency diffs on pull requests and fail when high or critical vulnerabilities are introduced.
+    read_only: true
+    safe_to_run_locally: false
+    emits_json: false
+    used_by: [ci]
+    rerun_command: gh run list --workflow dependency-review.yml
   - id: workflow:issue-breakdown-bot
     kind: workflow
     path: .github/workflows/issue-breakdown-bot.yml


### PR DESCRIPTION
## Summary

- Add a SHA-pinned `dependency-review` workflow for PRs that touch npm manifests, the shrinkwrap lockfile, or GitHub Actions workflow/action files.
- Configure dependency review to fail on high/critical vulnerabilities while leaving license policy deferred.
- Document the dependency-review policy, Dependabot-alerts distinction, and the decision to keep Dependabot security updates disabled initially for PR-volume control.
- Register the new workflow in `tools/automation-registry.yml`.

Refs #246.

## Verification

- `npm ci` passed.
- `npm run verify:changed` passed.
- `npm run verify` passed.
- `git diff --check` passed.

## Repository settings

- Enabled Dependabot vulnerability alerts via GitHub API: `PUT /repos/Luis85/agentic-workflow/vulnerability-alerts` returned `204 No Content`.
- Confirmed alerts are enabled: `GET /repos/Luis85/agentic-workflow/vulnerability-alerts` returned `204 No Content`.
- Left Dependabot security updates disabled intentionally for now; documented the decision in `docs/ci-automation.md`.