### PR TITLE
fix(scripts): skip code regions in check:links (#298)

### DIFF
--- a/docs/scripts/lib/markdown-links/README.md
+++ b/docs/scripts/lib/markdown-links/README.md
@@ -24,3 +24,4 @@ entry_point: true
 - [safeDecode](functions/safeDecode.md)
 - [shouldIgnoreTarget](functions/shouldIgnoreTarget.md)
 - [slugVariants](functions/slugVariants.md)
+- [stripCodeRegions](functions/stripCodeRegions.md)

--- a/docs/scripts/lib/markdown-links/functions/stripCodeRegions.md
+++ b/docs/scripts/lib/markdown-links/functions/stripCodeRegions.md
@@ -1,0 +1,24 @@
+[**@luis85/agentic-workflow**](../../../README.md)
+
+***
+
+[@luis85/agentic-workflow](../../../modules.md) / [lib/markdown-links](../README.md) / stripCodeRegions
+
+# Function: stripCodeRegions()
+
+> **stripCodeRegions**(`text`): `string`
+
+Replace fenced code blocks and inline code spans with whitespace so the link
+scanner does not match path-like substrings inside code examples. Newlines
+and total character offsets within a line are preserved, so diagnostic line
+numbers continue to match the original source.
+
+## Parameters
+
+### text
+
+`string`
+
+## Returns
+
+`string`

--- a/docs/scripts/lib/markdown-links/functions/stripCodeRegions.md
+++ b/docs/scripts/lib/markdown-links/functions/stripCodeRegions.md
@@ -10,8 +10,9 @@
 
 Replace fenced code blocks and inline code spans with whitespace so the link
 scanner does not match path-like substrings inside code examples. Newlines
-and total character offsets within a line are preserved, so diagnostic line
-numbers continue to match the original source.
+and total character offsets are preserved, so diagnostic line numbers
+continue to match the original source. Block-quoted fences are recognised,
+and inline code spans may cross line boundaries.
 
 ## Parameters
 

--- a/scripts/check-markdown-links.ts
+++ b/scripts/check-markdown-links.ts
@@ -1,14 +1,20 @@
 import fs from "node:fs";
 import path from "node:path";
 import { failIfErrors, markdownFiles, readText, relativeToRoot, repoRoot } from "./lib/repo.js";
-import { collectAnchors, linkDiagnostic, safeDecode, shouldIgnoreTarget } from "./lib/markdown-links.js";
+import {
+  collectAnchors,
+  linkDiagnostic,
+  safeDecode,
+  shouldIgnoreTarget,
+  stripCodeRegions,
+} from "./lib/markdown-links.js";
 
 const errors = [];
 const linkPattern = /!?\[[^\]]*?\]\(([^)\s]+(?:\s+"[^"]*")?)\)/g;
 
 for (const filePath of markdownFiles()) {
   const text = readText(filePath);
-  const lines = text.split(/\r?\n/);
+  const lines = stripCodeRegions(text).split(/\r?\n/);
   for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
     const line = lines[lineIndex];
     for (const match of line.matchAll(linkPattern)) {

--- a/scripts/lib/markdown-links.ts
+++ b/scripts/lib/markdown-links.ts
@@ -67,6 +67,12 @@ export function stripCodeRegions(text: string): string {
       continue;
     }
     if (fenceMatch) {
+      const info = line.slice(fenceMatch[0].length);
+      const isBacktickFence = fenceMatch[1][0] === "`";
+      if (isBacktickFence && info.includes("`")) {
+        out.push(stripInlineCodeSpans(line));
+        continue;
+      }
       fenceChar = fenceMatch[1][0] as "`" | "~";
       fenceLen = fenceMatch[1].length;
       out.push("");

--- a/scripts/lib/markdown-links.ts
+++ b/scripts/lib/markdown-links.ts
@@ -94,6 +94,11 @@ function stripInlineCodeSpans(line: string): string {
     }
     let runLen = 0;
     while (i + runLen < line.length && line[i + runLen] === "`") runLen += 1;
+    if (isBackslashEscaped(line, i)) {
+      result += line.slice(i, i + runLen);
+      i += runLen;
+      continue;
+    }
     const closeIdx = findClosingBackticks(line, i + runLen, runLen);
     if (closeIdx === -1) {
       result += line.slice(i, i + runLen);
@@ -105,6 +110,16 @@ function stripInlineCodeSpans(line: string): string {
     i = closeIdx + runLen;
   }
   return result;
+}
+
+function isBackslashEscaped(line: string, pos: number): boolean {
+  let backslashes = 0;
+  let j = pos - 1;
+  while (j >= 0 && line[j] === "\\") {
+    backslashes += 1;
+    j -= 1;
+  }
+  return backslashes % 2 === 1;
 }
 
 function findClosingBackticks(line: string, start: number, runLen: number): number {

--- a/scripts/lib/markdown-links.ts
+++ b/scripts/lib/markdown-links.ts
@@ -40,6 +40,82 @@ function linkDiagnosticMessage(code: LinkDiagnosticCode, target: string): string
   return `links to missing anchor ${target}`;
 }
 
+/**
+ * Replace fenced code blocks and inline code spans with whitespace so the link
+ * scanner does not match path-like substrings inside code examples. Newlines
+ * and total character offsets within a line are preserved, so diagnostic line
+ * numbers continue to match the original source.
+ */
+export function stripCodeRegions(text: string): string {
+  const lines = text.split(/\r?\n/);
+  const out: string[] = [];
+  let fenceChar: "`" | "~" | null = null;
+  let fenceLen = 0;
+  for (const line of lines) {
+    const fenceMatch = /^ {0,3}(`{3,}|~{3,})/.exec(line);
+    if (fenceChar !== null) {
+      if (
+        fenceMatch &&
+        fenceMatch[1][0] === fenceChar &&
+        fenceMatch[1].length >= fenceLen &&
+        line.slice(fenceMatch[0].length).trim() === ""
+      ) {
+        fenceChar = null;
+        fenceLen = 0;
+      }
+      out.push("");
+      continue;
+    }
+    if (fenceMatch) {
+      fenceChar = fenceMatch[1][0] as "`" | "~";
+      fenceLen = fenceMatch[1].length;
+      out.push("");
+      continue;
+    }
+    out.push(stripInlineCodeSpans(line));
+  }
+  return out.join("\n");
+}
+
+function stripInlineCodeSpans(line: string): string {
+  let result = "";
+  let i = 0;
+  while (i < line.length) {
+    if (line[i] !== "`") {
+      result += line[i];
+      i += 1;
+      continue;
+    }
+    let runLen = 0;
+    while (i + runLen < line.length && line[i + runLen] === "`") runLen += 1;
+    const closeIdx = findClosingBackticks(line, i + runLen, runLen);
+    if (closeIdx === -1) {
+      result += line.slice(i, i + runLen);
+      i += runLen;
+      continue;
+    }
+    const spanLen = closeIdx + runLen - i;
+    result += " ".repeat(spanLen);
+    i = closeIdx + runLen;
+  }
+  return result;
+}
+
+function findClosingBackticks(line: string, start: number, runLen: number): number {
+  let i = start;
+  while (i < line.length) {
+    if (line[i] !== "`") {
+      i += 1;
+      continue;
+    }
+    let len = 0;
+    while (i + len < line.length && line[i + len] === "`") len += 1;
+    if (len === runLen) return i;
+    i += len;
+  }
+  return -1;
+}
+
 export function shouldIgnoreTarget(target: string): boolean {
   if (!target || target.startsWith("#")) return false;
   if (/^(https?:|mailto:|app:|plugin:)/.test(target)) return true;

--- a/scripts/lib/markdown-links.ts
+++ b/scripts/lib/markdown-links.ts
@@ -95,7 +95,36 @@ function stripBlockQuotePrefix(line: string): string {
 }
 
 function stripInlineCodeSpansGlobal(text: string): string {
-  const chars = text.split("");
+  const blocks = splitIntoInlineBlocks(text);
+  return blocks.map(stripInlineCodeSpansInBlock).join("\n");
+}
+
+function splitIntoInlineBlocks(text: string): string[] {
+  const lines = text.split("\n");
+  const blocks: string[] = [];
+  let current: string[] = [];
+  const flush = () => {
+    if (current.length > 0) {
+      blocks.push(current.join("\n"));
+      current = [];
+    }
+  };
+  for (const line of lines) {
+    const isBlank = /^[ \t]*$/.test(line);
+    const isHeading = /^[ \t]{0,3}#{1,6}([ \t]|$)/.test(line);
+    if (isBlank || isHeading) {
+      flush();
+      blocks.push(line);
+    } else {
+      current.push(line);
+    }
+  }
+  flush();
+  return blocks;
+}
+
+function stripInlineCodeSpansInBlock(block: string): string {
+  const chars = block.split("");
   let i = 0;
   while (i < chars.length) {
     if (chars[i] !== "`") {

--- a/scripts/lib/markdown-links.ts
+++ b/scripts/lib/markdown-links.ts
@@ -43,22 +43,28 @@ function linkDiagnosticMessage(code: LinkDiagnosticCode, target: string): string
 /**
  * Replace fenced code blocks and inline code spans with whitespace so the link
  * scanner does not match path-like substrings inside code examples. Newlines
- * and total character offsets within a line are preserved, so diagnostic line
- * numbers continue to match the original source.
+ * and total character offsets are preserved, so diagnostic line numbers
+ * continue to match the original source. Block-quoted fences are recognised,
+ * and inline code spans may cross line boundaries.
  */
 export function stripCodeRegions(text: string): string {
+  return stripInlineCodeSpansGlobal(stripFencedBlocks(text));
+}
+
+function stripFencedBlocks(text: string): string {
   const lines = text.split(/\r?\n/);
   const out: string[] = [];
   let fenceChar: "`" | "~" | null = null;
   let fenceLen = 0;
   for (const line of lines) {
-    const fenceMatch = /^ {0,3}(`{3,}|~{3,})/.exec(line);
+    const body = stripBlockQuotePrefix(line);
+    const fenceMatch = /^ {0,3}(`{3,}|~{3,})/.exec(body);
     if (fenceChar !== null) {
       if (
         fenceMatch &&
         fenceMatch[1][0] === fenceChar &&
         fenceMatch[1].length >= fenceLen &&
-        line.slice(fenceMatch[0].length).trim() === ""
+        body.slice(fenceMatch[0].length).trim() === ""
       ) {
         fenceChar = null;
         fenceLen = 0;
@@ -67,10 +73,10 @@ export function stripCodeRegions(text: string): string {
       continue;
     }
     if (fenceMatch) {
-      const info = line.slice(fenceMatch[0].length);
+      const info = body.slice(fenceMatch[0].length);
       const isBacktickFence = fenceMatch[1][0] === "`";
       if (isBacktickFence && info.includes("`")) {
-        out.push(stripInlineCodeSpans(line));
+        out.push(line);
         continue;
       }
       fenceChar = fenceMatch[1][0] as "`" | "~";
@@ -78,59 +84,62 @@ export function stripCodeRegions(text: string): string {
       out.push("");
       continue;
     }
-    out.push(stripInlineCodeSpans(line));
+    out.push(line);
   }
   return out.join("\n");
 }
 
-function stripInlineCodeSpans(line: string): string {
-  let result = "";
+function stripBlockQuotePrefix(line: string): string {
+  const match = /^(?:[ \t]{0,3}>[ \t]?)+/.exec(line);
+  return match ? line.slice(match[0].length) : line;
+}
+
+function stripInlineCodeSpansGlobal(text: string): string {
+  const chars = text.split("");
   let i = 0;
-  while (i < line.length) {
-    if (line[i] !== "`") {
-      result += line[i];
+  while (i < chars.length) {
+    if (chars[i] !== "`") {
       i += 1;
       continue;
     }
     let runLen = 0;
-    while (i + runLen < line.length && line[i + runLen] === "`") runLen += 1;
-    if (isBackslashEscaped(line, i)) {
-      result += line.slice(i, i + runLen);
+    while (i + runLen < chars.length && chars[i + runLen] === "`") runLen += 1;
+    if (isBackslashEscaped(chars, i)) {
       i += runLen;
       continue;
     }
-    const closeIdx = findClosingBackticks(line, i + runLen, runLen);
+    const closeIdx = findClosingBackticksGlobal(chars, i + runLen, runLen);
     if (closeIdx === -1) {
-      result += line.slice(i, i + runLen);
       i += runLen;
       continue;
     }
-    const spanLen = closeIdx + runLen - i;
-    result += " ".repeat(spanLen);
+    for (let k = i; k < closeIdx + runLen; k += 1) {
+      if (chars[k] !== "\n" && chars[k] !== "\r") chars[k] = " ";
+    }
     i = closeIdx + runLen;
   }
-  return result;
+  return chars.join("");
 }
 
-function isBackslashEscaped(line: string, pos: number): boolean {
+function isBackslashEscaped(chars: string[], pos: number): boolean {
   let backslashes = 0;
   let j = pos - 1;
-  while (j >= 0 && line[j] === "\\") {
+  while (j >= 0 && chars[j] === "\\") {
     backslashes += 1;
     j -= 1;
   }
   return backslashes % 2 === 1;
 }
 
-function findClosingBackticks(line: string, start: number, runLen: number): number {
+function findClosingBackticksGlobal(chars: string[], start: number, runLen: number): number {
   let i = start;
-  while (i < line.length) {
-    if (line[i] !== "`") {
+  while (i < chars.length) {
+    if (chars[i] !== "`") {
       i += 1;
       continue;
     }
     let len = 0;
-    while (i + len < line.length && line[i + len] === "`") len += 1;
+    while (i + len < chars.length && chars[i + len] === "`") len += 1;
     if (len === runLen) return i;
     i += len;
   }

--- a/scripts/lib/markdown-links.ts
+++ b/scripts/lib/markdown-links.ts
@@ -110,9 +110,7 @@ function splitIntoInlineBlocks(text: string): string[] {
     }
   };
   for (const line of lines) {
-    const isBlank = /^[ \t]*$/.test(line);
-    const isHeading = /^[ \t]{0,3}#{1,6}([ \t]|$)/.test(line);
-    if (isBlank || isHeading) {
+    if (isBlockBoundary(line)) {
       flush();
       blocks.push(line);
     } else {
@@ -121,6 +119,16 @@ function splitIntoInlineBlocks(text: string): string[] {
   }
   flush();
   return blocks;
+}
+
+function isBlockBoundary(line: string): boolean {
+  if (/^[ \t]*$/.test(line)) return true;
+  if (/^[ \t]{0,3}#{1,6}([ \t]|$)/.test(line)) return true;
+  if (/^[ ]{0,3}(=+|-+)[ \t]*$/.test(line)) return true;
+  if (/^[ ]{0,3}(?:-[ \t]*){3,}$/.test(line)) return true;
+  if (/^[ ]{0,3}(?:\*[ \t]*){3,}$/.test(line)) return true;
+  if (/^[ ]{0,3}(?:_[ \t]*){3,}$/.test(line)) return true;
+  return false;
 }
 
 function stripInlineCodeSpansInBlock(block: string): string {

--- a/tests/scripts/markdown-links.test.ts
+++ b/tests/scripts/markdown-links.test.ts
@@ -104,6 +104,26 @@ test("stripCodeRegions still strips spans when an escape is itself escaped", () 
   assert.equal(stripped.endsWith(" trailing"), true);
 });
 
+test("stripCodeRegions blanks fenced blocks nested in block quotes", () => {
+  const input = ["> ```", "> [x](missing.md)", "> ```", "after [real](./real.md)"].join("\n");
+  const stripped = stripCodeRegions(input).split("\n");
+  assert.equal(stripped.length, 4);
+  assert.equal(stripped[0], "");
+  assert.equal(stripped[1], "");
+  assert.equal(stripped[2], "");
+  assert.equal(stripped[3], "after [real](./real.md)");
+});
+
+test("stripCodeRegions handles inline code spans that cross line boundaries", () => {
+  const input = ["before `code", "[x](missing.md)", "end` after"].join("\n");
+  const stripped = stripCodeRegions(input);
+  assert.equal(stripped.length, input.length);
+  assert.equal(stripped.includes("missing.md"), false, "link inside multi-line span is blanked");
+  assert.equal(stripped.startsWith("before "), true);
+  assert.equal(stripped.endsWith(" after"), true);
+  assert.equal(stripped.split("\n").length, 3, "newlines are preserved across the span");
+});
+
 test("stripCodeRegions rejects backtick fence openers whose info string contains backticks", () => {
   const input = ["```js `inline` style explainer", "after [real](./real.md)"].join("\n");
   const stripped = stripCodeRegions(input).split("\n");

--- a/tests/scripts/markdown-links.test.ts
+++ b/tests/scripts/markdown-links.test.ts
@@ -85,3 +85,14 @@ test("stripCodeRegions leaves unmatched backticks alone", () => {
   const stripped = stripCodeRegions("a ` lone backtick and [link](./real.md)");
   assert.equal(stripped, "a ` lone backtick and [link](./real.md)");
 });
+
+test("stripCodeRegions rejects backtick fence openers whose info string contains backticks", () => {
+  const input = ["```js `inline` style explainer", "after [real](./real.md)"].join("\n");
+  const stripped = stripCodeRegions(input).split("\n");
+  assert.equal(stripped.length, 2);
+  assert.equal(
+    stripped[1],
+    "after [real](./real.md)",
+    "a backtick line with backtick info string must not open a fence",
+  );
+});

--- a/tests/scripts/markdown-links.test.ts
+++ b/tests/scripts/markdown-links.test.ts
@@ -86,6 +86,24 @@ test("stripCodeRegions leaves unmatched backticks alone", () => {
   assert.equal(stripped, "a ` lone backtick and [link](./real.md)");
 });
 
+test("stripCodeRegions treats escaped backticks as literals, not code-span delimiters", () => {
+  const stripped = stripCodeRegions("\\`[bad](missing.md)\\` real");
+  assert.equal(
+    stripped,
+    "\\`[bad](missing.md)\\` real",
+    "escaped backticks must not blank the link target between them",
+  );
+});
+
+test("stripCodeRegions still strips spans when an escape is itself escaped", () => {
+  const input = "leading \\\\`code (foo.md)` trailing";
+  const stripped = stripCodeRegions(input);
+  assert.equal(stripped.length, input.length);
+  assert.equal(stripped.includes("foo.md"), false, "double-backslash leaves backtick unescaped");
+  assert.equal(stripped.startsWith("leading \\\\"), true);
+  assert.equal(stripped.endsWith(" trailing"), true);
+});
+
 test("stripCodeRegions rejects backtick fence openers whose info string contains backticks", () => {
   const input = ["```js `inline` style explainer", "after [real](./real.md)"].join("\n");
   const stripped = stripCodeRegions(input).split("\n");

--- a/tests/scripts/markdown-links.test.ts
+++ b/tests/scripts/markdown-links.test.ts
@@ -114,6 +114,25 @@ test("stripCodeRegions blanks fenced blocks nested in block quotes", () => {
   assert.equal(stripped[3], "after [real](./real.md)");
 });
 
+test("stripCodeRegions does not pair backticks across heading or blank-line boundaries", () => {
+  const acrossHeading = ["# Title `", "See [bad](missing.md) and `ok`."].join("\n");
+  const stripped1 = stripCodeRegions(acrossHeading);
+  assert.equal(
+    stripped1.includes("[bad](missing.md)"),
+    true,
+    "stray backtick in heading must not consume a link in the paragraph below",
+  );
+  assert.equal(stripped1.includes("ok"), false, "real inline code in the paragraph is still stripped");
+
+  const acrossBlank = ["leading `paragraph", "", "[real](./real.md) paired `tail"].join("\n");
+  const stripped2 = stripCodeRegions(acrossBlank);
+  assert.equal(
+    stripped2.includes("[real](./real.md)"),
+    true,
+    "backticks must not pair across a blank line",
+  );
+});
+
 test("stripCodeRegions handles inline code spans that cross line boundaries", () => {
   const input = ["before `code", "[x](missing.md)", "end` after"].join("\n");
   const stripped = stripCodeRegions(input);

--- a/tests/scripts/markdown-links.test.ts
+++ b/tests/scripts/markdown-links.test.ts
@@ -114,6 +114,27 @@ test("stripCodeRegions blanks fenced blocks nested in block quotes", () => {
   assert.equal(stripped[3], "after [real](./real.md)");
 });
 
+test("stripCodeRegions does not pair backticks across setext underlines or thematic breaks", () => {
+  const acrossSetext = ["Title `", "===", "See [bad](missing.md) and `ok`."].join("\n");
+  const stripped1 = stripCodeRegions(acrossSetext);
+  assert.equal(
+    stripped1.includes("[bad](missing.md)"),
+    true,
+    "stray backtick before a setext underline must not pair across blocks",
+  );
+  assert.equal(stripped1.includes("ok"), false);
+
+  const acrossThematic = ["paragraph `", "---", "after [bad](missing.md) `tail`"].join("\n");
+  const stripped2 = stripCodeRegions(acrossThematic);
+  assert.equal(stripped2.includes("[bad](missing.md)"), true);
+  assert.equal(stripped2.includes("tail"), false);
+
+  const acrossThematicAsterisks = ["lead `", "***", "[real](./real.md) `code`"].join("\n");
+  const stripped3 = stripCodeRegions(acrossThematicAsterisks);
+  assert.equal(stripped3.includes("[real](./real.md)"), true);
+  assert.equal(stripped3.includes("code"), false);
+});
+
 test("stripCodeRegions does not pair backticks across heading or blank-line boundaries", () => {
   const acrossHeading = ["# Title `", "See [bad](missing.md) and `ok`."].join("\n");
   const stripped1 = stripCodeRegions(acrossHeading);

--- a/tests/scripts/markdown-links.test.ts
+++ b/tests/scripts/markdown-links.test.ts
@@ -7,6 +7,7 @@ import {
   safeDecode,
   shouldIgnoreTarget,
   slugVariants,
+  stripCodeRegions,
 } from "../../scripts/lib/markdown-links.js";
 
 test("collectAnchors follows GitHub-style duplicate heading suffixes", () => {
@@ -41,4 +42,46 @@ test("shouldIgnoreTarget skips external and template-placeholder links", () => {
   assert.equal(shouldIgnoreTarget("https://example.com"), true);
   assert.equal(shouldIgnoreTarget("specs/<feature-slug>/workflow-state.md"), true);
   assert.equal(shouldIgnoreTarget("./local.md"), false);
+});
+
+test("stripCodeRegions blanks fenced code blocks while preserving line numbers", () => {
+  const input = [
+    "before",
+    "```",
+    "see [text](missing.md) here",
+    "```",
+    "after [real](./real.md)",
+  ].join("\n");
+  const stripped = stripCodeRegions(input).split("\n");
+  assert.equal(stripped.length, 5);
+  assert.equal(stripped[0], "before");
+  assert.equal(stripped[1], "");
+  assert.equal(stripped[2], "");
+  assert.equal(stripped[3], "");
+  assert.equal(stripped[4], "after [real](./real.md)");
+});
+
+test("stripCodeRegions blanks tilde fences and respects fence length", () => {
+  const input = ["~~~~", "[x](y.md)", "~~~", "still inside [a](b.md)", "~~~~", "out"].join("\n");
+  const stripped = stripCodeRegions(input).split("\n");
+  assert.deepEqual(stripped, ["", "", "", "", "", "out"]);
+});
+
+test("stripCodeRegions blanks inline code spans without shifting columns", () => {
+  const stripped = stripCodeRegions("see `0027-adopt-shape-b.md` and [real](./real.md)");
+  assert.equal(stripped.length, "see `0027-adopt-shape-b.md` and [real](./real.md)".length);
+  assert.equal(stripped.includes("0027-adopt-shape-b.md"), false);
+  assert.equal(stripped.endsWith("[real](./real.md)"), true);
+});
+
+test("stripCodeRegions handles nested backtick runs in inline code", () => {
+  const stripped = stripCodeRegions("text ``with ` backtick (foo.md)`` rest");
+  assert.equal(stripped.includes("foo.md"), false);
+  assert.equal(stripped.startsWith("text "), true);
+  assert.equal(stripped.endsWith(" rest"), true);
+});
+
+test("stripCodeRegions leaves unmatched backticks alone", () => {
+  const stripped = stripCodeRegions("a ` lone backtick and [link](./real.md)");
+  assert.equal(stripped, "a ` lone backtick and [link](./real.md)");
 });


### PR DESCRIPTION
## Summary

Resolves #298. The `check:links` script was flagging bare paths inside quoted code examples as broken links because the regex scanner did not exclude fenced code blocks or inline code spans.

This change adds a `stripCodeRegions` pre-processor in `scripts/lib/markdown-links.ts` and applies it in `scripts/check-markdown-links.ts` before splitting into lines:

- Fenced code blocks (``` ``` ``` and `~~~`, including ≥3 length matching) are blanked out, line-by-line, so line numbers stay aligned for diagnostics.
- Inline code spans are replaced with same-length whitespace, so column-level reporting and surrounding text remain unaffected.
- Unmatched/lonely backticks are left in place.

## Acceptance criteria (#298)

- [x] `check:links` does not flag bare paths inside fenced code blocks or inline code spans.
- [x] Unit tests cover "bare path inside a code fence is not flagged as a broken link" plus inline code, tilde fences, nested-backtick spans, and lonely backticks.
- [x] All existing passing link checks continue to pass (`check:links: ok`).

## Test plan

- [x] `npx tsx --test tests/scripts/markdown-links.test.ts` — 11/11 pass (5 new).
- [x] `npx tsx scripts/check-markdown-links.ts` — `check:links: ok` against the full repo.
- [ ] CI: `npm run verify` green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BXNqzRcEWsaRrJN8rNZ9A5)_