### PR TITLE
fix(release): map immutable 404 to disabled

### DIFF
--- a/docs/scripts/lib/release-readiness/type-aliases/ImmutableSettingProbe.md
+++ b/docs/scripts/lib/release-readiness/type-aliases/ImmutableSettingProbe.md
@@ -18,11 +18,11 @@ positive against repos where the workflow token simply cannot read the
 endpoint — operators saw "ENABLED" every dispatch even when the setting
 was off.
 
-- `enabled` — endpoint returned `enabled=true` (or org-level enforcement).
-- `disabled` — endpoint returned `enabled=false`.
+- `enabled` — endpoint returned HTTP 200 with `enabled=true` (or org-level
+  enforcement).
+- `disabled` — endpoint returned HTTP 404, the documented disabled state.
 - `denied` — endpoint returned 401 / 403 / "Bad credentials" /
   "Resource not accessible". The probe could not verify the setting;
   surface a distinct warning so the operator checks manually.
-- `unknown` — endpoint missing (404, older GitHub instance), network
-  blip, parse error. Fail quiet — a transient signal must not block
-  dispatch.
+- `unknown` — network blip, parse error, or another unrecognized response.
+  Fail quiet — a transient signal must not block dispatch.

--- a/scripts/check-release-readiness.ts
+++ b/scripts/check-release-readiness.ts
@@ -207,10 +207,12 @@ function realGit(): GitInterface {
 function realGitHub(): GitHubInterface {
   return {
     immutableReleasesSetting(): ImmutableSettingProbe {
-      // `gh api repos/{owner}/{repo}/immutable-releases` returns
-      // `{enabled: bool, enforced_by_owner: bool}`. The setting is on if
-      // either flag is true (org-level enforcement counts even when the
-      // repo's own toggle is off).
+      // Per the GitHub REST contract, `gh api
+      // repos/{owner}/{repo}/immutable-releases` returns HTTP 404 when the
+      // setting is disabled (the safe state). HTTP 200 returns
+      // `{enabled: bool, enforced_by_owner: bool}` for the enabled state; the
+      // org-level enforcement flag counts even when the repo's own toggle is
+      // off.
       //
       // Failure handling returns four distinct states (Codex P2 round 4
       // on PR #242 — round 3 coerced 401/403 -> true, which produced an
@@ -221,9 +223,8 @@ function realGitHub(): GitHubInterface {
       //     so checkRepoImmutableSetting emits ImmutableProbeDenied
       //     ("could not verify; check manually") instead of pretending
       //     the setting is confirmed on.
-      //   - Endpoint missing (404 — older GitHub instance) -> "unknown",
-      //     fail quiet. The warning was never going to be authoritative
-      //     on a host without the endpoint.
+      //   - 404 -> "disabled", because the REST endpoint uses Not Found as
+      //     the documented disabled-state response.
       //   - Anything else (network blip, parse error) -> "unknown",
       //     fail quiet. Transient errors should not pollute the warning.
       //
@@ -252,11 +253,13 @@ function realGitHub(): GitHubInterface {
         if (/HTTP 401|HTTP 403|Bad credentials|Resource not accessible/i.test(stderr)) {
           return "denied";
         }
+        if (/HTTP 404|Not Found/i.test(stderr)) {
+          return "disabled";
+        }
         return "unknown";
       }
       const trimmed = out.trim();
       if (trimmed === "true") return "enabled";
-      if (trimmed === "false") return "disabled";
       return "unknown";
     },
   };

--- a/scripts/lib/release-readiness.ts
+++ b/scripts/lib/release-readiness.ts
@@ -118,14 +118,14 @@ export const RELEASE_READINESS_WARNING_CODES = {
  * endpoint — operators saw "ENABLED" every dispatch even when the setting
  * was off.
  *
- * - `enabled` — endpoint returned `enabled=true` (or org-level enforcement).
- * - `disabled` — endpoint returned `enabled=false`.
+ * - `enabled` — endpoint returned HTTP 200 with `enabled=true` (or org-level
+ *   enforcement).
+ * - `disabled` — endpoint returned HTTP 404, the documented disabled state.
  * - `denied` — endpoint returned 401 / 403 / "Bad credentials" /
  *   "Resource not accessible". The probe could not verify the setting;
  *   surface a distinct warning so the operator checks manually.
- * - `unknown` — endpoint missing (404, older GitHub instance), network
- *   blip, parse error. Fail quiet — a transient signal must not block
- *   dispatch.
+ * - `unknown` — network blip, parse error, or another unrecognized response.
+ *   Fail quiet — a transient signal must not block dispatch.
  */
 export type ImmutableSettingProbe = "enabled" | "disabled" | "denied" | "unknown";
 

--- a/tests/scripts/release-readiness.test.ts
+++ b/tests/scripts/release-readiness.test.ts
@@ -734,7 +734,7 @@ test("checkRepoImmutableSetting: probe denied (401/403) -> emits distinct Immuta
   assert.match(warnings[0].message, /401\/403/);
 });
 
-test("checkRepoImmutableSetting: probe unknown (endpoint missing / network) -> no warning, fail-quiet", () => {
+test("checkRepoImmutableSetting: probe unknown (network / parse error) -> no warning, fail-quiet", () => {
   const github: GitHubInterface = { immutableReleasesSetting: () => "unknown" };
   assert.deepEqual(
     checkRepoImmutableSetting(github),


### PR DESCRIPTION
## Summary

- Map `gh api repos/{owner}/{repo}/immutable-releases` HTTP 404 to the `disabled` probe state.
- Remove the dead `false` success branch from the immutable releases adapter.
- Refresh source and generated script docs so `ImmutableSettingProbe` documents 404 as the disabled safe state.

Closes #244.

## Verification

- `npm run test:scripts -- --test-name-pattern release-readiness`
- `npm run verify`

## Notes

- First `npm run verify` attempt stopped at `check:script-docs` because the fresh worktree had no local `node_modules`; ran `npm ci`, then reran `npm run verify` successfully.