### PR TITLE
ci(rules): require status checks and review policy on main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,9 @@
 ## Checklist
 
 - [ ] `npm run verify` gate is green locally
+- [ ] Required GitHub checks are green on the latest commit (`Verify`, PR title, typos, gitleaks)
+- [ ] Path-triggered checks are green when applicable (`actionlint`, `zizmor`, dependency review)
+- [ ] Review threads are resolved before merge
 - [ ] Docs and steering files updated in this PR — no "I'll do it after"
 - [ ] Product page updated or explicitly marked unaffected (`sites/index.html`)
 - [ ] ADR filed if this is an irreversible architectural decision (`/adr:new "<title>"`)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,7 @@
 - [ ] `npm run verify` gate is green locally
 - [ ] Required GitHub checks are green on the latest commit (`Verify`, PR title, typos, gitleaks)
 - [ ] Path-triggered checks are green when applicable (`actionlint`, `zizmor`, dependency review)
-- [ ] Review threads are resolved before merge
+- [ ] Review threads are resolved before merge when present
 - [ ] Docs and steering files updated in this PR — no "I'll do it after"
 - [ ] Product page updated or explicitly marked unaffected (`sites/index.html`)
 - [ ] ADR filed if this is an irreversible architectural decision (`/adr:new "<title>"`)

--- a/docs/branching.md
+++ b/docs/branching.md
@@ -58,9 +58,6 @@ The ruleset must:
 - block non-fast-forward updates;
 - require pull requests before merge;
 - require the branch to be up to date before merge;
-- require at least one approving review;
-- dismiss stale approvals when new commits are pushed;
-- require approval of the most recent reviewable push;
 - require all review threads to be resolved before merge;
 - require these always-running status checks:
   - `Verify`
@@ -69,6 +66,8 @@ The ruleset must:
   - `scan for committed secrets`
 
 Workflow-path security checks (`actionlint`, `zizmor static analysis`, and `dependency review`) stay path-triggered so ordinary docs and script PRs are not blocked by jobs that never run. When a PR changes `.github/workflows/**`, `.github/actions/**`, or dependency manifests, the relevant path-triggered checks must be green before merge; require them in a path-scoped ruleset if the repository configuration supports that shape.
+
+Approving reviews are intentionally not required in the upstream ruleset yet. Solo-maintainer and agent-heavy iteration currently gets more value from required CI, PR-only integration, and resolved review threads than from mandatory approval ceremony. Revisit this when there is a regular second reviewer or code-owner model.
 
 ## Rules
 

