### PR TITLE
ci(security): add OpenSSF Scorecard scheduled report

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -22,6 +22,9 @@ jobs:
       id-token: write
       contents: read
       actions: read
+      issues: read
+      pull-requests: read
+      checks: read
 
     steps:
       - name: Checkout code

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,49 @@
+name: Scorecard supply-chain security
+
+on:
+  schedule:
+    - cron: '30 2 * * 1'
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -18,13 +18,13 @@ jobs:
     name: Scorecard analysis
     runs-on: ubuntu-latest
     permissions:
-      security-events: write
-      id-token: write
-      contents: read
-      actions: read
-      issues: read
-      pull-requests: read
-      checks: read
+      security-events: write # Required to upload Scorecard SARIF results to code scanning on public repos.
+      id-token: write # Required by Scorecard when publish_results is true.
+      contents: read # Required to inspect repository files and commits.
+      actions: read # Required by Scorecard for workflow and token-permission checks.
+      issues: read # Required by Scorecard for project health checks in private downstream repos.
+      pull-requests: read # Required by Scorecard for branch protection and review checks.
+      checks: read # Required by Scorecard for CI status checks in private downstream repos.
 
     steps:
       - name: Checkout code

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -47,6 +47,7 @@ jobs:
           retention-days: 5
 
       - name: Upload to code scanning
+        if: ${{ github.event.repository.visibility == 'public' }}
         uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           sarif_file: results.sarif

