### PR TITLE
ci(security): pin workflow tool acquisition

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -32,7 +32,11 @@ jobs:
       - name: Download actionlint
         id: download
         shell: bash
-        run: bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        env:
+          ACTIONLINT_INSTALLER_SHA: 914e7df21a07ef503a81201c76d2b11c789d3fca # rhysd/actionlint v1.7.12
+          ACTIONLINT_VERSION: 1.7.12
+        run: |
+          bash <(curl -fsSL "https://raw.githubusercontent.com/rhysd/actionlint/${ACTIONLINT_INSTALLER_SHA}/scripts/download-actionlint.bash") "${ACTIONLINT_VERSION}"
 
       - name: Run actionlint
         shell: bash

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -37,7 +37,7 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Run zizmor (SARIF for Security tab)
-        run: uvx zizmor --persona=auditor --format=sarif . > zizmor.sarif
+        run: uvx zizmor==1.24.1 --persona=auditor --format=sarif . > zizmor.sarif
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -49,6 +49,6 @@ jobs:
           category: zizmor
 
       - name: Run zizmor (gate the build)
-        run: uvx zizmor .
+        run: uvx zizmor==1.24.1 .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/security-ci.md
+++ b/docs/security-ci.md
@@ -49,11 +49,13 @@ When iterating on workflow YAML or hunting a leaked secret without waiting for C
 
 ```bash
 # actionlint
-bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+ACTIONLINT_INSTALLER_SHA=914e7df21a07ef503a81201c76d2b11c789d3fca
+ACTIONLINT_VERSION=1.7.12
+bash <(curl -fsSL "https://raw.githubusercontent.com/rhysd/actionlint/${ACTIONLINT_INSTALLER_SHA}/scripts/download-actionlint.bash") "${ACTIONLINT_VERSION}"
 ./actionlint -color
 
 # zizmor (requires uv: https://github.com/astral-sh/uv)
-uvx zizmor .
+uvx zizmor==1.24.1 .
 
 # gitleaks (requires the gitleaks binary: https://github.com/gitleaks/gitleaks)
 gitleaks detect --source . --redact
@@ -90,6 +92,12 @@ Pinning to SHA is a hard requirement enforced by zizmor's `unpinned-uses` rule. 
 3. Verify the workflow still parses (`actionlint`) and is happy with zizmor.
 
 SHA bumps are automated by Dependabot — see [`ci-automation.md`](ci-automation.md#dependabot-policy).
+
+Pinned tool installers follow the same review habit even when they are not
+GitHub Actions `uses:` references. `actionlint.yml` pins both the upstream
+installer script commit and the downloaded actionlint release version.
+`zizmor.yml` pins the PyPI package version used by `uvx`; bump it in the
+workflow and the local-equivalent command above in the same PR.
 
 ## Adopting in a downstream project
 


### PR DESCRIPTION
## Summary

- Pin actionlint installer retrieval to the upstream `rhysd/actionlint` v1.7.12 commit and request actionlint `1.7.12` explicitly.
- Pin zizmor CI invocations to `zizmor==1.24.1` instead of floating through latest `uvx` resolution.
- Update `docs/security-ci.md` local commands and bump guidance to match the pinned CI behavior.

## Verification

- `npm ci`
- `npm run verify`
- `actionlint.exe -color` against the repository workflows using actionlint `1.7.12`
- `git diff --check`

Skipped: local `uvx zizmor==1.24.1 .` because `uvx` is not installed in this Windows shell; the pinned command is exercised by the zizmor GitHub Actions workflow.

## Linked issue

- Addresses the P2 tool-acquisition recommendation in #243.

## Known limitations

- This pins the actionlint installer script and requested release version, but does not add a checksum verification step for the downloaded actionlint release archive.