### PR TITLE
docs(rbac): address Codex P1 + P2 follow-ups from #276

### DIFF
--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -64,6 +64,9 @@ Adopters host the work on GitHub. The minimum repository permissions for the aut
 | `contents: write` | Push topic branches, tag releases, generate Pages artifact | `dev`, `release-manager`, `pages.yml`, `release.yml`, `issue-breakdown-bot` decompose job |
 | `pull-requests: write` | Open / edit / comment on PRs from CLI and bots | `gh pr create` (any agent with `Bash`), `issue-breakdown-bot`, `project-reviewer` |
 | `issues: write` | Open / edit / comment / label issues | `issue-breakdown-bot`, `project-reviewer`, `review-bot`, `docs-review-bot` |
+| `packages: write` | Publish the released npm package to GitHub Packages (`@luis85/agentic-workflow`) | `release.yml` (publish step). See [§ GitHub Packages](#github-packages-npm-registry). |
+| `pages: write`, `id-token: write` | Build + deploy the public product page via GitHub Pages OIDC | `pages.yml` deploy job. See [§ GitHub Pages](#github-pages). |
+| `security-events: write` | Upload zizmor SARIF results to code scanning | `zizmor.yml` |
 | `metadata: read` | Inherent for any token | All workflows |
 
 Stage 9 review and Stage 11 retrospective do **not** need write to remote — they read the diff and write spec artifacts in-repo. Their PRs go through the same `feat/*` / `chore/*` push allowlist as code changes.
@@ -197,7 +200,7 @@ Track / class taxonomy frozen by [ADR-0026](adr/0026-freeze-v1-workflow-track-ta
 
 | Class | Reads (under repo root) | Writes | External calls | Agents |
 |---|---|---|---|---|
-| **Lifecycle** (Stage 1–11) | `specs/<slug>/`, `docs/`, `memory/`, `templates/` | `specs/<slug>/` per stage | `dev` / `qa` / `release-manager` may run Bash; `release-manager` may invoke `gh` | `analyst`, `pm`, `ux-designer`, `ui-designer`, `architect`, `planner`, `dev`, `qa`, `reviewer`, `release-manager`, `sre`, `retrospective`, `orchestrator` |
+| **Lifecycle** (Stage 1–11) | `specs/<slug>/`, `docs/`, `memory/`, `templates/` | `specs/<slug>/` per stage | `dev`, `qa`, `reviewer`, `sre`, `retrospective`, `release-manager` may run Bash; `release-manager` may invoke `gh`. `analyst` may use `WebSearch` / `WebFetch`. | `analyst`, `pm`, `ux-designer`, `ui-designer`, `architect`, `planner`, `dev`, `qa`, `reviewer`, `release-manager`, `sre`, `retrospective`, `orchestrator` |
 | **Discovery** *(opt-in)* | `discovery/<sprint>/`, `docs/`, `inputs/`, `stock-taking/` | `discovery/<sprint>/` per phase | `WebSearch`, `WebFetch` for product-strategist, user-researcher | `facilitator`, `product-strategist`, `user-researcher`, `game-designer`, `divergent-thinker`, `critic`, `prototyper` |
 | **Stock-taking** *(opt-in)* | `stock-taking/<slug>/`, existing-system docs in `inputs/` | `stock-taking/<slug>/` per phase | `WebSearch`, `WebFetch` | `legacy-auditor` |
 | **Sales** *(opt-in)* | `sales/<deal>/`, `inputs/`, `templates/` | `sales/<deal>/` per phase | `WebSearch` for `sales-qualifier` | `sales-qualifier`, `scoping-facilitator`, `estimator`, `proposal-writer` |


### PR DESCRIPTION
## Summary

Two findings from the second Codex pass on #276 landed after merge. Captured here as a follow-up PR.

- **P1** — `packages: write` missing from `## GitHub repository` minimum-permissions table. `release.yml` publishes `@luis85/agentic-workflow` to GitHub Packages and explicitly requests `packages: write`; an adopter provisioning a fine-grained token from the table as written would fail at the npm publish step. The fix adds rows for the three other non-default scopes the shipped workflows request (`packages: write` for release, `pages: write` + `id-token: write` for Pages OIDC, `security-events: write` for zizmor SARIF) so the table is comprehensive instead of partial.
- **P2** — Lifecycle class row in `## Class overview` claimed only `dev`, `qa`, `release-manager` may run Bash. The per-agent table later in the same doc and the actual agent frontmatter grant Bash to `reviewer`, `sre`, and `retrospective` as well. The class row now enumerates all six Bash-capable lifecycle agents and notes `analyst`'s `WebSearch` / `WebFetch` capability so the quick-scan summary matches the per-agent detail.

No code changes; docs only. The deferred `scripts/check-rbac.ts` noted in `docs/rbac.md` §Future work would have caught the P2 drift automatically — both findings are evidence that the manual contract has gaps the script should close.

## Test plan

- [x] `npm run verify` green locally.
- [ ] CI: verify, gitleaks, typos, pr-title pass.
- [ ] Reviewer: confirm the four added rows match `.github/workflows/*.yml` `permissions:` blocks (`release.yml`, `pages.yml`, `zizmor.yml`).
- [ ] Reviewer: confirm the lifecycle class row matches `.claude/agents/{dev,qa,reviewer,sre,retrospective,release-manager}.md` `tools:` frontmatter.