--- a/docs/security-ci.md
+++ b/docs/security-ci.md
@@ -46,13 +46,15 @@ This map keeps deferred candidates separate from checks that already exist so ad
 | PR-title lint | [`ci-automation.md`](ci-automation.md#pr-title-rules), [`.github/workflows/pr-title.yml`](../.github/workflows/pr-title.yml) | Required on every PR. |
 | Spell check | [`ci-automation.md`](ci-automation.md#typos-config), [`.github/workflows/typos.yml`](../.github/workflows/typos.yml) | Required on every PR. |
 | Dependabot version updates | [`ci-automation.md`](ci-automation.md#dependabot-policy), [`.github/dependabot.yml`](../.github/dependabot.yml) | Bumps pinned GitHub Actions and npm dev dependencies. |
+| Supply-chain posture (Scorecard) | `.github/workflows/scorecard.yml` | Weekly + push to main. Publishes SARIF to code scanning. Initial findings are advisory — triage via Security tab. |
+
+> **Note:** Scorecard findings are advisory at first. Triage results via the GitHub Security/code-scanning tab and file concrete issues before promoting any check to a required gate.
 
 ### Deferred
 
 | Candidate | Current decision |
 | --- | --- |
 | CodeQL default setup or explicit CodeQL workflow | Candidate for TypeScript/scripts and GitHub Actions code scanning once the repository settings path is chosen. |
-| OSSF Scorecard | Candidate periodic supply-chain posture report after the current P1/P2 hardening work is stable. |
 | Markdown lint | Deferred until the existing Markdown baseline is cleaned or a non-blocking changed-files rollout is designed. See [`ci-automation.md`](ci-automation.md#why-not-markdownlint-yet). |
 
 ### Rejected for now

--- a/docs/security-ci.md
+++ b/docs/security-ci.md
@@ -48,11 +48,11 @@ This map keeps deferred candidates separate from checks that already exist so ad
 | PR-title lint | [`ci-automation.md`](ci-automation.md#pr-title-rules), [`.github/workflows/pr-title.yml`](../.github/workflows/pr-title.yml) | Required on every PR. |
 | Spell check | [`ci-automation.md`](ci-automation.md#typos-config), [`.github/workflows/typos.yml`](../.github/workflows/typos.yml) | Required on every PR. |
 | Dependabot version updates | [`ci-automation.md`](ci-automation.md#dependabot-policy), [`.github/dependabot.yml`](../.github/dependabot.yml) | Bumps pinned GitHub Actions and npm dev dependencies. |
-| Supply-chain posture (Scorecard) | `.github/workflows/scorecard.yml` | Weekly + push to main. Publishes SARIF to code scanning. Initial findings are advisory — triage via Security tab. |
+| Supply-chain posture (Scorecard) | `.github/workflows/scorecard.yml` | Weekly + push to main. Uploads SARIF as an artifact for every repo and to code scanning on public repos. Initial findings are advisory — triage via Security tab. |
 | Dependabot alerts | GitHub repository settings | Alerts on vulnerable dependencies introduced to the repo. Security update PRs are opt-in. |
 | Markdown lint (advisory) | `.github/workflows/markdownlint.yml` | PR-triggered, changed files only, non-blocking. Promotion plan: `docs/markdownlint-rollout.md`. |
 
-> **Note:** Scorecard findings are advisory at first. Triage results via the GitHub Security/code-scanning tab and file concrete issues before promoting any check to a required gate.
+> **Note:** Scorecard findings are advisory at first. Public repositories also publish results to the GitHub Security/code-scanning tab; private/internal downstream repositories still receive the SARIF artifact without requiring GitHub Code Security. Triage results and file concrete issues before promoting any check to a required gate.
 
 ### Deferred
 

--- a/docs/superpowers/plans/2026-05-03-backlog-issue-closure.md
+++ b/docs/superpowers/plans/2026-05-03-backlog-issue-closure.md
@@ -249,7 +249,7 @@
 
   Add after the existing deferred rationale:
   ```
-  See [`docs/markdownlint-rollout.md`](markdownlint-rollout.md) for the phased promotion plan.
+  See `docs/markdownlint-rollout.md` for the phased promotion plan.
   ```
 
 - [ ] **Step 5: Update `docs/security-ci.md`** — move markdownlint from Deferred → a new "Staged rollout" status or update the row.
@@ -257,7 +257,7 @@
   Find: `| Markdown lint | Deferred until...`
   Replace with:
   ```
-  | Markdown lint | Non-blocking changed-files workflow active. See [`docs/markdownlint-rollout.md`](markdownlint-rollout.md) for promotion plan. |
+  | Markdown lint | Non-blocking changed-files workflow active. See `docs/markdownlint-rollout.md` for promotion plan. |
   ```
 
 - [ ] **Step 6: Run verify gate**
@@ -621,7 +621,7 @@
 
   In the "Implemented" table, add:
   ```
-  | Supply-chain posture (Scorecard) | [`.github/workflows/scorecard.yml`](../.github/workflows/scorecard.yml) | Weekly + push to main. Publishes SARIF to code scanning. |
+  | Supply-chain posture (Scorecard) | `.github/workflows/scorecard.yml` | Weekly + push to main. Publishes SARIF to code scanning. |
   ```
 
   In the "Deferred" table, remove the Scorecard row.

--- a/tools/automation-registry.yml
+++ b/tools/automation-registry.yml
@@ -569,6 +569,16 @@ entries:
     emits_json: false
     used_by: [ci]
     rerun_command: gh run list --workflow verify.yml
+  - id: workflow:scorecard
+    kind: workflow
+    path: .github/workflows/scorecard.yml
+    purpose: Weekly supply-chain posture report via OSSF Scorecard. Uploads SARIF results to GitHub code scanning. Findings are advisory; see docs/security-ci.md for triage guidance.
+    read_only: false
+    safe_to_run_locally: false
+    emits_json: false
+    triggers: [schedule, push]
+    used_by: [ci]
+    rerun_command: gh run list --workflow scorecard.yml
   - id: workflow:zizmor
     kind: workflow
     path: .github/workflows/zizmor.yml

--- a/tools/automation-registry.yml
+++ b/tools/automation-registry.yml
@@ -572,7 +572,7 @@ entries:
   - id: workflow:scorecard
     kind: workflow
     path: .github/workflows/scorecard.yml
-    purpose: Weekly supply-chain posture report via OSSF Scorecard. Uploads SARIF results to GitHub code scanning. Findings are advisory; see docs/security-ci.md for triage guidance.
+    purpose: Weekly supply-chain posture report via OSSF Scorecard. Uploads SARIF as an artifact and publishes to GitHub code scanning on public repos. Findings are advisory; see docs/security-ci.md for triage guidance.
     read_only: false
     safe_to_run_locally: false
     emits_json: false


### PR DESCRIPTION
Closes #253. Adds weekly Scorecard workflow (Monday 02:30 UTC + push to main) with SARIF upload to code scanning. publish_results: true for public badge. Findings are advisory; triage via Security tab before promoting any check to required. Updates security-ci.md posture map and automation registry.

## Summary
- Creates `.github/workflows/scorecard.yml` with SHA-pinned `ossf/scorecard-action@v2.4.3` (`4eaacf05`)
- Registers `workflow:scorecard` in `tools/automation-registry.yml` following the existing workflow entry pattern
- Moves Scorecard from Deferred → Implemented in `docs/security-ci.md` and adds advisory triage note

## Test plan
- [ ] `npm run verify` passes (all checks green except pre-existing `check:script-docs` which requires `npm ci` in the worktree)
- [ ] Workflow YAML is valid — actionlint will confirm on CI
- [ ] zizmor passes — all actions are SHA-pinned, permissions are minimal, `publish_results: true` requires `id-token: write`
- [ ] PR closes issue #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)