### PR TITLE
fix(scripts): add index-bleed guard + worktree pitfall docs (#261)

### DIFF
--- a/.claude/memory/feedback_worktrees_required.md
+++ b/.claude/memory/feedback_worktrees_required.md
@@ -42,5 +42,6 @@ git worktree prune                   # if needed
 - Do **not** symlink `node_modules/` (or any other dependency tree) between worktrees. The whole point is isolation.
 - Do **not** commit anything from `.worktrees/`. The directory is gitignored on purpose.
 - Do **not** create a worktree on the integration branch itself. Worktrees are for the *topic* branch; the main checkout stays on the integration branch.
+- Do **not** use the main checkout to work on multiple feature branches sequentially. Staged-for-addition files carry across `git checkout` because git does not track them to a branch — the next commit silently picks them all up. Use one worktree per branch to get an isolated index. Run `npm run check:index-bleed` before committing if you are in the main checkout. See [docs/worktrees.md#common-pitfalls](../../docs/worktrees.md#common-pitfalls) and [Issue #261](https://github.com/Luis85/agentic-workflow/issues/261).
 
 See [`docs/worktrees.md`](../../docs/worktrees.md) for the full guide.

--- a/docs/scripts/README.md
+++ b/docs/scripts/README.md
@@ -234,6 +234,7 @@ In GitHub Actions, `verify` requests JSON diagnostics from supported check scrip
 | `npm run check:specs` | Validate lifecycle `workflow-state.md` files and their artifact maps. |
 | `npm run check:roadmaps` | Validate roadmap state frontmatter, dates, document maps, and required sections. |
 | `npm run check:traceability` | Validate lifecycle artifact IDs and local traceability references. |
+| `npm run check:index-bleed` | Warn when the git index contains staged-for-addition files on a feature branch (index-bleed guard). Not in verify. |
 | `npm run self-check` | Run a comprehensive local quality review using verify diagnostics, quality metrics, and learning evidence. |
 
 ## Script Documentation

--- a/docs/scripts/check-index-bleed/README.md
+++ b/docs/scripts/check-index-bleed/README.md
@@ -1,0 +1,13 @@
+---
+title: "check-index-bleed"
+folder: "docs/scripts/check-index-bleed"
+description: "Entry point for generated API reference for the check-index-bleed script."
+entry_point: true
+---
+[**@luis85/agentic-workflow**](../README.md)
+
+***
+
+[@luis85/agentic-workflow](../modules.md) / check-index-bleed
+
+# check-index-bleed

--- a/docs/scripts/modules.md
+++ b/docs/scripts/modules.md
@@ -15,6 +15,7 @@
 - [check-content](check-content/README.md)
 - [check-fast](check-fast/README.md)
 - [check-frontmatter](check-frontmatter/README.md)
+- [check-index-bleed](check-index-bleed/README.md)
 - [check-issues](check-issues/README.md)
 - [check-markdown-links](check-markdown-links/README.md)
 - [check-obsidian](check-obsidian/README.md)

--- a/docs/worktrees.md
+++ b/docs/worktrees.md
@@ -57,6 +57,7 @@ For anything that touches code, runs tests, or is reviewed by an automated revie
 - **Deleting a worktree directory with `rm -rf`.** Use `git worktree remove`. A bare `rm -rf` leaves a stale `.git/worktrees/<slug>` administrative entry; `git worktree prune` cleans that up after the fact.
 - **Empty directories left under `.worktrees/`.** `npm run doctor` warns when a directory exists under `.worktrees/` but is not registered as a git worktree. Confirm it is empty and unrelated to active work before deleting it.
 - **Merged local branches piling up.** `npm run doctor` warns when local topic branches are already merged into `origin/main`. Delete them after the PR merge is confirmed and the matching worktree is removed.
+- **Staged new files bleeding across branches on `git checkout`.** When you switch branches while the index contains files staged for addition that are not tracked on either branch, git carries them into the new branch's index. A subsequent commit — even one that targets a single specific file — silently includes every staged file, pulling work from the wrong branch into your commit. **The fix is worktrees:** each worktree has its own index, so files staged in one branch never appear in another. If you must use the main checkout, run `npm run check:index-bleed` before committing; see [Issue #261](https://github.com/Luis85/agentic-workflow/issues/261) for the full incident report.
 
 ## Settings
 

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "check:traceability": "tsx scripts/check-traceability.ts",
     "check:token-budget": "tsx scripts/check-token-budget.ts",
     "check:issues": "tsx scripts/check-issues.ts",
+    "check:index-bleed": "tsx scripts/check-index-bleed.ts",
     "check:release-package-contents": "tsx scripts/check-release-package-contents.ts",
     "check:release-readiness": "tsx scripts/check-release-readiness.ts",
     "sync:issues": "tsx scripts/sync-issues.ts",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -230,6 +230,7 @@ In GitHub Actions, `verify` requests JSON diagnostics from supported check scrip
 | `npm run check:specs` | Validate lifecycle `workflow-state.md` files and their artifact maps. |
 | `npm run check:roadmaps` | Validate roadmap state frontmatter, dates, document maps, and required sections. |
 | `npm run check:traceability` | Validate lifecycle artifact IDs and local traceability references. |
+| `npm run check:index-bleed` | Warn when the git index contains staged-for-addition files on a feature branch (index-bleed guard). Not in verify. |
 | `npm run self-check` | Run a comprehensive local quality review using verify diagnostics, quality metrics, and learning evidence. |
 
 ## Script Documentation

--- a/scripts/check-index-bleed.ts
+++ b/scripts/check-index-bleed.ts
@@ -1,0 +1,51 @@
+/**
+ * Index-bleed guard.
+ *
+ * Warns when the git index contains files staged for addition while the current
+ * branch is a feature branch. Staged new files carry across `git checkout` calls
+ * when they are not tracked on either branch — the failure mode documented in
+ * docs/worktrees.md#common-pitfalls.
+ *
+ * This check is intentionally NOT in `npm run verify`. It is a pre-switch or
+ * pre-commit advisory. Run it explicitly: `npm run check:index-bleed`
+ *
+ * Flags:
+ *   --json   Emit structured JSON instead of console output.
+ */
+
+import { spawnSync } from "node:child_process";
+import { repoRoot } from "./lib/repo.js";
+
+const wantsJson = process.argv.includes("--json");
+const INTEGRATION_BRANCHES = new Set(["main", "develop"]);
+
+const warnings: string[] = [];
+
+function run(command: string, args: string[]): { ok: boolean; stdout: string } {
+  const result = spawnSync(command, args, { cwd: repoRoot, encoding: "utf8", windowsHide: true });
+  return { ok: result.status === 0, stdout: String(result.stdout || "").trim() };
+}
+
+const branch = run("git", ["branch", "--show-current"]);
+
+if (branch.ok && branch.stdout && !INTEGRATION_BRANCHES.has(branch.stdout)) {
+  const staged = run("git", ["diff", "--name-only", "--cached", "--diff-filter=A"]);
+  if (staged.ok && staged.stdout) {
+    for (const file of staged.stdout.split(/\r?\n/).filter(Boolean)) {
+      warnings.push(
+        `${file}: staged for addition on "${branch.stdout}" — if this file belongs to another branch, it will bleed into the next commit (see docs/worktrees.md#common-pitfalls)`,
+      );
+    }
+  }
+}
+
+if (wantsJson) {
+  console.log(JSON.stringify({ errors: [], warnings }, null, 2));
+} else {
+  for (const w of warnings) console.warn(`[warn] check:index-bleed: ${w}`);
+  if (warnings.length === 0) {
+    console.log("check:index-bleed: ok");
+  } else {
+    console.log(`check:index-bleed: ${warnings.length} warning(s) — review staged files before switching branches`);
+  }
+}

--- a/scripts/check-index-bleed.ts
+++ b/scripts/check-index-bleed.ts
@@ -1,10 +1,13 @@
 /**
  * Index-bleed guard.
  *
- * Warns when the git index contains files staged for addition while the current
- * branch is a feature branch. Staged new files carry across `git checkout` calls
- * when they are not tracked on either branch — the failure mode documented in
- * docs/worktrees.md#common-pitfalls.
+ * Warns when the git index contains files staged for addition on any branch.
+ * Staged new files carry across `git checkout` calls when they are not tracked
+ * on either branch — the failure mode documented in docs/worktrees.md#common-pitfalls.
+ *
+ * This includes integration branches (main, develop): staged files on main bleed
+ * onto a feature branch when you checkout into it, which is exactly the documented
+ * pre-switch scenario.
  *
  * This check is intentionally NOT in `npm run verify`. It is a pre-switch or
  * pre-commit advisory. Run it explicitly: `npm run check:index-bleed`
@@ -17,7 +20,6 @@ import { spawnSync } from "node:child_process";
 import { repoRoot } from "./lib/repo.js";
 
 const wantsJson = process.argv.includes("--json");
-const INTEGRATION_BRANCHES = new Set(["main", "develop"]);
 
 const warnings: string[] = [];
 
@@ -27,15 +29,14 @@ function run(command: string, args: string[]): { ok: boolean; stdout: string } {
 }
 
 const branch = run("git", ["branch", "--show-current"]);
+const branchName = branch.ok ? (branch.stdout || "(detached HEAD)") : "(unknown)";
 
-if (branch.ok && branch.stdout && !INTEGRATION_BRANCHES.has(branch.stdout)) {
-  const staged = run("git", ["diff", "--name-only", "--cached", "--diff-filter=A"]);
-  if (staged.ok && staged.stdout) {
-    for (const file of staged.stdout.split(/\r?\n/).filter(Boolean)) {
-      warnings.push(
-        `${file}: staged for addition on "${branch.stdout}" — if this file belongs to another branch, it will bleed into the next commit (see docs/worktrees.md#common-pitfalls)`,
-      );
-    }
+const staged = run("git", ["diff", "--name-only", "--cached", "--diff-filter=A"]);
+if (staged.ok && staged.stdout) {
+  for (const file of staged.stdout.split(/\r?\n/).filter(Boolean)) {
+    warnings.push(
+      `${file}: staged for addition on "${branchName}" — these files carry across git checkout and will bleed into the next commit on any branch (see docs/worktrees.md#common-pitfalls)`,
+    );
   }
 }
 

--- a/tools/automation-registry.yml
+++ b/tools/automation-registry.yml
@@ -299,6 +299,16 @@ entries:
     emits_json: true
     used_by: [human, agent]
     rerun_command: npm run check:issues
+  - id: check:index-bleed
+    kind: check
+    command: npm run check:index-bleed
+    path: scripts/check-index-bleed.ts
+    purpose: Warn when the git index contains staged-for-addition files on a feature branch. These files bleed across git checkout calls and can corrupt commits. Not in verify — run before committing or switching branches.
+    read_only: true
+    safe_to_run_locally: true
+    emits_json: true
+    used_by: [human, agent]
+    rerun_command: npm run check:index-bleed
   - id: check:specs
     kind: check
     command: npm run check:specs


### PR DESCRIPTION
## Summary

Addresses the staged-file bleed incident documented in #261, where staged-for-addition files carried across a `git checkout` and ended up in a commit on the wrong branch.

- **`scripts/check-index-bleed.ts`** — new `npm run check:index-bleed` command. Warns when the git index contains files staged for addition while on a feature branch. Not wired into `verify` (advisory); run before committing or switching branches if working in the main worktree.
- **`docs/worktrees.md`** — adds the failure mode as a documented pitfall: why staged new files bleed on checkout, and how worktrees prevent it.
- **`.claude/memory/feedback_worktrees_required.md`** — adds an explicit hard stop: do not use the main checkout for sequential feature-branch work; use one worktree per branch.
- **`tools/automation-registry.yml`** + **`scripts/README.md`** — registry and docs updated consistently.

## Test plan

- [x] `npm run check:index-bleed` exits 0 with clean index on `fix/index-bleed-guard`
- [x] `npm run check:index-bleed -- --json` emits `{"errors":[],"warnings":[]}`
- [x] `npm run check:automation-registry` passes with new registry entry
- [x] `npm run fix:script-docs` regenerated `docs/scripts/check-index-bleed/README.md`
- [x] `npm run verify` green

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)