### PR TITLE
fix(scripts): skip fenced code blocks and inline code spans in check:links

### DIFF
--- a/docs/scripts/lib/markdown-links/README.md
+++ b/docs/scripts/lib/markdown-links/README.md
@@ -20,7 +20,9 @@ entry_point: true
 
 - [collectAnchors](functions/collectAnchors.md)
 - [githubSlug](functions/githubSlug.md)
+- [isCodeFenceDelimiter](functions/isCodeFenceDelimiter.md)
 - [linkDiagnostic](functions/linkDiagnostic.md)
 - [safeDecode](functions/safeDecode.md)
 - [shouldIgnoreTarget](functions/shouldIgnoreTarget.md)
 - [slugVariants](functions/slugVariants.md)
+- [stripInlineCode](functions/stripInlineCode.md)

--- a/docs/scripts/lib/markdown-links/functions/isCodeFenceDelimiter.md
+++ b/docs/scripts/lib/markdown-links/functions/isCodeFenceDelimiter.md
@@ -1,0 +1,19 @@
+[**@luis85/agentic-workflow**](../../../README.md)
+
+***
+
+[@luis85/agentic-workflow](../../../modules.md) / [lib/markdown-links](../README.md) / isCodeFenceDelimiter
+
+# Function: isCodeFenceDelimiter()
+
+> **isCodeFenceDelimiter**(`line`): `boolean`
+
+## Parameters
+
+### line
+
+`string`
+
+## Returns
+
+`boolean`

--- a/docs/scripts/lib/markdown-links/functions/stripInlineCode.md
+++ b/docs/scripts/lib/markdown-links/functions/stripInlineCode.md
@@ -1,0 +1,19 @@
+[**@luis85/agentic-workflow**](../../../README.md)
+
+***
+
+[@luis85/agentic-workflow](../../../modules.md) / [lib/markdown-links](../README.md) / stripInlineCode
+
+# Function: stripInlineCode()
+
+> **stripInlineCode**(`line`): `string`
+
+## Parameters
+
+### line
+
+`string`
+
+## Returns
+
+`string`

--- a/scripts/check-markdown-links.ts
+++ b/scripts/check-markdown-links.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { failIfErrors, markdownFiles, readText, relativeToRoot, repoRoot } from "./lib/repo.js";
-import { collectAnchors, linkDiagnostic, safeDecode, shouldIgnoreTarget } from "./lib/markdown-links.js";
+import { collectAnchors, isCodeFenceDelimiter, linkDiagnostic, safeDecode, shouldIgnoreTarget, stripInlineCode } from "./lib/markdown-links.js";
 
 const errors = [];
 const linkPattern = /!?\[[^\]]*?\]\(([^)\s]+(?:\s+"[^"]*")?)\)/g;
@@ -9,9 +9,16 @@ const linkPattern = /!?\[[^\]]*?\]\(([^)\s]+(?:\s+"[^"]*")?)\)/g;
 for (const filePath of markdownFiles()) {
   const text = readText(filePath);
   const lines = text.split(/\r?\n/);
+  let inFence = false;
   for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
     const line = lines[lineIndex];
-    for (const match of line.matchAll(linkPattern)) {
+    if (isCodeFenceDelimiter(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    const scanLine = stripInlineCode(line);
+    for (const match of scanLine.matchAll(linkPattern)) {
       const rawTarget = match[1].replace(/\s+"[^"]*"$/, "").trim();
       const target = rawTarget.replace(/^<|>$/g, "");
       if (shouldIgnoreTarget(target)) continue;

--- a/scripts/lib/markdown-links.ts
+++ b/scripts/lib/markdown-links.ts
@@ -86,3 +86,11 @@ export function githubSlug(value: string): string {
     .trim()
     .replace(/\s/gu, "-");
 }
+
+export function isCodeFenceDelimiter(line: string): boolean {
+  return /^(`{3,}|~{3,})/.test(line);
+}
+
+export function stripInlineCode(line: string): string {
+  return line.replace(/`+[^`\n]*`+/g, "");
+}

--- a/tests/scripts/markdown-links.test.ts
+++ b/tests/scripts/markdown-links.test.ts
@@ -3,10 +3,12 @@ import assert from "node:assert/strict";
 import {
   collectAnchors,
   githubSlug,
+  isCodeFenceDelimiter,
   linkDiagnostic,
   safeDecode,
   shouldIgnoreTarget,
   slugVariants,
+  stripInlineCode,
 } from "../../scripts/lib/markdown-links.js";
 
 test("collectAnchors follows GitHub-style duplicate heading suffixes", () => {
@@ -41,4 +43,35 @@ test("shouldIgnoreTarget skips external and template-placeholder links", () => {
   assert.equal(shouldIgnoreTarget("https://example.com"), true);
   assert.equal(shouldIgnoreTarget("specs/<feature-slug>/workflow-state.md"), true);
   assert.equal(shouldIgnoreTarget("./local.md"), false);
+});
+
+test("isCodeFenceDelimiter identifies opening and closing fenced code block markers", () => {
+  assert.equal(isCodeFenceDelimiter("```"), true);
+  assert.equal(isCodeFenceDelimiter("```typescript"), true);
+  assert.equal(isCodeFenceDelimiter("~~~"), true);
+  assert.equal(isCodeFenceDelimiter("~~~~"), true);
+  assert.equal(isCodeFenceDelimiter("``"), false);
+  assert.equal(isCodeFenceDelimiter("not a fence"), false);
+  assert.equal(isCodeFenceDelimiter("  ```"), false);
+});
+
+test("stripInlineCode removes backtick-delimited code spans from a line", () => {
+  assert.equal(stripInlineCode("`[text](missing.md)`"), "");
+  assert.equal(stripInlineCode("See `[text](path.md)` for details"), "See  for details");
+  assert.equal(stripInlineCode("``double-backtick``"), "");
+  assert.equal(stripInlineCode("[real](link.md) and `[fake](missing.md)`"), "[real](link.md) and ");
+});
+
+test("bare path inside a code fence is not flagged as a broken link (isCodeFenceDelimiter + stripInlineCode guard)", () => {
+  const fencedBlock = "```\n[broken](no-such-file.md)\n```";
+  const lines = fencedBlock.split("\n");
+  const linkPattern = /!?\[[^\]]*?\]\(([^)\s]+(?:\s+"[^"]*")?)\)/g;
+  let inFence = false;
+  const matches: string[] = [];
+  for (const line of lines) {
+    if (isCodeFenceDelimiter(line)) { inFence = !inFence; continue; }
+    if (inFence) continue;
+    for (const m of stripInlineCode(line).matchAll(linkPattern)) matches.push(m[1]);
+  }
+  assert.deepEqual(matches, []);
 });


### PR DESCRIPTION
## Summary

- `check:links` now tracks fenced code block state (`inFence` toggle on ` ``` ` / `~~~` delimiters) and skips link-pattern matching inside fences
- Inline code spans are stripped from each line before the link pattern is applied (`stripInlineCode`)
- Two new exported helpers added to `scripts/lib/markdown-links.ts`: `isCodeFenceDelimiter` and `stripInlineCode`
- 3 new unit tests cover both helpers and the end-to-end fence-skip behaviour
- Generated script docs regenerated (`fix:script-docs`)

Closes #298 — retrospective action item A-BRANCH-001.

## Test plan

- [ ] `npm run test:scripts` — 294 pass (was 291)
- [ ] `npm run verify` — all checks green
- [ ] Confirm `check:links` no longer flags bare paths inside fenced code blocks or inline code spans

🤖 Generated with [Claude Code](https://claude.com/claude-code)