--- a/docs/branching.md
+++ b/docs/branching.md
@@ -48,6 +48,28 @@ Scopes are optional. The expected shape is `<type>: <subject>` or `<type>(<scope
 
 Use `docs:` for planning artifacts, specs, workflow notes, README changes, and other documentation-only work. Do not use descriptive-but-unsupported types such as `plan:`, `release:`, or `workflow:` unless the CI allowlist is updated in the same concern.
 
+## Required main ruleset
+
+This upstream repository protects the default branch with a GitHub ruleset named `main`. Downstream projects should reproduce the same contract on their integration branch, whether that branch is `main` in Shape A or `develop` in Shape B.
+
+The ruleset must:
+
+- block branch deletion;
+- block non-fast-forward updates;
+- require pull requests before merge;
+- require the branch to be up to date before merge;
+- require at least one approving review;
+- dismiss stale approvals when new commits are pushed;
+- require approval of the most recent reviewable push;
+- require all review threads to be resolved before merge;
+- require these always-running status checks:
+  - `Verify`
+  - `Conventional Commits PR title`
+  - `spell check`
+  - `scan for committed secrets`
+
+Workflow-path security checks (`actionlint`, `zizmor static analysis`, and `dependency review`) stay path-triggered so ordinary docs and script PRs are not blocked by jobs that never run. When a PR changes `.github/workflows/**`, `.github/actions/**`, or dependency manifests, the relevant path-triggered checks must be green before merge; require them in a path-scoped ruleset if the repository configuration supports that shape.
+
 ## Rules
 
 1. **No direct commits on `main` (or `develop`)** — *ever*. Every change lands via a topic branch and a merged PR. This applies to code, docs, ADRs, glossary entries, memory files, brainstorm output, planning artifacts, and generated docs. There is no "small enough" exception. The `.claude/settings.json` push deny is a backstop; the rule applies even to local commits, because extracting a stray `main` commit into a topic branch later costs more than cutting the branch up front. See [`feedback_no_main_commits.md`](../.claude/memory/feedback_no_main_commits.md).

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -23,6 +23,8 @@ Companion to [`verify-gate.md`](verify-gate.md) and [`security-ci.md`](security-
 - **dependabot** closes the loop on the [SHA-pin policy](security-ci.md#action-pinning) — without an automated bumper, pinning is a maintenance burden that ages out the codebase.
 - **dependency-review** adds PR-diff vulnerability feedback before a lockfile or workflow dependency change reaches `main`.
 
+The upstream `main` ruleset requires the always-running PR checks (`Verify`, PR title, typos, and gitleaks). Path-triggered checks remain merge-blocking when they run, but are not global required checks because GitHub does not create them for unrelated PRs.
+
 ## Why **not** markdownlint (yet)
 
 `markdownlint-cli2` was scoped for this bundle but pulled out — the existing artefact templates produce ~2000 findings on first run, dominated by table-pipe-spacing (`MD060`), heading rules around H1 placeholders (`MD025`), and fenced-code language tags (`MD040`). Adding it without a dedicated cleanup PR would either spam CI or require disabling so many rules that the check becomes a no-op. Track it as a follow-up: a single sweep PR that auto-fixes table style and adds language tags to fenced blocks, then enable the workflow.
@@ -103,4 +105,5 @@ typos --config _typos.toml
 2. Update `dependabot.yml` `directory:` if `package.json` is not at repo root.
 3. Enable Dependabot alerts in the repository security settings.
 4. Decide whether to require the `dependency review` check in branch protection or rulesets.
-5. Decide whether to lock a `locale` in `_typos.toml`. The template stays unlocked because it mixes en-us and en-gb spellings; a real product probably picks one.
+5. Reproduce the required-check policy from [`branching.md`](branching.md#required-main-ruleset) on the integration branch.
+6. Decide whether to lock a `locale` in `_typos.toml`. The template stays unlocked because it mixes en-us and en-gb spellings; a real product probably picks one.

--- a/docs/security-ci.md
+++ b/docs/security-ci.md
@@ -39,7 +39,7 @@ The upstream `main` ruleset requires the always-running checks that every PR sho
 - `spell check`
 - `scan for committed secrets`
 
-The ruleset also requires an up-to-date branch, one approving review, latest-push approval, stale-review dismissal, and resolved review threads. This makes the remote policy match the local rule that `npm run verify` must be green before merge.
+The ruleset also requires an up-to-date branch and resolved review threads. It does not require approving reviews yet; for the current solo-maintainer workflow, required checks provide the stronger signal without adding approval ceremony. This makes the remote policy match the local rule that `npm run verify` must be green before merge.
 
 Path-triggered security workflows are intentionally not global required checks:
 

--- a/docs/security-ci.md
+++ b/docs/security-ci.md
@@ -30,6 +30,25 @@ Each gate is a separate workflow file under `.github/workflows/` so it can be en
 
 Higher-friction or domain-specific gates (CodeQL, OSSF Scorecard, markdownlint) are deferred until a concrete signal demands them. `typos`, conventional-commits PR titles, and dependency review are now implemented.
 
+## Required status checks
+
+The upstream `main` ruleset requires the always-running checks that every PR should produce:
+
+- `Verify`
+- `Conventional Commits PR title`
+- `spell check`
+- `scan for committed secrets`
+
+The ruleset also requires an up-to-date branch, one approving review, latest-push approval, stale-review dismissal, and resolved review threads. This makes the remote policy match the local rule that `npm run verify` must be green before merge.
+
+Path-triggered security workflows are intentionally not global required checks:
+
+- `actionlint` runs only for `.github/workflows/**` and `.github/actions/**`.
+- `zizmor static analysis` runs only for workflow/action changes and on its weekly schedule.
+- `dependency review` runs only for dependency manifest, lockfile, workflow, and local-action changes.
+
+If GitHub rulesets in the target repository support path-scoped required checks, require those checks for the matching paths. Otherwise, reviewers must treat the path-triggered job result as merge-blocking whenever GitHub runs it.
+
 ## Dependency review policy
 
 The dependency-review workflow uses GitHub's dependency graph diff for pull requests. It runs only when a PR changes the npm manifest/lock or GitHub Actions workflow/action files.


### PR DESCRIPTION
## Summary

- Documents the live main ruleset policy in branching and security automation docs.
- Updates the PR template with required-check, path-triggered-check, and review-thread checklist items.
- Applies the live GitHub ruleset update for #245: PR required, up-to-date branch required, resolved review threads, and required always-running checks.

## Verification

- `npm ci`
- `npm run verify`
- `npm run verify` after removing the approval requirement

## Linked issue

Closes #245

## Known limitations

- Approving reviews are intentionally not required yet; current solo-maintainer/agent-heavy iteration gets more value from required checks than mandatory approval ceremony.
- Path-triggered checks (`actionlint`, `zizmor static analysis`, `dependency review`) are documented as merge-blocking when they run, but are not configured as global required checks because GitHub does not create those jobs for unrelated PRs.