### PR TITLE
chore(agents): add Stage 7 workflow-state close-out

### DIFF
--- a/.claude/agents/dev.md
+++ b/.claude/agents/dev.md
@@ -39,6 +39,11 @@ You implement tasks owned by `dev` in `specs/<feature>/tasks.md`. You make faili
    - outcome (done | partial | blocked),
    - deviation from spec (if any) with rationale, and ADR link if material.
 7. Update `workflow-state.md` (tick the task in `tasks.md`; append a hand-off note if the next task has a different owner).
+8. **Stage 7 close-out:** After the final verify run, update `workflow-state.md` so the `implementation-log.md` artifact entry and Stage 7 progress row match the real implementation state:
+   - set `implementation-log.md` to `complete` when all implementation tasks have been executed and accounted for in `implementation-log.md`;
+   - set `implementation-log.md` to `in-progress` when human-owned tasks, deferred implementation tasks, or blockers remain;
+   - record the hand-off date, verification performed, remaining owner if any, and next agent in `## Hand-off notes`.
+   The stage is not done until this close-out step is complete.
 
 ## Quality bar
 

--- a/templates/implementation-log-template.md
+++ b/templates/implementation-log-template.md
@@ -64,3 +64,4 @@ Avoid starting nested task subsections with a bare `### T-<AREA>-NNN` heading at
 - [ ] No unrelated changes ("scope creep") in any task entry.
 - [ ] Lint, type checks, unit tests green for the changed surface.
 - [ ] Commits reference task IDs.
+- [ ] `workflow-state.md` Stage 7 close-out complete: `implementation-log.md` is `complete` when all tasks are executed, or `in-progress` when human-owned tasks, deferred implementation tasks, or blockers remain; `## Hand-off notes` records the date, verification, remaining owner if any, and next agent.


### PR DESCRIPTION
## Summary

- Add an explicit Stage 7 close-out step to `.claude/agents/dev.md` requiring `workflow-state.md` to reflect the final `implementation-log.md` state.
- Document the completion distinction: `complete` when all implementation tasks are accounted for, `in-progress` when human-owned tasks, deferred implementation tasks, or blockers remain.
- Add the same close-out requirement to the implementation-log template quality gate.

Closes #300.

## Verification

- `npm ci`
- `npm run verify`

## Notes

- Template PR; no ADR added per issue acceptance criteria.